### PR TITLE
Revert Sass @elseif deprecation fixes

### DIFF
--- a/_sass/_helpers.scss
+++ b/_sass/_helpers.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 /* ==========================================================================
    Helpers and Utility Classes
    ========================================================================== */
@@ -56,7 +54,7 @@
 
 @include media($medium) {
   .shorten {
-    width: percentage(math.div(8, 12));
+    width: percentage(8/12);
   }
 }
 

--- a/_sass/vendor/bourbon/css3/_flex-box.scss
+++ b/_sass/vendor/bourbon/css3/_flex-box.scss
@@ -78,7 +78,7 @@
         display: flex;
     }
 
-    @else if $value == "inline-flex" {
+    @elseif $value == "inline-flex" {
         display: -webkit-inline-box;
         display: -moz-inline-box;
         display: inline-box;
@@ -124,16 +124,16 @@
         $value-2009: horizontal;
     }
 
-    @else if $value == "row-reverse" {
+    @elseif $value == "row-reverse" {
         $value-2009: horizontal;
         $direction: reverse;
     }
 
-    @else if $value == column {
+    @elseif $value == column {
         $value-2009: vertical;
     }
 
-    @else if $value == "column-reverse" {
+    @elseif $value == "column-reverse" {
         $value-2009: vertical;
         $direction: reverse;
     }
@@ -162,11 +162,11 @@
         $alt-value: single;
     }
 
-    @else if $value == wrap {
+    @elseif $value == wrap {
         $alt-value: multiple;
     }
 
-    @else if $value == "wrap-reverse" {
+    @elseif $value == "wrap-reverse" {
         $alt-value: multiple;
     }
 
@@ -224,15 +224,15 @@
         $alt-value: start;
     }
 
-    @else if $value == "flex-end" {
+    @elseif $value == "flex-end" {
         $alt-value: end;
     }
 
-    @else if $value == "space-between" {
+    @elseif $value == "space-between" {
         $alt-value: justify;
     }
 
-    @else if $value == "space-around" {
+    @elseif $value == "space-around" {
         $alt-value: center;
     }
 
@@ -257,7 +257,7 @@
         $alt-value: start;
     }    
 
-    @else if $value == "flex-end" {
+    @elseif $value == "flex-end" {
         $alt-value: end;
     }
 
@@ -280,7 +280,7 @@
         $value-2011: start;
     }    
 
-    @else if $value == "flex-end" {
+    @elseif $value == "flex-end" {
         $value-2011: end;
     }
 
@@ -300,15 +300,15 @@
         $value-2011: start;
     }    
 
-    @else if $value == "flex-end" {
+    @elseif $value == "flex-end" {
         $value-2011: end;
     }
 
-    @else if $value == "space-between" {
+    @elseif $value == "space-between" {
         $value-2011: justify;
     }
 
-    @else if $value == "space-around" {
+    @elseif $value == "space-around" {
         $value-2011: distribute;
     }
 


### PR DESCRIPTION
This reverts the changes that updated bourbon flex-box to use @else if instead of @elseif which was causing deprecation warnings in Sass.

Reverts commit 335768a.