### PR TITLE
feat: Convert all 2005 Blogger archive posts to Jekyll format

### DIFF
--- a/_posts/2005/2005-01-19-printer-banner-on-windows-servers.md
+++ b/_posts/2005/2005-01-19-printer-banner-on-windows-servers.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: 'Printer Banner on Windows Servers'
+date: '2005-01-19T17:06:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+[How do I configure a Print Separator Page? ](http://www.windowsitpro.com/Article/ArticleID/14517/14517.html) (March 1999)
+- Explains very briefly how to do it.
+
+[Using separator pages](http://www.elementkjournals.com/premier/showArticle.asp?aid=8939)
+- A much more useful article.
+
+[Shared printer separator page for Windows 2000 and Windows XP](http://www.windowsnetworking.com/kbase/WindowsTips/WindowsXP/AdminTips/Network/SharedprinterseparatorpageforWindows2000andWindowsXP.html)
+- Another source.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[17:06](http://www.tgharold.com/techblog/2005/01/printer-banner-on-windows-servers.shtml)
+
+		</div>

--- a/_posts/2005/2005-02-11-subversion-links.md
+++ b/_posts/2005/2005-02-11-subversion-links.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: 'SubVersion Links'
+date: '2005-02-11T10:03:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+[Experiences with SubVersion](http://www.chiark.greenend.org.uk/~sgtatham/svn.html) (first-hand user account of using SubVersion compared to CVS)
+
+[Version Control System Comparison](http://better-scm.berlios.de/comparison/comparison.html)
+
+[Why Bitkeeper Isn't Right For Free Software](http://web.mit.edu/ghudson/thoughts/bitkeeper.whynot)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[10:03](http://www.tgharold.com/techblog/2005/02/subversion-links.shtml)
+
+		</div>

--- a/_posts/2005/2005-03-29-gentoo-epia-install-part-1.md
+++ b/_posts/2005/2005-03-29-gentoo-epia-install-part-1.md
@@ -1,0 +1,97 @@
+---
+layout: post
+title: 'Gentoo EPIA Install (part 1)'
+date: '2005-03-29T12:55:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
+
+So, I'm back to re-building my VIA EPIA linux box (it was scavanged for another project for a few months).  Once again, I'm digging out my Gentoo CDs and I'm going to simply build a box where I can house my music MP3s and do some Apache / PostGreSQL work.  Since this is an EPIA box, the [EPIAWiki.org](http://www.epiawiki.org/wiki/tiki-index.php) site comes in handy.  I'll also be referring back to my [April 2004 notes](2004_04_01_archive.shtml) to speed up my setup process.
+
+Hardware:
+
+(1) VIA EPIA ME6000 (EPIA M series), 600Mhz fanless CPU
+(2) 160GB 5400rpm hard drives (primary master, secondary master)
+(1) DVD-ROM (secondary slave)
+(1) Morex Venus 668 Black Case
+(1) 512MB PC2100 DIMM
+
+First up is BIOS settings:
+
+<b>Standard CMOS Features</b>
+- Halt On: All, But Keyboard
+- all other settings are automatic
+
+<b>Advanced CMOS Features</b>
+- Virus Warning: Disabled
+- CPU L2 Cache ECC Checking: Enabled
+- Quick Power On Self Test: Disabled
+- First Boot Device: Floppy
+- Second Boot Device: CDROM
+- Third Boot Device: HDD-0
+- Boot Other Device: Disabled
+- Swap Floppy Drive: Disabled
+- Boot Up Floopy Seek: Enabled
+- Boot Up NumLock Status: Enabled
+- Typematic Rate Setting: 30
+- Typematic Delay: 250
+- Security Option: Setup (not configured)
+- Dispaly Full Screen Logo: Disabled
+- Show Summary Information: Enabled
+- Display Small Logo: Enabled
+
+<b>Advanced Chipset Features</b>
+- AP Aperture Size: 32M
+- CPU to PCI POST Write: Enabled
+- Select Display Device: CRT
+- Panel Type: 1024x768
+- TV Type: NTSC
+- CPU Direct Access FB: Enabled
+
+<b>Integrated Peripherals</b>
+- Super IO Devices: All disabled except FDC Controller
+- Onboard IDE Channel 1: Enabled
+- Onboard IDE Channel 2: Enabled
+- IDE Prefetch Mode: Enabled
+- Display Card Priority: AGP
+- Frame Buffer Size: 32MB (amount of RAM to use for video card)
+- AC97 Audio: Disabled
+- MC97 Modem: Disabled
+- VIA OnChip LAN: Enabled
+- USB Keyboard Support: Disabled
+- Onboard LAN Boot ROM: Disabled
+- Onboard Fast IR: Disabled
+
+<b>Power Management Setup</b>
+- ACPI Suspend Type: S1&amp;S3
+- HDD Power Down: Disabled
+- Power Management Timer: Disabled
+- Video Off Option: Suspend -&gt; Off
+- Power Off by PWRBTN: Delay 4 Sec
+- Run VGABIOS if S3 Resume: Auto
+- AC Loss Auto Restart: On
+- Peripherals Activities: (not important)
+- IRQs Activities: (not important)
+
+<b>PnP/PCI Configurations</b>
+- PNP OS Installed: Yes
+- (ignoring the rest of the options)
+
+<b>PC Health Status</b>
+- (information only)
+
+<b>Frequency/Voltage Control</b>
+- (left alone)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[12:55](http://www.tgharold.com/techblog/2005/03/gentoo-epia-install-part-1.shtml)
+
+		</div>

--- a/_posts/2005/2005-03-29-gentoo-epia-install-part-2.md
+++ b/_posts/2005/2005-03-29-gentoo-epia-install-part-2.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title: 'Gentoo EPIA Install (part 2)'
+date: '2005-03-29T13:16:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
+
+First up, still using the 2004.0 Gentoo Boot CD and referring to my [old notes from last year](/techblog/2004/04/gentoo-epia-install-part-1.shtml).  Also note that I rebuilt it in [June 2004](http://www.tgharold.com/techblog/2004_06_01_archive.shtml), so it may be better to look at those notes.  Especially the "gentoo nohotplug" command during the boot process.
+
+Going to use last June's installation notes for the most part, with a few notes here if I change anything.
+
+Key commands (that don't do anything other then report status):
+
+<b>/sbin/ifconfig</b> - verifies networking
+<b>ls -l /dev/hd*</b> - shows hard drives
+<b>hdparm -i /dev/hda</b> - display information about hda
+
+Now to fire up fdisk and wipe any existing partitions.  Then I'm going to create the same partitions I did last year.  (Helps to refer to the Gentoo handbook for this step.)
+
+Currently making my raid volumes, no changes from the June 2004 instructions.  Verifying progress using "<b>cat /proc/mdstat</b>".<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[13:16](http://www.tgharold.com/techblog/2005/03/gentoo-epia-install-part-2.shtml)
+
+		</div>

--- a/_posts/2005/2005-03-29-gentoo-epia-install-part-3.md
+++ b/_posts/2005/2005-03-29-gentoo-epia-install-part-3.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: 'Gentoo EPIA Install (part 3)'
+date: '2005-03-29T16:09:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>The RAID array has finally finished synchronizing.  Continuing on, referecing my [June 2004 notes about setting up LVM](/techblog/2004/06/gentoo-install-2-via-epia-me6000.shtml).
+
+Things went well up until I started extracting the portage tree.  Then I started to get random errors, which means I need to stop and verify that the hardware is behaving properly.
+
+(Time to dig out my memory test programs...)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[16:09](http://www.tgharold.com/techblog/2005/03/gentoo-epia-install-part-3.shtml)
+
+		</div>

--- a/_posts/2005/2005-03-31-gentoo-20050-on-gigabyte-ga-6va7-part-1.md
+++ b/_posts/2005/2005-03-31-gentoo-20050-on-gigabyte-ga-6va7-part-1.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: 'Gentoo 2005.0 on Gigabyte GA-6VA7+ (part 1)'
+date: '2005-03-31T09:32:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
+
+While I swap around some memory modules in the old EPIA box, I'm also going to take a swipe at using the new 2005.0 Gentoo image and build a 2nd box.
+
+This is an old Celeron 350Mhz or 400Mhz CPU with 384MB of RAM (Gigabyte GA-6VA7+).  About the same power as the VIA EPIA motherboard.  I've already gone into the BIOS and disabled all optional ports (serial, parallel, etc).  Drives are configured as:
+
+Pri M: 72GB - /dev/hda
+Pri S: (free)
+Sec M: 72GB - /dev/hdc
+Sec S: CD-ROM - /dev/hdd
+
+I also have a 3rd hard drive (80GB, /dev/hde) hooked up to an old Promise FastTrak66 PCI RAID card.  It uses the PDC20262 chip and I'm really just using it as an IDE card rather then making use of its RAID functionality.
+
+I plan on mirroring using the two 72GB master drives and using the 80GB as a backup/scratch disk.  Similar setup and goals as the EPIA box from [last June's install](/techblog/2004_06_01_archive.shtml).<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[09:32](http://www.tgharold.com/techblog/2005/03/gentoo-20050-on-gigabyte-ga-6va7-part.shtml)
+
+		</div>

--- a/_posts/2005/2005-03-31-gentoo-20050-on-gigabyte-ga-6va7-part-2.md
+++ b/_posts/2005/2005-03-31-gentoo-20050-on-gigabyte-ga-6va7-part-2.md
@@ -1,0 +1,145 @@
+---
+layout: post
+title: 'Gentoo 2005.0 on Gigabyte GA-6VA7+ (part 2)'
+date: '2005-03-31T09:43:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
+
+Okay, tossed the new 2005.0 boot CD in, and I'm booting it up.  Just trying a standard default boot for the moment (not trying to use the "nohotplug" option yet).
+
+Load the RAID modules, and verify some things:
+
+<code># modprobe md
+# modprobe dm-mod
+# ifconfig         { verifies that the ethernet card is working }
+# ls -l /dev/hd*</code>
+
+Now, use <b>fdisk</b> to blow away and setup partitions.  (Note: You will lose all data on these disks when you perform this step.)  Use the 'w' command to confirm the destruction of all partitions when you're finished.
+
+Setup the new partitions:
+
+<code># fdisk /dev/hda
+
+Command: n
+Command action: p
+Partition number: 1
+First cylinder: 1
+Last cylinder: +128M
+Command: a
+Partition number: 1
+Command: t
+Hex code: fd
+
+Command: n
+Command action: p
+Partition number: 2
+First cylinder: [enter]
+Last cylinder: +2048M
+Command: t
+Partition number: 2
+Hex code: fd
+
+Command: n
+Command action: p
+Partition number: 3
+First cylinder: [enter]
+Last cylinder: +2048M
+Command: t
+Partition number: 3
+Hex code: fd
+
+Command: n
+Command action: p
+First cylinder: [enter]
+Last cylinder: [enter]
+Command: t
+Partition number: 4
+Hex code: fd
+
+Command: p
+
+Command: w</code>
+
+This gives me a 128MB boot area, a 2GB swap area, a 2GB root area, with the rest of the disk set aside for my LVM partitions.  Repeat the above commands to configure the 2nd disk in the same fashion.  Note that I'm using a different partition type then that shown in [chapter 4.c](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=4).  The 'fd' partition type is what I need to use since all 4 partitions on hda/hdc are going to be put into a software RAID1 set.
+
+The 3rd disk is a single primary partition with the '8E' (LVM) type.  (Need to verify this, but I'm pretty sure that's correct.)
+
+Create your "/etc/raidtab" configuration file (I used "<b>nano -w /etc/raidtab</b>", but other text editors will work).
+
+<code># this config is for mirroring /dev/hda with /dev/hdc
+# /boot (RAID1)
+raiddev                 /dev/md0
+raid-level              1
+nr-raid-disks           2
+nr-spare-disks          0
+chunk-size              32
+persistent-superblock   1
+device                  /dev/hda1
+raid-disk               0
+device                  /dev/hdc1
+raid-disk               1 
+
+# *swap* (RAID1)
+raiddev                 /dev/md1
+raid-level              1
+nr-raid-disks           2
+nr-spare-disks          0
+chunk-size              8
+persistent-superblock   1
+device                  /dev/hda2
+raid-disk               0
+device                  /dev/hdc2
+raid-disk               1 
+
+# / (RAID1)
+raiddev                 /dev/md2
+raid-level              1
+nr-raid-disks           2
+nr-spare-disks          0
+chunk-size              32
+persistent-superblock   1
+device                  /dev/hda3
+raid-disk               0
+device                  /dev/hdc3
+raid-disk               1 
+
+# LVM (RAID1)
+raiddev                 /dev/md3
+raid-level              1
+nr-raid-disks           2
+nr-spare-disks          0
+chunk-size              16
+persistent-superblock   1
+device                  /dev/hda4
+raid-disk               0
+device                  /dev/hdc4
+raid-disk               1 
+
+# end of /etc/raidtab</code>
+
+Create the raid set(s).
+
+<code># mkraid /dev/md0
+# mkraid /dev/md1
+# mkraid /dev/md2
+# mkraid /dev/md3</code>
+
+If you get the error message: "raid_disks + spare_disks != nr_disks" when attempting to create any of your RAID sets, go back and verify your "/etc/raidtab" file as well as verifying your disk partitions. The RAID sets will build in the background and you should periodically monitor their progress using "<b>cat /proc/mdstat</b>". Another possibility is that you have set the "chunk-size" setting to be too small or too large (e.g. "chunk-size 4" did not work for me, but "chunk size 8" worked fine).
+
+Building the raid sets may take a while, so once again, I'll come back to this point in a few hours.
+
+Update:  <b>mkraid is tossing errors</b> (see my next post)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[09:43](http://www.tgharold.com/techblog/2005/03/gentoo-20050-on-gigabyte-ga-6va7-part_31.shtml)
+
+		</div>

--- a/_posts/2005/2005-03-31-gentoo-mkraid-errors.md
+++ b/_posts/2005/2005-03-31-gentoo-mkraid-errors.md
@@ -1,0 +1,41 @@
+---
+layout: post
+title: 'Gentoo mkraid errors'
+date: '2005-03-31T10:08:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
+
+So, I've created my /etc/raidtab file.  I've done the "<b>modprobe md</b>" and "<b>modprobe dm-mod</b>" commands.  I'm able to "<b>cat /proc/mdstat</b>" which shows that I have no personalities and no unused devices.  But, when I try to use the "<b>mkraid</b>" command, I get the following error:
+
+<code># mkraid /dev/md0
+cannot determine md version: no MD device file in /dev.</code>
+
+The fix (according to the wiki is):
+
+<code>cd /dev ; MAKEDEV md</code>
+
+The key resource to setting up Gentoo on a RAID:
+
+[Gentoo Install on Software RAID](http://gentoo-wiki.com/HOWTO_Gentoo_Install_on_Software_RAID)
+
+Now, they're not putting their swap file on a RAID1.  The reason that I put my swap in a RAID1 partition is that I don't want the system to crash if a drive dies (which it will, if you have 2 seperate, non-RAID swap partitions).  It's a question of whether you want a slightly higher level of stability, or if you want speed.
+
+Other possible gotches:
+
+1) (not confirmed) After you fdisk, you may want to reboot so make sure that the disks are no longer in use.  Otherwise you may get "bd_claim" errors when trying to setup the RAID array.
+
+(still fighting with this a few hours later... going to start a new post)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[10:08](http://www.tgharold.com/techblog/2005/03/gentoo-mkraid-errors.shtml)
+
+		</div>

--- a/_posts/2005/2005-03-31-installing-gentoo-on-software-raid.md
+++ b/_posts/2005/2005-03-31-installing-gentoo-on-software-raid.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: 'Installing Gentoo on Software RAID'
+date: '2005-03-31T15:48:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>I'm currently fighting with this again.  Apparently, there have been some changes between the 2004.0 CD and the 2005.0 CD (mostly related to the 2.6 kernal and the DevFS vs UDev systems).
+
+First off, some tips-n-tricks:
+
+1) <b>ifconfig</b> - find out the IP address of the box
+2) <b>passwd</b> - change the root password to something you know
+3) [Starting the SSH daemon](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=2) - The command is: <b>/etc/init.d/sshd start</b>
+
+Now I'll be able to use SecureCRT and have an easier time of copy-n-paste.  (Pick 'keyboard interactive' and 'ssh2' under options when setting up the connection in SecureCRT.)
+
+Links:
+
+[Gentoo 2004.3 Software RAID Install HOWTO](http://forums.gentoo.org/viewtopic.php?t=257374&amp;highlight=mknod+dev+md0)
+[Gentoo.org - x86 tips and tricks (including software RAID)](http://www.gentoo.org/doc/en/gentoo-x86-tipsntricks.xml)
+[The Linux Documentation Project: Software RAID](http://www.tldp.org/HOWTO/Software-RAID-HOWTO.html)
+[An older gentoo.org thread on software raid](http://forums.gentoo.org/viewtopic.php?p=46458#46458)
+
+Now... to show you what I did and where it breaks.  I have (2) IDE disks, attached as /dev/hda and /dev/hdc.  I plan on mirroring them, and have already created /dev/hda1 (128MB for /boot), /dev/hda2 (2GB for swap), /dev/hda3 (2GB for root), and /dev/hda4 (rest of disk for LVM).  All partitions are flagged as type 'fd' (linux raid auto).
+
+<code># modprobe md
+# ls /dev/md*
+ls: /dev/md*: No such file or directory
+# for i in 0 1 2 3; do mknod /dev/md$i b 9 $i; done 
+# ls /dev/md*
+/dev/md0  /dev/md1  /dev/md2  /dev/md3
+# nano -w /etc/mdadm.conf</code>
+
+Contents of my mdadm.conf file:
+
+<code>DEVICE /dev/hda1 /dev/hda2 /dev/hda3 /dev/hda4
+DEVICE /dev/hdc1 /dev/hdc2 /dev/hdc3 /dev/hdc4
+
+ARRAY /dev/md0 devices=/dev/hda1,/dev/hdc1
+ARRAY /dev/md1 devices=/dev/hda2,/dev/hdc2
+ARRAY /dev/md2 devices=/dev/hda3,/dev/hdc3
+ARRAY /dev/md3 devices=/dev/hda4,/dev/hdc4 </code>
+
+Pretty generic... now to create the raid.  This is where we hit our first issue:
+
+<code># modprobe raid1
+# mdadm --create /dev/md0 --level=1 --raid-devices=2 /dev/hda1 /dev/hdc1 
+mdadm: /dev/hda1 appears to contain an ext2fs file system
+    size=72192K  mtime=Wed Mar 30 16:46:07 2005
+mdadm: /dev/hdc1 appears to contain an ext2fs file system
+    size=72192K  mtime=Wed Mar 30 16:46:07 2005
+Continue creating array? y
+mdadm: ADD_NEW_DISK for /dev/hda1 failed: Device or resource busy
+# </code>
+
+Here are the problems:
+
+1) Even though I have a 128MB partition for /boot, it is still showing 64MB from a previous partitioning scheme.
+
+2) mdadm: ADD_NEW_DISK for /dev/hda1 failed: Device or resource busy
+
+So... take a look at my partition list:
+
+<code>livecd root # fdisk -l 
+
+Disk /dev/hda: 76.8 GB, 76869918720 bytes
+16 heads, 63 sectors/track, 148945 cylinders
+Units = cylinders of 1008 * 512 = 516096 bytes
+
+   Device Boot      Start         End      Blocks   Id  System
+/dev/hda1   *           1         249      125464+  fd  Linux raid autodetect
+/dev/hda2             250        4218     2000376   fd  Linux raid autodetect
+/dev/hda3            4219        8187     2000376   fd  Linux raid autodetect
+/dev/hda4            8188      148945    70942032   fd  Linux raid autodetect
+
+Disk /dev/hdc: 76.8 GB, 76869918720 bytes
+16 heads, 63 sectors/track, 148945 cylinders
+Units = cylinders of 1008 * 512 = 516096 bytes
+
+   Device Boot      Start         End      Blocks   Id  System
+/dev/hdc1   *           1         249      125464+  fd  Linux raid autodetect
+/dev/hdc2             250        4218     2000376   fd  Linux raid autodetect
+/dev/hdc3            4219        8187     2000376   fd  Linux raid autodetect
+/dev/hdc4            8188      148945    70942032   fd  Linux raid autodetect
+livecd root # </code>
+
+All of which looks right and proper.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[15:48](http://www.tgharold.com/techblog/2005/03/installing-gentoo-on-software-raid.shtml)
+
+		</div>

--- a/_posts/2005/2005-04-19-gentoo-20043-on-gigabyte-ga-6va7-part-1.md
+++ b/_posts/2005/2005-04-19-gentoo-20043-on-gigabyte-ga-6va7-part-1.md
@@ -1,0 +1,207 @@
+---
+layout: post
+title: 'Gentoo 2004.3 on Gigabyte GA-6VA7+ (part 1)'
+date: '2005-04-19T16:21:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
+
+This is a continuation of [Gentoo and Software RAID (2004.3)](/techblog/2005/04/gentoo-and-software-raid-20043.shtml), where I configured the disks and setup the RAID array.  I'm now picking up at the point where the RAID array has been configured and we're ready to start installing file systems.
+
+/dev/md0 - 128MB boot
+/dev/md1 - 2GB root partition
+/dev/md2 - 2GB swap
+/dev/md3 - rest of disk (user files)
+
+Now, some folks say copy the /etc/mdadm.conf file, but in the same breath, they indicate that mdadm does not require the use of a config file at all.  Since I'm documenting my configuration here, and my array is extremely straightforward, I'm going to skip creating the mdadm.conf file and see how it goes.
+
+Links:
+[Software RAID (Gentoo Tips-n-Tricks)](http://www.gentoo.org/doc/en/gentoo-x86-tipsntricks.xml)
+[LinuxDevCenter article on mdadm](http://www.linuxdevcenter.com/pub/a/linux/2002/12/05/RAID.html)
+
+The LinuxDevCenter article actually explains how to create the mdadm.conf file yourself (semi-automatically).  Notice the use of wild cards that lets me compactly express that I want all 4 partitions on /dev/hda and /dev/hdc to be used in arrays.  You will need to edit the results to match the syntax of the mdadm.conf file.
+
+<code># echo 'DEVICES /dev/hda*' &gt;&gt; /etc/mdadm.conf
+# echo 'DEVICES /dev/hdc*' &gt;&gt; /etc/mdadm.conf
+# mdadm --detail --scan &gt;&gt; /etc/mdadm.conf
+# nano -w /etc/mdadm.conf</code>
+
+Contents of my mdadm.conf file:
+
+<code>EVICES /dev/hda*
+DEVICES /dev/hdc*
+ARRAY /dev/md3 level=raid1 num-devices=2 devices=/dev/hda4,/dev/hdc4                                
+ARRAY /dev/md2 level=raid1 num-devices=2 devices=/dev/hda3,/dev/hdc3                                
+ARRAY /dev/md1 level=raid1 num-devices=2 devices=/dev/hda2,/dev/hdc2                                
+ARRAY /dev/md0 level=raid1 num-devices=2 devices=/dev/hda1,/dev/hdc1 </code>
+
+Picking up again with [Chapter 4 of the installation handbook](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=4).  This is also very similar to what I did back in [June 2004 with Software RAID and LVM2](/techblog/2004/06/gentoo-install-2-via-epia-me6000.shtml).
+
+<code># mke2fs /dev/md0
+# mke2fs -j /dev/md1
+# mkswap /dev/md2
+# swapon /dev/md2
+# mount /dev/md1 /mnt/gentoo
+# mkdir /mnt/gentoo/boot
+# mount /dev/md0 /mnt/gentoo/boot</code>
+
+Now, we initialize the 4th raid partition for LVM2 operations.  See [Gentoo LVM2 Documentation](http://www.gentoo.org/doc/en/lvm2.xml) for more details about this.
+
+<code># modprobe dm-mod
+# pvcreate /dev/md3
+# echo 'devices { filter=["r/cdrom/"] }' &gt;/etc/lvm/lvm.conf
+# vgcreate vgmirror /dev/md3
+# vgscan</code>
+
+Here is my plan for logical volumes inside the vgmirror partition (this uses up 22GB):
+
+4GB /tmp (ext2)
+4GB /var/tmp (ext2)
+2GB /opt (ext3)
+4GB /usr (ext3)
+4GB /var (ext3)
+4GB /home (ext3)
+
+Create the logical volumes.  If you see the error message "/etc/lvm/backup: fsync failed: Invalid argument", you can ignore this warning (according to [Gentoo's LVM2 page](http://www.gentoo.org/doc/en/lvm2.xml)).
+
+<code># lvcreate -L4G -ntmp vgmirror
+# lvcreate -L4G -nvartmp vgmirror
+# lvcreate -L2G -nopt vgmirror
+# lvcreate -L4G -nusr vgmirror
+# lvcreate -L4G -nvar vgmirror
+# lvcreate -L4G -nhome vgmirror
+# ls -l /dev/vgmirror
+# lvscan</code>
+
+Output of the lvscan command:
+
+<code>  ACTIVE            '/dev/vgmirror/tmp' [4.00 GB] next free (default)
+  ACTIVE            '/dev/vgmirror/vartmp' [4.00 GB] next free (default)
+  ACTIVE            '/dev/vgmirror/opt' [2.00 GB] next free (default)
+  ACTIVE            '/dev/vgmirror/usr' [4.00 GB] next free (default)
+  ACTIVE            '/dev/vgmirror/var' [4.00 GB] next free (default)
+  ACTIVE            '/dev/vgmirror/home' [4.00 GB] next free (default)</code>
+
+Format the logical volumes:
+
+<code># mke2fs /dev/vgmirror/tmp
+# mke2fs /dev/vgmirror/vartmp
+# mke2fs -j /dev/vgmirror/opt
+# mke2fs -j /dev/vgmirror/usr
+# mke2fs -j /dev/vgmirror/var
+# mke2fs -j /dev/vgmirror/home</code>
+
+Make the directories to hold your mounted volumes. Mount your volumes.
+
+<code># mkdir /mnt/gentoo/opt
+# mkdir /mnt/gentoo/usr
+# mkdir /mnt/gentoo/var
+# mkdir /mnt/gentoo/home
+# mount /dev/vgmirror/opt /mnt/gentoo/opt
+# mount /dev/vgmirror/usr /mnt/gentoo/usr
+# mount /dev/vgmirror/var /mnt/gentoo/var
+# mount /dev/vgmirror/home /mnt/gentoo/home</code>
+
+Make the special directories to hold your temp file volumes (these require special permissions). Then mount your temp file volumes. Also mount your proc folder.
+
+<code># mkdir /mnt/gentoo/tmp
+# mount /dev/vgmirror/tmp /mnt/gentoo/tmp
+# chmod 1777 /mnt/gentoo/tmp
+# mkdir /mnt/gentoo/var/tmp
+# mount /dev/vgmirror/vartmp /mnt/gentoo/var/tmp
+# chmod 1777 /mnt/gentoo/var/tmp
+# mkdir /mnt/gentoo/proc
+# mount -t proc none /mnt/gentoo/proc</code>
+
+Now we move into [Installation (chapter 5)](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=5) in the handbook.  Verify your system date and then start extracting the tarballs.
+
+<code># date
+# ls -l /mnt/cdrom/stages
+# cd /mnt/gentoo
+# tar -xvjpf /mnt/cdrom/stages/stage1-x86-2004.3.tar.bz2
+# ls -l /mnt/cdrom/snapshots
+# cd /mnt/gentoo
+# tar -xvjf /mnt/cdrom/snapshots/portage-20041022.tar.bz2 -C /mnt/gentoo/usr
+# cd /mnt/gentoo
+# mkdir /mnt/gentoo/usr/portage/distfiles
+# cp /mnt/cdrom/distfiles/* /mnt/gentoo/usr/portage/distfiles/</code>
+
+Before I configure the make.conf file, I should take a look at my system configuration.
+
+<code># cat /proc/version
+Linux version 2.6.9-gentoo-r1 (root@inertia) (gcc version 3.3.4 20040623 (Gentoo Linux 3.3.4-r1, ssp-3.3.2-2, pie-8.7.6)) #1 SMP Thu Nov 25 03:43:53 UTC 2004
+# cat /proc/cpuinfo
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 8
+model name      : Celeron (Coppermine)
+stepping        : 6
+cpu MHz         : 568.097
+cache size      : 128 KB
+fdiv_bug        : no
+hlt_bug         : no
+f00f_bug        : no
+coma_bug        : no
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 2
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 sep mtrr pge mca cmov pat pse36 mmx fxsr sse
+bogomips        : 1114.11</code>
+
+Now we're ready to edit the make.conf file and change flags:
+
+<code># nano -w /mnt/gentoo/etc/make.conf</code>
+
+Here is my personal make.conf (<b>use at your own risk</b>).  This is for a Celeron Coppermine CPU (Pentium III).  I prefer to compile for size given the small amount of installed RAM on this system.
+
+<code>CFLAGS="-Os -march=pentium3 -pipe -fomit-frame-pointer"
+CHOST="i686-pc-linux-gnu"
+CXXFLAGS="${CFLAGS}"
+MAKEOPTS="-j2"
+USE="apache2 kerberos ldap -apm -gif -gnome -gtk -jpeg -kde -mad -mikmod -mpeg -oggvorbis -opengl -oss -pdflib -png -qt -quicktime -sdl -truetype -xmms -xv"</code>
+
+Pick up again with [Installing the Gentoo Base System](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=6) in the handbook.  Where we pick a mirror and start the move from stage1 to stage3.  I see that the mirrorselect command has changed between 2004.0 and 2004.3.
+
+<code># mirrorselect -i -o &gt;&gt; /mnt/gentoo/etc/make.conf
+# mirrorselect -i -r -o &gt;&gt; /mnt/gentoo/etc/make.conf</code>
+
+This should have dumped 2 extra lines into your make.conf file (cat /mnt/gentoo/etc/make.conf).  Here is what got added to my make.conf file:
+
+<code>GENTOO_MIRRORS="http://gentoo.osuosl.org/ http://csociety-ftp.ecn.purdue.edu/pub/gentoo/ http://gentoo.chem.wisc.edu/gentoo/"
+SYNC="rsync://rsync.us.gentoo.org/gentoo-portage"</code>
+
+Now we need to copy some files.
+
+<code># cp -L /mnt/gentoo/etc/make.conf /mnt/gentoo/boot/make.conf-backupcopy
+# cp -L /etc/resolv.conf /mnt/gentoo/etc/resolv.conf
+# cp -L /etc/mdadm.conf /mnt/gentoo/etc/mdadm.conf
+# cp -L /etc/mdadm.conf /mnt/gentoo/boot/mdadm.conf-backupcopy
+# mkdir /mnt/gentoo/etc/lvm
+# cp -L /etc/lvm/lvm.conf /mnt/gentoo/etc/lvm/lvm.conf
+# cp -L /etc/lvm/lvm.conf /mnt/gentoo/boot/lvm.conf-backupcopy</code>
+
+Change into the new system (note that we already mounted the proc filesystem earlier).
+
+<code># chroot /mnt/gentoo /bin/bash
+# env-update
+# source /etc/profile
+# emerge --sync</code>
+
+This should update your portage tree to the latest version (and make take a while to run).
+
+([See the next step](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[16:21](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part.shtml)
+
+		</div>

--- a/_posts/2005/2005-04-19-gentoo-20043-on-gigabyte-ga-6va7-part-2.md
+++ b/_posts/2005/2005-04-19-gentoo-20043-on-gigabyte-ga-6va7-part-2.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title: 'Gentoo 2004.3 on Gigabyte GA-6VA7+ (part 2)'
+date: '2005-04-19T18:58:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>([Continuation of part 1](/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part.shtml))
+
+<code># ls -l /etc/make.profile</code>
+
+As far as I can tell the 2004.3 already uses the 2.6 kernel, so there's nothing to do here.  I also configured my USE flags in my last post, so that's already done as well.
+
+<code># cd /usr/portage
+# scripts/bootstrap.sh</code>
+
+This will take a while to run (I estimate a few hours, maybe even overnight).  Once that finishes, you move from stage2 to stage3.
+
+<code># emerge --emptytree system</code>
+
+Which will also take a few hours.
+
+([next step](/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part_20.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[18:58](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part_19.shtml)
+
+		</div>

--- a/_posts/2005/2005-04-19-gentoo-and-software-raid-20043.md
+++ b/_posts/2005/2005-04-19-gentoo-and-software-raid-20043.md
@@ -1,0 +1,107 @@
+---
+layout: post
+title: 'Gentoo and Software RAID (2004.3)'
+date: '2005-04-19T11:04:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Going back to the 2004.3 Gentoo Universal boot CD.  Trying to get past my previous issue [bd_claim issues when setting up a software RAID](/techblog/2005/03/installing-gentoo-on-software-raid.shtml).  This is on my Gigabyte GA-6VA7+ motherboard ([notes on the Gigabyte GA-6VA7+ motherboard and other hardware](/techblog/2005/03/gentoo-20050-on-gigabyte-ga-6va7-part.shtml)).
+
+Starting with the usual tricks:
+
+1) Boot the system using the Universal CD
+2) ifconfig - find out the IP address of the box
+3) passwd - change the root password to something you know
+4) Start the SSH daemon - /etc/init.d/sshd start
+
+Since these drives were nuked since my last attempt, I have to re-configure the partitions.
+
+<code># fdisk /dev/hda
+
+Command: n
+Command action: p
+Partition number: 1
+First cylinder: 1
+Last cylinder: +128M
+Command: a
+Partition number: 1
+Command: t
+Hex code: fd
+
+Command: n
+Command action: p
+Partition number: 2
+First cylinder: [enter]
+Last cylinder: +2048M
+Command: t
+Partition number: 2
+Hex code: fd
+
+Command: n
+Command action: p
+Partition number: 3
+First cylinder: [enter]
+Last cylinder: +2048M
+Command: t
+Partition number: 3
+Hex code: fd
+
+Command: n
+Command action: p
+First cylinder: [enter]
+Last cylinder: [enter]
+Command: t
+Partition number: 4
+Hex code: fd
+
+Command: p
+
+Command: w</code>
+
+This gives me a 128MB boot area, a 2GB swap area, a 2GB root area, with the rest of the disk set aside for my LVM2 partitions. Repeat the above commands to configure the 2nd disk in the same fashion (/dev/hdc for me).
+
+Now I need to configure software RAID.  This is a bit easier then last year since I don't need to muck with the /etc/raidtab file (instead, I'm going to use mdadm).
+
+The following loads the 'md' module and creates the nodes (/dev/md*).
+
+<code># modprobe md
+# ls /dev/md*
+ls: /dev/md*: No such file or directory
+# for i in 0 1 2 3; do mknod /dev/md$i b 9 $i; done
+# ls /dev/md*
+/dev/md0 /dev/md1 /dev/md2 /dev/md3</code>
+
+Now, we create our RAID1 sets.
+
+<code># modprobe raid1
+# mdadm --create /dev/md0 --level=1 --raid-devices=2 /dev/hda1 /dev/hdc1 
+mdadm: array /dev/md0 started.
+# mdadm --create /dev/md1 --level=1 --raid-devices=2 /dev/hda2 /dev/hdc2
+mdadm: array /dev/md1 started.
+# cat /proc/mdstat
+Personalities : [raid1] 
+md1 : active raid1 hdc2[1] hda2[0]
+      2000256 blocks [2/2] [UU]
+      [==&gt;..................]  resync = 13.8% (277760/2000256) finish=3.6min speed=7920K/sec
+md0 : active raid1 hdc1[1] hda1[0]
+      125376 blocks [2/2] [UU]
+
+unused devices: &lt;none&gt;</code>
+
+Seems to be working fine.  Once each RAID set finishes initialization, I'll create the next one in the series using the following commands:
+
+<code># mdadm --create /dev/md2 --level=1 --raid-devices=2 /dev/hda3  /dev/hdc3
+# mdadm --create /dev/md3 --level=1 --raid-devices=2 /dev/hda4 /dev/hdc4</code>
+
+The last RAID set will take a while to initialize (2 hours?), so I'm going to go work on other things while it runs.  I also need to go back and review the documentation to see what else I need to do when doing software RAID.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[11:04](http://www.tgharold.com/techblog/2005/04/gentoo-and-software-raid-20043.shtml)
+
+		</div>

--- a/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-3.md
+++ b/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-3.md
@@ -1,0 +1,41 @@
+---
+layout: post
+title: 'Gentoo 2004.3 on Gigabyte GA-6VA7+ (part 3)'
+date: '2005-04-20T19:42:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
+
+([previous step](/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part_19.shtml))
+
+Time to configure the timezone and setup the kernel, this is [chapter 7 in the Gentoo handbook](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).
+
+Timezone for me is EST5EDT, so here's how to set that up.
+
+<code># ls /usr/share/zoneinfo
+# ln -sf /usr/share/zoneinfo/EST5EDT /etc/localtime
+# date
+# zdump GMT
+# zdump EST5EDT</code>
+
+Last year, I went with development-sources for the kernel in order to get 2.6.  This is no longer necessary (and development-sources has been rolled into vanilla-sources).  So I'm going to go with the default gentoo-sources.
+
+<code># emerge gentoo-sources
+# ls -l /usr/src</code>
+
+This takes a while to run (maybe an hour or two).
+
+(next step)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[19:42](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part_20.shtml)
+
+		</div>

--- a/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-4.md
+++ b/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-4.md
@@ -1,0 +1,149 @@
+---
+layout: post
+title: 'Gentoo 2004.3 on Gigabyte GA-6VA7+ (part 4)'
+date: '2005-04-20T20:43:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
+
+(previous step)
+
+Time to [configure the kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).
+
+<code># emerge lvm2
+# emerge mdadm
+# cd /usr/src/linux
+# make menuconfig</code>
+
+Linux Kernel v2.6.11 Configuration
+(C)ode maturity level options
+(G)eneral setup
+--&gt; (C)onfigure standard kernel features for small systems (turn ON)
+--&gt; --&gt; (O)ptimize for size (turn ON)
+(L)oadable module support
+(P)rocessor type and features
+--&gt; (P)rocessor family (changed to "Pentium-III...")
+--&gt; (S)ymetric multi-processing support (turned this one OFF)
+--&gt; M(a)chine Check Exception (turned this OFF)
+(P)ower management options (ACPI, APM)
+(B)us options (PCI, PCMCIA, EISA&lt; MCA, ISA)
+(E)xecutable file formats
+(D)evice drivers
+--&gt; (P)arallel port support (turned OFF)
+--&gt; (A)TA/ATAPI/MFM/RLL support (turned ON the PDC20262 chipset support as BUILT-IN)
+--&gt; M(u)lti-device support (turn it ON)
+--&gt; --&gt; (R)AID support (turn it ON as BUILT-IN)
+--&gt; --&gt; --&gt; (R)AID-1 mirroring mode (turn it ON as BUILT-IN)
+--&gt; --&gt; (D)evice mapper support (set to MODULE, per section 13 of LVM2 guide)
+--&gt; (C)haracter Devices
+--&gt; --&gt; (I)ntel/AMD/VIA HW Random Number Generator (turn ON as BUILT-IN)
+--&gt; (S)ound
+--&gt; --&gt; (S)ound card support (turn OFF)
+(F)ile systems
+(P)rofiling support
+(K)ernel hacking
+(S)ecurity options
+(C)ryptographic options
+(L)ibrary routines
+
+Exit and save your configuration. Then build the kernel (the following is for 2.6 kernels). Expect the compile to take about an hour.
+
+<code># make &amp;&amp; make modules_install</code>
+
+Now you need to install your kernel into the boot partition. Change the "2.6.6-gentoo" portion of the filenames to whatever you want.
+
+<code># cp arch/i386/boot/bzImage /boot/kernel-2.6.11-gentoo-Apr20
+# cp System.map /boot/System.map-2.6.11-gentoo-Apr20
+# cp .config /boot/config-2.6.11-gentoo-Apr20</code>
+
+Now we need to configure LVM to auto-load.
+
+<code># nano -w /etc/modules.autoload.d/kernel-2.6</code>
+
+Here is what my autoload file looks like:
+
+<code># /etc/modules.autoload.d/kernel-2.6:  kernel modules to load when system boots.
+# $Header: /home/cvsroot/gentoo-src/rc-scripts/etc/modules.autoload.d/kernel-2.6,v 1.1 2003/07/16 18:13:45 azarah Exp $
+#
+# Note that this file is for 2.6 kernels.
+#
+# Add the names of modules that you'd like to load when the system
+# starts into this file, one per line.  Comments begin with # and
+# are ignored.  Read man modules.autoload for additional details.
+
+# For example:
+# 3c59x
+
+dm-mod</code>
+
+Now, edit the /etc/fstab file:
+
+<code># /etc/fstab: static file system information.
+# $Header: /home/cvsroot/gentoo-src/rc-scripts/etc/fstab,v 1.14 2003/10/13 20:03:38 azarah Exp $
+#
+# noatime turns off atimes for increased performance (atimes normally aren't
+# needed; notail increases performance of ReiserFS (at the expense of storage
+# efficiency).  It's safe to drop the noatime options if you want and to
+# switch between notail and tail freely.
+
+# &lt;fs&gt;                  &lt;mountpoint&gt;    &lt;type&gt;          &lt;opts&gt;                  &lt;dump/pass&gt;
+
+# NOTE: If your BOOT partition is ReiserFS, add the notail option to opts.
+/dev/md0                /boot           ext2            noauto,noatime          1 2
+/dev/md1                /               ext3            noatime                 0 1
+/dev/md2                none            swap            sw                      0 0
+/dev/cdroms/cdrom0      /mnt/cdrom      auto            noauto,ro,user          0 0
+#/dev/fd0               /mnt/floppy     auto            noauto                  0 0
+
+/dev/vgmirror/opt       /opt            ext3            noatime                 0 3        
+/dev/vgmirror/usr       /usr            ext3            noatime                 0 3
+/dev/vgmirror/var       /var            ext3            noatime                 0 3
+/dev/vgmirror/home      /home           ext3            noatime                 0 3
+/dev/vgmirror/tmp       /tmp            ext2            noatime                 0 3
+/dev/vgmirror/vartmp    /var/tmp        ext2            noatime                 0 3        
+
+# NOTE: The next line is critical for boot!
+none                    /proc           proc            defaults                0 0
+
+# glibc 2.2 and above expects tmpfs to be mounted at /dev/shm for
+# POSIX shared memory (shm_open, shm_unlink).
+# (tmpfs is a dynamically expandable/shrinkable ramdisk, and will
+#  use almost no memory if not populated with files)
+# Adding the following line to /etc/fstab should take care of this:
+
+none                    /dev/shm        tmpfs           defaults                0 0</code>
+
+Now, some misc stuff:
+
+<code># echo yourhostname &gt; /etc/hostname
+# echo yourdnsname &gt; /etc/dnsdomainname
+# rc-update add domainname default
+# nano -w /etc/conf.d/net
+(either use iface_eth0="dhcp" or configure your IP and gateway)
+# rc-update add net.eth0 default
+# cat /etc/resolv.conf
+(verify your DNS servers if you specified a static IP)
+# nano -w /etc/rc.conf
+(change CLOCK="UTC" to CLOCK="local")
+# passwod
+(set your root password to something you will remember)
+
+# useradd -m -G users,wheel,audio -s /bin/bash john
+# passwd john
+
+(add a user called 'john' and set a password)</code>
+
+(next step)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[20:43](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-g_111404509792475776.shtml)
+
+		</div>

--- a/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-5.md
+++ b/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-5.md
@@ -1,0 +1,79 @@
+---
+layout: post
+title: 'Gentoo 2004.3 on Gigabyte GA-6VA7+ (part 5)'
+date: '2005-04-20T23:39:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
+
+(previous step)
+
+Time to [install the bootloader](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=10).  I plan on using GRUB:
+
+<code># emerge grub</code>
+
+Now to configure GRUB (refer to my [old post about GRUB](/techblog/2004/06/gentoo-install-6-grub-system-tools.shtml) for a more in-depth explanation of what I'm telling GRUB to do here).
+
+<code># grub --no-floppy
+grub&gt; find /grub/stage1
+(hd0,0)
+(hd1,0)
+grub&gt; root (hd0,0)
+grub&gt; setup (hd0)
+grub&gt; device (hd0) /dev/hdc
+grub&gt; root (hd0,0)       
+grub&gt; setup (hd0)
+grub&gt; quit
+#</code>
+
+Now, edit your config file for grub:
+
+<code># nano -w /boot/grub/grub.conf</code>
+
+Here is what mine looks like.  Yours may be different, depending on how you configured things (and remember that I'm using Software RAID).
+
+<code># cat /boot/grub/grub.conf
+default 0
+timeout 30
+title=Gentoo Linux 2.6.11 (April 20 2005)
+root (hd0,0)
+kernel /kernel-2.6.11-gentoo-Apr20 root=/dev/md2
+#</code>
+
+Now I install various system tools (see the handbook):
+
+<code># emerge syslog-ng
+# rc-update add syslog-ng default
+# emerge dcron
+# rc-update add dcron default
+# crontab /etc/crontab</code>
+
+Note: Now you need to unmount everything that you can (including LVM), possibly shutdown the RAID as well prior to reboot.
+
+<code>livecd gentoo # exit
+livecd / # cd /
+livecd / # cat /proc/mounts
+
+(unmount all of your mounted partitions, including the LVM mounts)
+
+livecd / # umount ... (insert list of mounted file systems)
+
+livecd / # vgchange -an vgmirror
+livecd / # reboot</code>
+
+Pull the CD-ROM at this point, otherwise the LiveCD will probably boot.
+
+(next step)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[23:39](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-g_111405560831835556.shtml)
+
+		</div>

--- a/_posts/2005/2005-04-20-gentoo-upgrading-your-profile.md
+++ b/_posts/2005/2005-04-20-gentoo-upgrading-your-profile.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: 'Gentoo Upgrading your Profile'
+date: '2005-04-20T23:59:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>At some point, I need to upgrade my Gentoo profile from 2004.3 to 2005.0.  Here's the error message that you see on screen when you need to do this.
+
+<code>livecd linux # emerge (something)
+
+!!! Your current profile is deprecated and not supported anymore.
+!!! Please upgrade to the following profile if possible:
+        default-linux/x86/2005.0
+
+To upgrade do the following steps:
+# emerge -n '&gt;=sys-apps/portage-2.0.51'
+# cd /etc/
+# rm make.profile
+# ln -s ../usr/portage/profiles/default-linux/x86/2005.0 make.profile
+
+# Gentoo has switched to 2.6 as the defaults for headers/kernels.  If you wish
+# to use 2.4 headers/kernels, then you should do the following to upgrade:
+# emerge -n '&gt;=sys-apps/portage-2.0.51'
+# cd /etc/
+# rm make.profile
+# ln -s ../usr/portage/profiles/default-linux/x86/2005.0/2.4 make.profile
+
+# More information can be found at the following URLs:
+# http://www.gentoo.org/doc/en/gentoo-upgrading.xml
+# http://www.gentoo.org/doc/en/migration-to-2.6.xml</code><div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[23:59](http://www.tgharold.com/techblog/2005/04/gentoo-upgrading-your-profile.shtml)
+
+		</div>

--- a/_posts/2005/2005-04-24-gentoo-cant-create-lock-file.md
+++ b/_posts/2005/2005-04-24-gentoo-cant-create-lock-file.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: 'Gentoo: Can't create lock file'
+date: '2005-04-24T00:10:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Well, first glitch. Looking at my boot screen with [Shift-PgUp] / [Shift-PgDn] to find the error. I see that the Software RAID is working fine (it built md0..md3 automatically).
+
+<code>* Mounting proc at /proc [ ok ]
+* Mounting sysfs at /sys [ !! ]
+can't create lock file /etc/mtab~944: Read-only file system (use -n flag to override)
+* Mounting ramfs at /dev... [ ok ]
+* Configuring system to use udev... [ ok ]
+*   Populating /dev with device nodes...
+*   Using /sbin/hotplug for udev management...
+* Mounting devpts at /dev/pts... [ ok ]
+* Activating (possible) swap... [ ok ]
+* Remounting root filesystem read-only (if necessary)... [ ok ]
+* Checking root filesystem...
+ext2fs_check_if_mount: No such file or directory while determining whether /dev/md2 is mounted.
+fsck.ext3: No such file or directory while trying to open /dev/md2
+/dev/md2: The superblock could not be read or does not describe a correct ext2 filesystem. If the device is valid and it really contains an ext2 filesystem (and not swap or ufs or something else), then the superblock is corrupt, and you might try running e2fsck -b 8193 &lt;device&gt;
+* Filesystem couldn't be fixed :( [ !! ]
+
+Give root password for maintenance
+(or type Control-D for normal startup):</code>
+
+So, according to a quick google, this indicates an issue with /etc/fstab.
+
+I'll be digging into this in a few days when I get a chance.  (See [Troubleshooting 1](http://www.blogger.com/techblog/2005/04/gentoo-troubleshooting-1.shtml).)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[00:10](http://www.tgharold.com/techblog/2005/04/gentoo-cant-create-lock-file.shtml)
+
+		</div>

--- a/_posts/2005/2005-04-29-gentoo-troubleshooting-1.md
+++ b/_posts/2005/2005-04-29-gentoo-troubleshooting-1.md
@@ -1,0 +1,109 @@
+---
+layout: post
+title: 'Gentoo: Troubleshooting 1'
+date: '2005-04-29T11:44:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>So, I've got a system that isn't booting yet.  The boot error is:
+
+<code>* Mounting proc at /proc [ ok ]
+* Mounting sysfs at /sys [ !! ]
+can't create lock file /etc/mtab~944: Read-only file system (use -n flag to override)</code>
+
+First, I have to go back to the boot CD and get up and running:
+
+<code>livecd root # passwd
+livecd root # /etc/init.d/sshd start
+livecd root # ifconfig
+(at this point, I switch over to using SecureCRT on the other system)
+livecd root # modprobe md
+livecd root # modprobe raid1
+livecd root # for i in 0 1 2 3; do mknod /dev/md$i b 9 $i; done
+livecd root # mdadm --assemble /dev/md0 /dev/hda1 /dev/hdc1
+livecd root # mdadm --assemble /dev/md1 /dev/hda2 /dev/hdc2
+livecd root # mdadm --assemble /dev/md2 /dev/hda3 /dev/hdc3
+livecd root # mdadm --assemble /dev/md3 /dev/hda4 /dev/hdc4</code>
+
+That gets the raid arrays up and running.
+
+<code>livecd root # swapon /dev/md2
+livecd root # mount /dev/md1 /mnt/gentoo
+livecd root # mount /dev/md0 /mnt/gentoo/boot
+livecd root # modprobe dm-mod
+livecd root # mkdir /etc/lvm
+livecd root # echo 'devices { filter=["r/cdrom/"] }' &gt;/etc/lvm/lvm.conf
+livecd / # lvscan
+livecd / # lvchange -ay vgmirror</code>
+
+Which gets the LVM2 up and running (and the logical volumes set to active).
+
+<code># mount /dev/vgmirror/opt /mnt/gentoo/opt
+# mount /dev/vgmirror/usr /mnt/gentoo/usr
+# mount /dev/vgmirror/var /mnt/gentoo/var
+# mount /dev/vgmirror/home /mnt/gentoo/home
+# mount /dev/vgmirror/tmp /mnt/gentoo/tmp
+# chmod 1777 /mnt/gentoo/tmp
+# mount /dev/vgmirror/vartmp /mnt/gentoo/var/tmp
+# chmod 1777 /mnt/gentoo/var/tmp
+# mount -t proc none /mnt/gentoo/proc</code>
+
+Should be ready to chroot into the hard disk.
+
+<code># chroot /mnt/gentoo /bin/bash ; env-update</code>
+
+Gonna redo my kernel configuration (see [Gentoo 2004.3 on Gigabyte GA-6VA7+ (part 4)](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-g_111404509792475776.shtml)) because I suspect that something needed to be loaded in differently.
+
+<code># cd /usr/src/linux
+# make menuconfig</code>
+
+Going to switch the LVM2 from loading as a "module" and change it to being "built-in".  Could be an error on the Gentoo LVM2 page according to a [note I see in the gentoo wiki](http://gentoo-wiki.com/HOWTO_Gentoo_Install_on_Software_RAID_mirror_and_LVM2_on_top_of_RAID).
+
+<code># make &amp;&amp; make modules_install
+# cp arch/i386/boot/bzImage /boot/kernel-2.6.11-gentoo-Apr20
+# cp System.map /boot/System.map-2.6.11-gentoo-Apr20
+# cp .config /boot/config-2.6.11-gentoo-Apr20
+# nano -w /etc/modules.autoload.d/kernel-2.6
+(remove dm-mod from being auto-loaded)
+livecd linux # exit
+livecd / # cd /
+livecd / # cat /proc/mounts
+
+(unmount all of your mounted partitions, including the LVM mounts)
+
+livecd / # umount ... (insert list of mounted file systems)
+
+livecd / # vgchange -an vgmirror
+livecd / # reboot
+
+(remove the gentoo boot CD)</code>
+
+Now to see if it works.  No luck.  Redoing the above, but going to re-do my LVM2, but changing to be 'static' per the wiki.
+
+<code># echo 'sys-fs/lvm2 static' &gt;&gt; /etc/portage/package.use
+# emerge lvm2</code>
+
+No joy here either.  Time to go do some more searching.
+
+Attempt #3 (#4?), editing the grub.conf file and adding "udev" to the end of the "kernel" line.  Nothing complex, just tack " udev" onto the end of the kernel line using nano.
+
+No joy again.
+
+Attempt #4 - added an initrd line to the grub.conf file.  Doubtful that this will fix the issue.
+
+Nope.
+
+Attempt #5 - using [this thread over at the gentoo forums](http://forums.gentoo.org/viewtopic-t-318344-highlight-mtab.html), I added some more information to my kernel line in the grub.conf file.
+
+Nope.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[11:44](http://www.tgharold.com/techblog/2005/04/gentoo-troubleshooting-1.shtml)
+
+		</div>

--- a/_posts/2005/2005-05-03-cwrsync-and-copssh.md
+++ b/_posts/2005/2005-05-03-cwrsync-and-copssh.md
@@ -1,0 +1,88 @@
+---
+layout: post
+title: 'cwRSync and copSSH'
+date: '2005-05-03T20:29:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<i>Note: These directions are works-in-progress... in fact, they might not even work at all.  I got side-tracked before I could finish this and will re-visit it at some point in the future.</i>
+
+The folks who created cwRSync ([www.itefix.no](http://www.itefix.no/)) have now released a package called copSSH which is basically SSH for windows and works with cwRSync.  I'll be refering back to my old post about [installing cwRSync](http://www.tgharold.com/techblog/2004/06/installing-cwrsync-on-windows-2000.shtml).  The latest version I have is from late April 2005 and includes bug fixes for Windows Server 2003.
+
+Also see the [rsyncd.conf file for configuring rsync](http://rsync.samba.org/ftp/rsync/rsyncd.conf.html).
+
+These steps are for installing rsync in a <b>server configuration</b> (meaning that it will be listening on the listed ports). Since the install process needs to (optionally) create an user account and create a new service, you'll need administrative access to the machine that you are using. (I'm not sure whether members of the Power Users group have enough privileges.)
+
+<ol>
+
+<li>Download cwRSync, open up the ZIP file, then extract/run cwRsync_x.x.x_Installer.exe.
+
+</li>
+<li>Click "Next" to begin the install.
+
+</li>
+<li>Read and agree to the licence.
+
+</li>
+<li>Make sure that both the client and server components are checked off and click "Next".
+
+</li>
+<li>Choose your installation location.  I prefer to put mine in a custom location (C:\bin\cwRsync).
+
+</li>
+<li>Click "Install" to begin the installation.
+
+</li>
+<li>The default user account is "cwrsync" (with a random password) and it will be installed as a service.  You will probably want to change the password to something stronger and adjust the properties of the service in Computer Management.  Specifically, I changed the Recovery tab to auto-restart the service after 5 minutes if it dies.  I've left the "auto-start" setting to "manual" until I've finished configuration and testing.
+
+</li>
+<li>By default, the newly created "cwRSync" folder grants permissions to the Administrators group (full control), the CWRSYNC user account (full control) and the Users account (read/execute).
+
+</li>
+<li>Now you should configure your rsyncd.conf file.
+
+</li>
+</ol>
+
+Now we need to install copSSH.
+
+<ol>
+
+<li>Download copSSH, open up the ZIP file, then extract/run copSSH_x.x.x_Installer.exe.
+
+</li>
+<li>Click "Next" to begin the install.
+
+</li>
+<li>Read and agree to the licence.
+
+</li>
+<li>Change the install folder to match where you installed cwRSync (C:\bin\cwRsync).  (This is according to the FAQ on the itefix.no web site.)
+
+</li>
+<li>This creates a new service called "OpenSSH SSHD" with a default users account of "SvcCOPSSH"
+
+</li>
+<li>You will probably want to change the password to something stronger and adjust the properties of the service in Computer Management.  Specifically, I changed the Recovery tab to auto-restart the service after 5 minutes if it dies.  I've changed the "auto-start" setting to "manual" until I've finished configuration and testing.
+
+</li>
+<li>Notice that the copSSH installation blows away existing permissions on the c:\bin\cwRSync folder.  This may require fixing (I have to test first).
+
+</li>
+<li>Re-start the SSHD service in manual mode (if you stopped it earlier).
+
+</li>
+</ol>
+<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[20:29](http://www.tgharold.com/techblog/2005/05/cwrsync-and-copssh.shtml)
+
+		</div>

--- a/_posts/2005/2005-06-27-gentoo-no-news.md
+++ b/_posts/2005/2005-06-27-gentoo-no-news.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: 'Gentoo: No news'
+date: '2005-06-27T12:33:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Been fighting with the Gentoo install for a few weeks now, but am currently working on another project.  It will be a few weeks before I get back around to working on the Gentoo issues again.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[12:33](http://www.tgharold.com/techblog/2005/06/gentoo-no-news.shtml)
+
+		</div>

--- a/_posts/2005/2005-07-13-gentoo-20050-software-raid-part-1.md
+++ b/_posts/2005/2005-07-13-gentoo-20050-software-raid-part-1.md
@@ -1,0 +1,81 @@
+---
+layout: post
+title: 'Gentoo 2005.0 Software RAID (part 1)'
+date: '2005-07-13T12:37:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<i>Note: As always, these are works-in-progress.  They might work, or they might not and are mostly here so that I can keep track of what I did or didn't do during an install.</i>
+
+Gentoo 2005.0 Software RAID (part 1) - Going to try again with Gentoo 2005.0 in a software RAID with LVM configuration.  There's a [post](http://forums.gentoo.org/viewtopic-t-358713.html) on the Gentoo forums that indicates it may now be possible to get it up and running (seems to indicate there was a bug with kernels prior to 2.6.12).
+
+The hardware that I'm using is a [VIA EPIA ME6000](/techblog/2005/03/gentoo-epia-install-part-1.shtml) (full details).  Basically 2x160GB drives, which will be mirrored.  
+
+Start with the usual first steps (I prefer to ssh into my box during the build, it allows me to keep a log file of all commands, errors, etc.).
+
+1) Boot the system using the Universal CD
+2) ifconfig - find out the IP address of the box
+3) passwd - change the root password to something you know
+4) Start the SSH daemon - /etc/init.d/sshd start
+
+Then I SSH in using SecureCRT and start my install.
+
+As always, I start by blowing away any existing partitions by using "fdisk" or Derik's Boot and Nuke (a bootable CD which you can use to erase hard drives).  Then I'll re-create my partitions and start in on the installation.
+
+<code># fdisk /dev/hda
+
+Command: n
+Command action: p
+Partition number: 1
+First cylinder: 1
+Last cylinder: +128M
+Command: a
+Partition number: 1
+Command: t
+Hex code: fd
+
+Command: n
+Command action: p
+Partition number: 2
+First cylinder: [enter]
+Last cylinder: +2048M
+Command: t
+Partition number: 2
+Hex code: fd
+
+Command: n
+Command action: p
+Partition number: 3
+First cylinder: [enter]
+Last cylinder: +2048M
+Command: t
+Partition number: 3
+Hex code: fd
+
+Command: n
+Command action: p
+First cylinder: [enter]
+Last cylinder: [enter]
+Command: t
+Partition number: 4
+Hex code: fd
+
+Command: p
+
+Command: w</code>
+
+This gives me a 128MB boot area, a 2GB swap area, a 2GB root area, with the rest of the disk set aside for my LVM partitions. Repeat the above commands to configure the 2nd disk in the same fashion. Note that I'm using a different partition type then that shown in chapter 4.c. The 'fd' partition type is what I need to use since all 4 partitions on hda/hdc are going to be put into a software RAID1 set.
+
+<i>(Eventually ran out of time to get this working due to other projects, now waiting on 2005.1 release.)</i><div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[12:37](http://www.tgharold.com/techblog/2005/07/gentoo-20050-software-raid-part-1.shtml)
+
+		</div>

--- a/_posts/2005/2005-08-09-more-rsync-links-for-using-rsync-as-a-backup-tool.md
+++ b/_posts/2005/2005-08-09-more-rsync-links-for-using-rsync-as-a-backup-tool.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: 'More rsync links for using rsync as a backup tool'
+date: '2005-08-09T08:58:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+[Easy Automated Snapshot-Style Backups with Linux and Rsync](http://www.mikerubel.org/computers/rsync_snapshots/)
+
+I'll need to come back and revisit this link, from a glance, it looks very well laid out and will be exactly what I want to pattern my backup systems after.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[08:58](http://www.tgharold.com/techblog/2005/08/more-rsync-links-for-using-rsync-as.shtml)
+
+		</div>

--- a/_posts/2005/2005-08-30-visual-basic-rnd-function-tricks-and-traps.md
+++ b/_posts/2005/2005-08-30-visual-basic-rnd-function-tricks-and-traps.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title: 'Visual Basic Rnd() function tricks and traps'
+date: '2005-08-30T11:12:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Found this while examining some code results this week.  
+
+One of our bits of code attempts to generate a negative 32bit integer to be used for a random ID.  The code is pretty standard for Visual Basic, and is used just about everywhere:
+
+<code>'Int((upperbound - lowerbound + 1) * Rnd + lowerbound)
+tmpUserID = Int((-1 - -2147483647 + 1) * Rnd + -2147483647)</code>
+
+The problem with this code is that the end result is <i>always</i> divisible by 4.  So instead of getting ~2,147,483,647 unique values, we're only getting around 536,870,911.  Needless to say, that tends to raise a bit of concern about the RNG in Visual Basic.
+
+But, if you do some digging, it becomes pretty apparent why this happens.  The Rnd() function returns a value of type "single", which is a 32-bit IEEE floating point value.  (One bit is used for the sign, 8 bits for the exponent, and 23 bits for the mantissa.) The value returned is always &gt;=0 and &lt;1, which is only about 30bits worth of randomness.
+
+So, when you try to eek out a full 31 or 32 bits worth of randomness, you simply don't have the bits to do it.  There are ways to combine two calls to the Rnd() function to get more bits, but I need to do some research rather then posting a broken method of doing this.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[11:12](http://www.tgharold.com/techblog/2005/08/visual-basic-rnd-function-tricks-and.shtml)
+
+		</div>

--- a/_posts/2005/2005-09-07-gentoo-20051-software-raid-part-1.md
+++ b/_posts/2005/2005-09-07-gentoo-20051-software-raid-part-1.md
@@ -1,0 +1,335 @@
+---
+layout: post
+title: 'Gentoo 2005.1 Software RAID (part 1)'
+date: '2005-09-07T13:03:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<b>Note: These directions are works-in-progress... in fact, they might not even work at all.  The big change that I'm trying this time around is using the 2005.1 release.  I'm also going to skip LVM2 on the initial installation.  I'm now in the process of updating this to include instructions for both with and without LVM2.</b>
+
+Now that the 2005.1 release is out, I'm going to take yet another swing at getting a software RAID configuration up and running on a pair of ATA disks. I'm working on two different systems.
+
+<b>System A:</b> This is an older motherboard (AT power, 2 ISA slots, 3 PCI slots) running on a Celeron processor ([system details](http://www.tgharold.com/techblog/2005/03/gentoo-20050-on-gigabyte-ga-6va7-part.shtml)).  But in the meantime, I've upgraded the disks to (3) 120GB 5400rpm drives (these run cooler then the old 7200rpm drives and will have less issues with heat).
+
+<b>System B:</b> The second system is [VIA EPIA ME6000](http://www.tgharold.com/techblog/2005/03/gentoo-epia-install-part-1.shtml) (EPIA M series), 600Mhz fanless CPU with a pair of 300GB PATA drives and a DVD-ROM.
+
+Derik's Boot and Nuke (DBaN) seems like a good first step to make sure that any old data is wiped off of the 3 drives.  Data rates on the wipe process (running all 3 drives at the same time) is around 7.5MB/s per drive.  After having issues with an older configuration, I now always run DBaN for 2-3 passes with verification on all passes.  It drastically increases the amount of time required for the initial wipe but allows me to discover errors before I get into installing Gentoo.
+
+Once that finishes running, I will have:
+
+<b>System A:</b>
+/dev/hda - 120GB primary IDE drive (Primary IDE channel, Master)
+/dev/hdc - CD-ROM (Secondary IDE channel, Master)
+/dev/hde - 120GB attached to Promise controller (PDC20262)
+/dev/hdg - 120GB attached to Promise controller (PDC20262)
+
+/dev/hda and /dev/hde will be mirrored together.  The /dev/hdeg disk will be used as a backup/scratch disk.
+
+<b>System B:</b>
+/dev/hda - 300GB IDE drive (Primary IDE channel, Master)
+/dev/hdc - 300GB IDE drive (Secondary IDE channel, Master)
+/dev/hdd - CD-ROM (Secondary IDE channel, Slave)
+
+/dev/hda and /dev/hdc will be mirrored together.
+
+Starting with the usual tricks:
+
+1) Boot the system using the Universal CD
+2) ifconfig - find out the IP address of the box
+3) passwd - change the root password to something you know
+4) Start the SSH daemon - /etc/init.d/sshd start
+
+Since these drives were nuked since my last attempt, I have to re-configure the partitions.
+
+<code># fdisk /dev/hda
+
+Command: n
+Command action: p
+Partition number: 1
+First cylinder: 1
+Last cylinder: +128M
+Command: a
+Partition number: 1
+Command: t
+Hex code: fd
+
+Command: n
+Command action: p
+Partition number: 2
+First cylinder: [enter]
+Last cylinder: +2048M
+Command: t
+Partition number: 2
+Hex code: fd
+
+(note that partition #3 can be different sizes based on needs)
+
+Command: n
+Command action: p
+Partition number: 3
+First cylinder: [enter]
+Last cylinder: +16384M or +2048M
+Command: t
+Partition number: 3
+Hex code: fd
+
+Command: n
+Command action: p
+First cylinder: [enter]
+Last cylinder: (use 99% of what's available)
+Command: t
+Partition number: 4
+Hex code: fd
+
+Command: p
+
+Command: w</code>
+
+This gives me a 128MB boot area, a 2GB swap area, a root area, with the rest of the disk set aside for my LVM2 partitions. Repeat the above commands to configure the 2nd disk in the same fashion (/dev/hdc or /dev/hde for my 2 systems).
+
+If you are not using LVM2 on the initial installation, I tend to use a 16GB root partition.  Otherwise if you are going to use LVM2 you can get away with a smaller 2GB root partition.
+
+I always use a slightly smaller size for the 4th partition then the maximum available on the disk.  That will hopefully protect me if I would have to replace one of the drives with another one that is slightly smaller then expected.  (Not all 250GB drives are identical in the number of cylinders.)  A fudge-factor of around 1% of the total # of cylinders should be adequate.
+
+Key resource: [HOWTO Gentoo Install on Software RAID](http://gentoo-wiki.com/HOWTO_Gentoo_Install_on_Software_RAID)
+
+Now I need to configure software RAID. This is a bit easier then last year since I don't need to muck with the /etc/raidtab file (instead, I'm going to use mdadm).  This is based on research that I did while [using the 2004.3 CDs](/techblog/2005/04/gentoo-and-software-raid-20043.shtml)
+
+The following loads the 'md' module and creates the nodes (/dev/md*).
+
+<code># modprobe md
+# ls /dev/md*
+ls: /dev/md*: No such file or directory
+# for i in 0 1 2 3; do mknod /dev/md$i b 9 $i; done
+# ls /dev/md*
+/dev/md0 /dev/md1 /dev/md2 /dev/md3</code>
+
+Now, we create our RAID1 sets.
+
+<b>System A:</b>
+<code># modprobe raid1
+# mdadm --create /dev/md0 --level=1 --raid-devices=2 /dev/hda1 /dev/hde1
+# mdadm --create /dev/md1 --level=1 --raid-devices=2 /dev/hda2 /dev/hde2
+# mdadm --create /dev/md2 --level=1 --raid-devices=2 /dev/hda3 /dev/hde3
+# mdadm --create /dev/md3 --level=1 --raid-devices=2 /dev/hda4 /dev/hde4
+# cat /proc/mdstat</code>
+
+<b>System B:</b>
+<code># modprobe raid1
+# mdadm --create /dev/md0 --level=1 --raid-devices=2 /dev/hda1 /dev/hdc1
+# mdadm --create /dev/md1 --level=1 --raid-devices=2 /dev/hda2 /dev/hdc2
+# mdadm --create /dev/md2 --level=1 --raid-devices=2 /dev/hda3 /dev/hdc3
+# mdadm --create /dev/md3 --level=1 --raid-devices=2 /dev/hda4 /dev/hdc4
+# cat /proc/mdstat</code>
+
+Seems to be working fine. You can choose to wait until all of the RAID arrays finish processing (recommended) or press onward.
+
+[LinuxDevCenter article on mdadm](http://www.linuxdevcenter.com/pub/a/linux/2002/12/05/RAID.html) explains mdadm in a bit more detail, and shows how to create the config file semi-automatically.  Be sure to change '/dev/hda' and 'dev/hde' to match the 2 disks that you are attempting to RAID.
+
+<code># mdadm --detail --scan &gt;&gt; /etc/mdadm.conf
+# nano -w /etc/mdadm.conf</code>
+
+Picking up again with [Chapter 4 of the installation handbook](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=4).  (This also matches what I did back in [June 2004 with Software RAID and LVM2](/techblog/2004/06/gentoo-install-2-via-epia-me6000.shtml) and [Gentoo 2004.3 on Gigabyte GA-6VA7+ (part 1)](/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part.shtml).)
+
+<code># mke2fs /dev/md0
+# mkswap /dev/md1 ; swapon /dev/md1
+# mke2fs -j /dev/md2
+# mount /dev/md2 /mnt/gentoo
+# mkdir /mnt/gentoo/boot ; mount /dev/md0 /mnt/gentoo/boot</code>
+
+If we're setting up LVM2, we need to now prep the 4th partition and setup the logical volumes inside of LVM2.
+
+<code># modprobe dm-mod
+# pvcreate /dev/md3
+# echo 'devices { filter=["r/cdrom/"] }' &gt; /etc/lvm/lvm.conf
+# vgcreate vgmirror /dev/md3
+# vgscan
+# lvcreate -L2G -ntmp vgmirror
+# lvcreate -L2G -nvartmp vgmirror
+# lvcreate -L2G -nopt vgmirror
+# lvcreate -L4G -nusr vgmirror
+# lvcreate -L2G -nvar vgmirror
+# lvcreate -L2G -nhome vgmirror
+# ls -l /dev/vgmirror
+# lvscan
+# mke2fs /dev/vgmirror/tmp
+# mke2fs /dev/vgmirror/vartmp
+# mke2fs -j /dev/vgmirror/opt
+# mke2fs -j /dev/vgmirror/usr
+# mke2fs -j /dev/vgmirror/var
+# mke2fs -j /dev/vgmirror/home
+# mkdir /mnt/gentoo/opt ; mount /dev/vgmirror/opt /mnt/gentoo/opt
+# mkdir /mnt/gentoo/usr ; mount /dev/vgmirror/usr /mnt/gentoo/usr
+# mkdir /mnt/gentoo/var ; mount /dev/vgmirror/var /mnt/gentoo/var
+# mkdir /mnt/gentoo/home ; mount /dev/vgmirror/home /mnt/gentoo/home
+# mkdir /mnt/gentoo/tmp ; mount /dev/vgmirror/tmp /mnt/gentoo/tmp
+# chmod 1777 /mnt/gentoo/tmp
+# mkdir /mnt/gentoo/var/tmp ; mount /dev/vgmirror/vartmp /mnt/gentoo/var/tmp
+# chmod 1777 /mnt/gentoo/var/tmp</code>
+
+Now we move into [Installation (chapter 5)](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=5) in the handbook. Verify your system date and then start extracting the tarballs.  Notice that the only stage available on the Universal CD is now <b>stage3</b>.
+
+<code># date
+# ls -l /mnt/cdrom/stages
+total 450586
+-rw-r--r--  1 root root 92520704 Aug  7 04:45 stage3-athlon-xp-2005.1.tar.bz2
+-rw-r--r--  1 root root 92413359 Aug  7 04:47 stage3-i686-2005.1.tar.bz2
+-rw-r--r--  1 root root 92122771 Aug  7 04:46 stage3-pentium3-2005.1.tar.bz2
+-rw-r--r--  1 root root 92475718 Aug  7 04:46 stage3-pentium4-2005.1.tar.bz2
+-rw-r--r--  1 root root 91866585 Aug  7 04:46 stage3-x86-2005.1.tar.bz2
+# cd /mnt/gentoo
+# tar -xvjpf /mnt/cdrom/stages/stage3-x86-2005.1.tar.bz2</code>
+
+That takes a while to uncompress.  Now we pickup with 5D (Installing Portage).  I'm going to use the portage snapshot on the CD-ROM.
+
+<code># cd /mnt/gentoo
+# ls -l /mnt/cdrom/snapshot
+# tar -xvjf /mnt/cdrom/snapshot/portage-2005.1.tar.bz2 -C /mnt/gentoo/usr</code>
+
+Before I configure the make.conf file, I should take a look at my system configuration.
+
+<code># cat /proc/version
+Linux version 2.6.12-gentoo-r6 (root@poseidon) (gcc version 3.3.5-20050130 (Gentoo 3.3.5.20050130-r1, ssp-3.3.5.20050130-1, pie-8.7.7.1)) #1 SMP Wed Aug 3 20:26:57 UTC 2005
+# cat /proc/cpuinfo
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 8
+model name      : Celeron (Coppermine)
+stepping        : 6
+cpu MHz         : 568.141
+cache size      : 128 KB
+fdiv_bug        : no
+hlt_bug         : no
+f00f_bug        : no
+coma_bug        : no
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 2
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 sep mtrr pge mca cmov pat pse36 mmx fxsr sse
+bogomips        : 1114.11
+# cat /proc/meminfo
+MemTotal:       320792 kB
+MemFree:          7600 kB
+Buffers:         57472 kB
+Cached:         180320 kB
+SwapCached:          4 kB
+Active:          29596 kB
+Inactive:       210948 kB
+HighTotal:           0 kB
+HighFree:            0 kB
+LowTotal:       320792 kB
+LowFree:          7600 kB
+SwapTotal:     2007992 kB
+SwapFree:      2000156 kB
+Dirty:               0 kB
+Writeback:           0 kB
+Mapped:           5144 kB
+Slab:            63636 kB
+CommitLimit:   2168388 kB
+Committed_AS:    15752 kB
+PageTables:        172 kB
+VmallocTotal:   704504 kB
+VmallocUsed:      6856 kB
+VmallocChunk:   696436 kB</code>
+
+Now to configure compile options (5E in the handbook).  Since we're using a stage3 installation, we'll need to be careful to not touch certain settings in the make.conf file.  I pretty much plan on using the defaults (except for optimizing for size due to the lower cache size in the Celeron and VIA CPUs, which is merely changing -O2 to -Os).  
+
+<code># nano -w /mnt/gentoo/etc/make.conf</code>
+
+Contents of my make.conf file:
+
+<code># These settings were set by the catalyst build script that automatically built this stage
+# Please consult /etc/make.conf.example for a more detailed example
+CFLAGS="-Os -mcpu=i686"
+CHOST="i386-pc-linux-gnu"
+CXXFLAGS="${CFLAGS}"
+MAKEOPTS="-j2"</code>
+
+Now to [Chapter 6 - Installing the Gentoo Base System](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=6).  Time to "chroot".
+
+<code># mirrorselect -i -o &gt;&gt; /mnt/gentoo/etc/make.conf
+# mirrorselect -i -r -o &gt;&gt; /mnt/gentoo/etc/make.conf
+# cat /mnt/gentoo/etc/make.conf
+CFLAGS="-Os -mcpu=i686"
+CHOST="i386-pc-linux-gnu"
+CXXFLAGS="${CFLAGS}"
+MAKEOPTS="-j2"
+
+GENTOO_MIRRORS="http://gentoo.osuosl.org/"
+SYNC="rsync://rsync.namerica.gentoo.org/gentoo-portage"</code>
+
+Looks good so far.
+
+<code># cp -L /etc/resolv.conf /mnt/gentoo/etc/resolv.conf
+# cp -L /etc/mdadm.conf /mnt/gentoo/etc/mdadm.conf
+(do the next 2 commands if you are using LVM2)
+# mkdir /mnt/gentoo/etc/lvm
+# cp -L /etc/lvm/lvm.conf /mnt/gentoo/etc/lvm/lvm.conf
+(end of optional LVM2 commands)
+# mount -t proc none /mnt/gentoo/proc
+# chroot /mnt/gentoo /bin/bash
+# env-update
+# source /etc/profile
+# emerge --sync</code>
+
+The sync will take a while to run (I generally plan on doing something else for a few hours).
+
+Time to choose a profile.  There shouldn't be much to do at this point since I plan on using the 2.6 kernel which is the default on the 2005.1 Gentoo CDs.
+
+<code># ls -FGg /etc/make.profile
+lrwxrwxrwx  1 48 Sep 21 10:22 /etc/make.profile -&gt; ../usr/portage/profiles/default-linux/x86/2005.1/
+# ls -d /usr/portage/profiles/default-linux/x86/2005.1/2.4
+/usr/portage/profiles/default-linux/x86/2005.1/2.4</code>
+
+Configuring the USE variable comes next in the handbook.  You'll see that I'm using a very aggressive set of USE flags that restrict a lot of options (since this is a headless server). You can see the [current list of USE flags](http://www.gentoo.org/dyn/use-index.xml) at the Gentoo.org site.  You can find the default set of USE flags via "cat /etc/make.profile/make.defaults".  The default listing in the 2005.1 profile is:
+
+<code>livecd / # ls -l /etc/make.profile
+lrwxrwxrwx  1 root root 48 Oct 22 21:04 /etc/make.profile -&gt; ../usr/portage/profiles/default-linux/x86/2005.1
+livecd / # cat /etc/make.profile/make.defaults
+# Copyright 1999-2005 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/profiles/default-linux/x86/2005.1/make.defaults,v 1.4 2005/08/29 22:20:25 wolf31o2 Exp $
+
+USE="alsa apm arts avi berkdb bitmap-fonts crypt cups eds emboss encode fortran foomaticdb gdbm gif gnome gpm gstreamer gtk gtk2 imlib ipv6 jpeg kde libg++ libwww mad mikmod motif mp3 mpeg ncurses nls ogg oggvorbis opengl oss pam pdflib perl png python qt quicktime readline sdl spell ssl tcpd truetype truetype-fonts type1-fonts vorbis X xml2 xmms xv zlib"
+livecd / # </code>
+
+Here are my current customized USE flags (for a headless server with no GUI shell).
+
+<code># less /usr/portage/profiles/use.desc
+# echo 'USE="apache2 kerberos ldap postgres samba -alsa -apm -arts -bitmap-fonts -gnome -gtk -gtk2 -kde -mad -mikmod -motif -opengl -oss -qt -quicktime -sdl -truetype -truetype-fonts -type1-fonts -X -xmms -xv"' &gt;&gt; /etc/make.conf
+# nano -w /etc/make.conf</code>
+
+The changes between this time and my last install are:
+
+Added: postgres samba
+Added: -alsa -arts -bitmap-fonts -gtk2 -mikmod -motif -truetype-fonts -type1-fonts -X
+Removed: -gif -jpeg -mpeg -oggvorbis -pdflib -png 
+
+Since I'm starting with a stage 3 tarball, I'm skipping directly to [7. Configuring the Kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7) in the handbook.
+
+<code># ls /usr/share/zoneinfo
+# ln -sf /usr/share/zoneinfo/EST5EDT /etc/localtime
+# date
+# zdump GMT
+# zdump EST5EDT</code>
+
+Pick your kernel using the [kernel guide](http://www.gentoo.org/doc/en/gentoo-kernel.xml).  Last year, I went with development-sources for the kernel in order to get 2.6. This is no longer necessary (and development-sources has been rolled into vanilla-sources). So I'm going to go with the default gentoo-sources.
+
+<code># emerge gentoo-sources
+# ls -l /usr/src</code>
+
+Next up is configuring the kernel, which I'll cover in another post.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[13:03](http://www.tgharold.com/techblog/2005/09/gentoo-20051-software-raid-part-1.shtml)
+
+		</div>

--- a/_posts/2005/2005-09-18-gentoo-emerge-sync-errors-during-installation.md
+++ b/_posts/2005/2005-09-18-gentoo-emerge-sync-errors-during-installation.md
@@ -1,0 +1,68 @@
+---
+layout: post
+title: 'Gentoo emerge sync errors during installation'
+date: '2005-09-18T12:50:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>So, I'm trying to install Gentoo 2005.1 on Software RAID and LVM2.  Everything seems to work up until I do my initial "emerge --sync".
+
+<code>livecd / # emerge --sync
+...
+app-benchmarks/bashmark/
+app-benchmarks/bashmark/files/
+app-benchmarks/httperf/
+app-benchmarks/httperf/files/
+app-benchmarks/iozone/
+app-benchmarks/iozone/files/
+app-benchmarks/jmeter/
+app-benchmarks/ltp/
+app-benchmarks/nbench/
+         986 100%    0.00kB/s    0:00:00
+app-accessibility/java-access-bridge/ChangeLog
+        2947 100%    0.00kB/s    0:00:00
+app-accessibility/java-access-bridge/Manifest
+         568 100%    0.00kB/s    0:00:00
+app-accessibility/java-access-bridge/files/digest-java-access-bridge-1.4.5-r1
+          77 100%    0.00kB/s    0:00:00
+app-accessibility/java-access-bridge/java-access-bridge-1.4.5-r1.ebuild
+        1250 100%    0.00kB/s    0:00:00
+app-accessibility/java-access-bridge/java-access-bridge-1.4.5.ebuild
+        1902 100%    0.00kB/s    0:00:00
+app-accessibility/mbrola/ChangeLog
+        3274 100%    0.00kB/s    0:00:00
+app-accessibility/mbrola/Manifest
+         616 100%    0.00kB/s    0:00:00
+mkstemp "/usr/portage/app-accessibility/mbrola/files/.digest-mbrola-3.0.1h-r1.S11U8n" failed: Input/output error
+         236 100%    0.00kB/s    0:00:00
+mkstemp "/usr/portage/app-accessibility/mbrola/files/.digest-mbrola-3.0.1h-r3.C8lndQ" failed: Read-only file system
+...</code>
+
+Plan A:
+
+Exit out of the chroot'd environment, umount the filesystem in question (/dev/vgmirror/usr).  I ran fsck against it and found numerous errors, so I just went and re-formatted.  Then re-mounted everything and started over with Chapter 5 (extraction of stages and onward).
+
+Same issues
+
+Plan B:
+
+Don't use LVM2 during the initial installation.  My guess is that there's something not quite right on the 2005.1 boot CD for Gentoo.  So far it seems to be working, at least I'm hoping that I can get a system up and running before trying to get LVM2 up and running.
+
+Plan C:
+
+Use smaller disks.  I did some more digging and the Gigabyte motherboard almost certainly does not support 48bit LBA drives (larger then 136GB).  In fact, the Promise FastTrak66 card certainly does not but I was misled by the fact that DBaN (drive wipe software) showed me the full 160GB of the disks.  I'm running some tests now to see whether DBaN will pickup this sort of issue if you run it in verify mode.
+
+I have (3) 120GB disks on order and will be dropping them into this system when they arrive.  That will take care of the issue and still allow me to put this older hardware into use.
+
+Update #1: DBaN is reporting errors on the (2) 160GB disks attached to the Promise FastTrak66 card, but not for the drive connected directly to the motherboard.  (Method: PRNG Stream, Verify: All Passes)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[12:50](http://www.tgharold.com/techblog/2005/09/gentoo-emerge-sync-errors-during.shtml)
+
+		</div>

--- a/_posts/2005/2005-09-21-gentoo-20051-software-raid-part-2-via-epia-me6000.md
+++ b/_posts/2005/2005-09-21-gentoo-20051-software-raid-part-2-via-epia-me6000.md
@@ -1,0 +1,74 @@
+---
+layout: post
+title: 'Gentoo 2005.1 Software RAID (part 2) VIA EPIA ME6000'
+date: '2005-09-21T12:44:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Time to [configure the Gentoo kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  I'm configuring this for my VIA EPIA ME6000 motherboard.  (Notice that I'm now including the LVM2 components as part of my base installation.)
+
+<code># emerge mdadm
+# emerge lvm2
+# cd /usr/src/linux
+# make menuconfig</code>
+
+Linux Kernel v2.6.11 Configuration
+(C)ode maturity level options
+(G)eneral setup
+--&gt; (C)onfigure standard kernel features for small systems (turn ON)
+--&gt; --&gt; (O)ptimize for size (turn ON)
+(L)oadable module support
+(P)rocessor type and features
+--&gt; (P)rocessor family (changed to "CyrixIII/VIA-C3")
+--&gt; (S)ymetric multi-processing support (turned this one OFF)
+--&gt; M(a)chine Check Exception (turned this OFF)
+(P)ower management options (ACPI, APM)
+(B)us options (PCI, PCMCIA, EISA&lt; MCA, ISA)
+(E)xecutable file formats
+(D)evice drivers
+--&gt; (P)arallel port support (turned OFF)
+--&gt; (A)TA/ATAPI/MFM/RLL support 
+--&gt; --&gt; (V)IA82CXXX chipset support (turned ON)
+--&gt; M(u)lti-device support (turn it ON)
+--&gt; --&gt; (R)AID support (turn it ON as BUILT-IN)
+--&gt; --&gt; --&gt; (R)AID-1 mirroring mode (turn it ON as BUILT-IN)
+--&gt; --&gt; (D)evice mapper support (set to MODULE, per section 13 of LVM2 guide)
+--&gt; N(e)tworking support 
+--&gt; --&gt; (E)thernet (10 or 100Mbit)
+--&gt; --&gt; --&gt; (R)ealTek RTL-8139 PCI Fast Ethernet (turn it OFF)
+--&gt; --&gt; --&gt; (V)IA Rhine support (turn it ON)
+--&gt; --&gt; --&gt; --&gt; (U)se MMIO instead of PIO (turn it ON)
+
+--&gt; (C)haracter Devices
+--&gt; --&gt; (I)ntel/AMD/VIA HW Random Number Generator (turn ON as BUILT-IN)
+--&gt; --&gt; (I)ntel 440LX/BX/GX, I8xx and E7x05 chipset support (turn it OFF)
+--&gt; --&gt; (V)IA chipset support (turn ON)
+--&gt; (S)ound
+--&gt; --&gt; (S)ound card support (turn OFF)
+(F)ile systems
+--&gt; N(e)twork File Systems
+--&gt; --&gt; (S)MB file system support (turn ON as BUILT-IN)
+--&gt; --&gt; (C)IFS support (turn ON as BUILT-IN)
+(P)rofiling support
+(K)ernel hacking
+(S)ecurity options
+(C)ryptographic options
+--&gt; (C)ryptographic API (turn ON)
+--&gt; --&gt; HM(A)C support (NEW) (turn ON as BUILT-IN)
+--&gt; --&gt; (turn ON all other options as MODULE)
+(L)ibrary routines
+
+Exit and save your configuration. Then build the kernel (the following command is for 2.6 kernels). Expect the compile to take about an hour.
+
+<code># make &amp;&amp; make modules_install</code><div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[12:44](http://www.tgharold.com/techblog/2005/09/gentoo-20051-software-raid-part-2-via.shtml)
+
+		</div>

--- a/_posts/2005/2005-09-22-gentoo-20051-software-raid-part-2-celeron-cpu.md
+++ b/_posts/2005/2005-09-22-gentoo-20051-software-raid-part-2-celeron-cpu.md
@@ -1,0 +1,76 @@
+---
+layout: post
+title: 'Gentoo 2005.1 Software RAID (part 2) Celeron CPU'
+date: '2005-09-22T23:31:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Time to [configure the Gentoo kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  I'm configuring this for my Celeron motherboard.
+
+Note the use of "emerge lvm2" since I'm using LVM2 on this system during the initial installation.
+
+<code># emerge mdadm
+# emerge lvm2
+# cd /usr/src/linux
+# make menuconfig</code>
+
+Linux Kernel v2.6.11 Configuration
+(C)ode maturity level options
+(G)eneral setup
+--&gt; (C)onfigure standard kernel features for small systems (turn ON)
+--&gt; --&gt; (O)ptimize for size (turn ON)
+(L)oadable module support
+(P)rocessor type and features
+--&gt; (P)rocessor family (changed to "Pentium-III...")
+--&gt; (S)ymetric multi-processing support (turned this one OFF)
+--&gt; M(a)chine Check Exception (turned this OFF)
+(P)ower management options (ACPI, APM)
+(B)us options (PCI, PCMCIA, EISA&lt; MCA, ISA)
+(E)xecutable file formats
+(D)evice drivers
+--&gt; (A)TA/ATAPI/MFM/RLL support
+--&gt; --&gt; (P)ROMISE PDC202{46|62|65|67} support (turn ON)
+--&gt; N(e)tworking support
+--&gt; --&gt; N(e)twork device support (should already be BUILT-IN)
+--&gt; --&gt; --&gt; (E)thernet (10 or 100Mbit)
+--&gt; --&gt; --&gt; --&gt; (T)ulip family network device support
+--&gt; --&gt; --&gt; --&gt; --&gt; "(T)ulip" family network device support (turn ON as BUILT-IN)
+--&gt; --&gt; --&gt; --&gt; --&gt; --&gt; (D)ECchip Tulip (dc2114x) PCI support (turn ON as BUILT-IN)
+--&gt; --&gt; --&gt; --&gt; --&gt; --&gt; --&gt; (I left the sub-options alone)
+--&gt; --&gt; --&gt; --&gt; (E)ISA, VLB, PCI and on board controllers (turn OFF)
+--&gt; (P)arallel port support (turned OFF)
+--&gt; M(u)lti-device support (turn it ON)
+--&gt; --&gt; (R)AID support (turn it ON as BUILT-IN)
+--&gt; --&gt; --&gt; (R)AID-1 mirroring mode (turn it ON as BUILT-IN)
+--&gt; --&gt; (D)evice mapper support (set to MODULE, per section 13 of LVM2 guide)
+--&gt; (C)haracter Devices
+--&gt; --&gt; (I)ntel/AMD/VIA HW Random Number Generator (turn ON as BUILT-IN)
+--&gt; (S)ound
+--&gt; --&gt; (S)ound card support (turn OFF)
+(F)ile systems
+--&gt; N(e)twork File Systems
+--&gt; --&gt; (S)MB file system support (turn ON as BUILT-IN)
+--&gt; --&gt; (C)IFS support (turn ON as BUILT-IN)
+(P)rofiling support
+(K)ernel hacking
+(S)ecurity options
+(C)ryptographic options
+--&gt; (C)ryptographic API (turn ON)
+--&gt; --&gt; HM(A)C support (NEW) (turn ON as BUILT-IN)
+--&gt; --&gt; (turn ON all other options as MODULE)
+(L)ibrary routines
+
+Exit and save your configuration. Then build the kernel (the following command is for 2.6 kernels). Expect the compile to take about an hour.
+
+<code># make &amp;&amp; make modules_install</code><div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[23:31](http://www.tgharold.com/techblog/2005/09/gentoo-20051-software-raid-part-2.shtml)
+
+		</div>

--- a/_posts/2005/2005-09-22-gentoo-emerge-grub-error---cat-procmounts-no-such-file-or-directory.md
+++ b/_posts/2005/2005-09-22-gentoo-emerge-grub-error---cat-procmounts-no-such-file-or-directory.md
@@ -1,0 +1,65 @@
+---
+layout: post
+title: 'Gentoo: emerge grub error - cat: /proc/mounts: No such file or directory'
+date: '2005-09-22T20:49:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>During my initial Gentoo installation, I ran into the following issue after trying to "emerge grub".
+
+<code>...
+&gt;&gt;&gt; Completed installing grub-0.96-r2 into /var/tmp/portage/grub-0.96-r2/image/
+
+&gt;&gt;&gt; Merging sys-boot/grub-0.96-r2 to /
+cat: /proc/mounts: No such file or directory
+cat: /proc/mounts: No such file or directory
+ * 
+ * Cannot automatically mount your /boot partition.
+ * Your boot partition has to be mounted rw before the installation
+ * can continue. grub needs to install important files there.
+ * 
+
+!!! ERROR: sys-boot/grub-0.96-r2 failed.
+!!! Function mount-boot_mount_boot_partition, Line 51, Exitcode 0
+!!! Please mount your /boot partition manually!
+!!! If you need support, post the topmost build error, NOT this status message.
+
+!!! FAILED preinst: 1
+livecd linux # grub
+bash: grub: command not found</code>
+
+[This thread over at Short-Media](http://www.short-media.com/forum/archive/index.php/t-15576.html) has exactly this error listed.  However, that thread went nowhere and the user was redirected to search over at the Gentoo.org forums.
+
+[emerge grub fails (Jun 2004)](http://forums.gentoo.org/viewtopic.php?t=187073)
+['emerge grub' fails (Jun 2004)](http://forums.gentoo.org/viewtopic.php?t=183830)
+[Grub wont compile. (Apr 2004)](http://forums.gentoo.org/viewtopic.php?t=165555)
+
+Most posters indicate that you must run the following command prior to entering the chroot environment.  
+
+<code>mount -t proc /proc /mnt/gentoo/proc </code>
+
+However, I can look back at my session logs and see that I already ran that particular command before entering the chroot.  Oh, wait... no I did not run that particular command. (This is where using a terminal program like SecureCRT comes in handy.)  This command should have been run just prior to entering the chroot environment.  ([See chapter 6 of the installation handbook.](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=6))
+
+The fix should be as simple as:
+
+<code>livecd linux # cat /proc/mounts
+cat: /proc/mounts: No such file or directory
+livecd linux # exit
+exit
+livecd gentoo # mount -t proc none /mnt/gentoo/proc
+livecd gentoo # chroot /mnt/gentoo /bin/bash
+livecd / # env-update
+&gt;&gt;&gt; Regenerating /etc/ld.so.cache...
+livecd / # source /etc/profile
+livecd / # emerge grub</code><div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[20:49](http://www.tgharold.com/techblog/2005/09/gentoo-emerge-grub-error-cat.shtml)
+
+		</div>

--- a/_posts/2005/2005-09-23-gentoo-20051-software-raid-part-3.md
+++ b/_posts/2005/2005-09-23-gentoo-20051-software-raid-part-3.md
@@ -1,0 +1,146 @@
+---
+layout: post
+title: 'Gentoo 2005.1 Software RAID (part 3)'
+date: '2005-09-23T16:18:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Picking up with part 7c after [compiling the kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  Now you need to install your kernel into the boot partition. Change the "2.6.12-Sep2005" portion of the filenames to whatever you want.
+
+<code># cp arch/i386/boot/bzImage /boot/kernel-2.6.12-Sep2005
+# cp System.map /boot/System.map-2.6.12-Sep2005
+# cp .config /boot/config-2.6.12-Sep2005</code>
+
+If you are using LVM2, you will need to add a line at the end of the autoload file to automatically load the LMV2 module.  Note that you may also need to add a line for DHCP support (not 100% sure about that).  Since I'm using these boxes for servers with static IPs I don't concern myself with it.
+
+<code># echo 'dm-mod' &gt;&gt; /etc/modules.autoload.d/kernel-2.6
+# cat /etc/modules.autoload.d/kernel-2.6</code>
+
+Time to configure the "/etc/fstab" file.  There are pages full of documentation on what goes in this file and the handbook covers some of it.  For my VIA EPIA box with only 3 partitions, my fstab file is going to be rather simple.
+
+<code># nano -w /etc/fstab
+
+/dev/md0 /boot ext2 noauto,noatime 1 2
+/dev/md2 / ext3 noatime 0 1
+/dev/md1 none swap sw 0 0
+/dev/cdroms/cdrom0 /mnt/cdrom auto noauto,ro,user 0 0
+
+#/dev/fd0 /mnt/floppy auto noauto 0 0
+
+proc /proc proc defaults 0 0
+
+shm /dev/shm tmpfs nodev,nosuid,noexec 0 0</code>
+
+For my Celeron box which is using LVM2 partitions, it's more complex.
+
+<code># nano -w /etc/fstab
+
+/dev/md0 /boot ext2 noauto,noatime 1 2
+/dev/md2 / ext3 noatime 0 1
+/dev/md1 none swap sw 0 0
+/dev/cdroms/cdrom0 /mnt/cdrom auto noauto,ro,user 0 0
+
+#/dev/fd0 /mnt/floppy auto noauto 0 0
+
+/dev/vgmirror/opt /opt ext3 noatime 0 3
+/dev/vgmirror/usr /usr ext3 noatime 0 3
+/dev/vgmirror/var /var ext3 noatime 0 3
+/dev/vgmirror/home /home ext3 noatime 0 3
+/dev/vgmirror/tmp /tmp ext2 noatime 0 3
+/dev/vgmirror/vartmp /var/tmp ext2 noatime 0 3 
+
+proc /proc proc defaults 0 0
+
+shm /dev/shm tmpfs nodev,nosuid,noexec 0 0</code>
+
+Now, some misc stuff (see [networking configuration](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=8#doc_chap2) for information on setting up DHCP or static IPs):
+
+<code># nano -w /etc/conf.d/hostname
+# nano -w /etc/conf.d/domainname
+# rc-update add domainname default
+# nano -w /etc/conf.d/net
+(either leave empty for DHCP or configure your IP and gateway)
+# rc-update add net.eth0 default
+# cat /etc/resolv.conf
+(verify your DNS servers if you specified a static IP)
+# nano -w /etc/conf.d/clock
+(change CLOCK="UTC" to CLOCK="local")
+# passwd
+(set your root password to something you will remember)
+
+# useradd -m -G users,wheel,audio -s /bin/bash john
+# passwd john
+(add a user called 'john' and set a password)</code>
+
+And a few other misc options (system logger, job scheduling):
+
+<code># emerge syslog-ng
+# rc-update add syslog-ng default
+# emerge dcron
+# rc-update add dcron default
+# crontab /etc/crontab</code>
+
+I also like to install the "sshd" service at this point so that I can ssh into the box after the initial reboot.  (These notes are based on a very old posting that I made about [installing sshd on Gentoo Linux](/techblog/2004_04_01_archive.shtml).)  Alternately, you can do these commands after booting the box for the first time by logging in as root at the console.
+
+<code># /usr/bin/ssh-keygen -t dsa -b 2048 -f /etc/ssh/ssh_host_dsa_key -N ""
+(the key may take a few minutes to generate)
+# chmod 600 /etc/ssh/ssh_host_dsa_key
+# chmod 644 /etc/ssh/ssh_host_dsa_key.pub
+# rc-update add sshd default</code>
+
+Now it's time to install and configure "grub" (the boot loader).  Note that where we are saying "/dev/hdc", you will need to change to match the name of your secondary mirror drive.
+
+<code># emerge grub</code>
+
+(Now, at this point, I got an error at the end of the emerge because I had failed to mount my /proc file system before entering the chroot environment.  The fix was easy, requiring me to exit the chroot environment, mount the /proc filesystem and then re-enter the chroot environment.)
+
+<code># ls -l /boot
+# nano -w /boot/grub/grub.conf</code>
+
+Contents of my grub.conf file:
+
+<code># Which listing to boot as default. 0 is the first, 1 the second etc.
+default 0
+timeout 30
+
+# Sep 2005 installation (software RAID, no LVM2)
+title=Gentoo Linux 2.6.12 (Sep 22 2005)  
+root (hd0,0)
+kernel /kernel-2.6.12-Sep2005 root=/dev/md2</code>
+
+Now I fire up grub and install it onto the MBR of both disks.
+
+<code># grub --no-floppy
+grub&gt; find /grub/stage1
+(hd0,0)
+(hd1,0)
+grub&gt; root (hd0,0)
+grub&gt; setup (hd0)
+grub&gt; device (hd0) /dev/hdc
+grub&gt; root (hd0,0)
+grub&gt; setup (hd0)
+grub&gt; quit</code>
+
+Time for the first reboot.  Now you need to unmount everything that you can (including LVM) prior to reboot.  Since I'm not using LVM2, this is rather simple.
+
+<code>livecd gentoo # exit
+livecd / # cd /
+livecd / # cat /proc/mounts
+(gives you a list of what is mounted)
+livecd / # umount /mnt/gentoo/boot
+livecd / # umount /mnt/gentoo/proc
+livecd / # umount /mnt/gentoo
+livecd / # reboot</code>
+
+Pull the CD-ROM at this point, otherwise the LiveCD will probably boot.  Then cross your fingers and watch the console for errors.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[16:18](http://www.tgharold.com/techblog/2005/09/gentoo-20051-software-raid-part-3.shtml)
+
+		</div>

--- a/_posts/2005/2005-10-05-ntbackup-to-a-disk-file.md
+++ b/_posts/2005/2005-10-05-ntbackup-to-a-disk-file.md
@@ -1,0 +1,62 @@
+---
+layout: post
+title: 'NTBackup to a disk file'
+date: '2005-10-05T19:36:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+<i>Note: This post may be incomplete...</i>
+
+Sometimes you have to start simple.  For us, after fighting with tape drives and tape drive software, we've switched back to using NTBACKUP that comes with Windows 2000 Server and Windows 2003 Server.  We've also given up on tape drives for the moment since our backup needs have drastically outstripped what the old tape drive is capable of.
+
+(Note to self:  If you're going to use a tape drive to backup your daily files.  Make sure you own (3+) drives of the same make/model that can read tapes from each other.  Make sure at least one of those drives is located at an alternate location and is tested weekly.  You may want to connect up with another local company who is also using the same technology, such as another company in the same building/town.)
+
+Our backup plan for data files has a few goals and is still a work in progress:
+
+1) Easy restoration when a user says "oops".  This means that we need an easy way to restore files that a user has screwed up or accidentally deleted.  Possibly even entire folder trees.  
+
+We handle this primarily through using "Shadow Copies" in Windows 2003 Server with a sizeable shadow cache setup on another drive within the server.  We have roughly 60GB of user data right now, and our cache is 25GB.  Shadows are created twice per day (7am and noon) on Monday-Friday and we're getting around 30 days of retention at the moment.
+
+Our secondary plan for dealing with "oops" issues is the weekly full NTBackup job that is written to a central file server.  We keep 2 sets of those weekly backups on that central server, giving us 7-14 days of "oops" protection.  In addition, since we're backing up to files, we don't have to go scrounging for tapes in order to do a quick file restore.  Daily appends also get written to those weekly snapshot folders.
+
+Our third, down-n-dirty method is a workstation that mirrors all changes to a local drive on a nightly basis.  This isn't very reliable and loses file attributes and security settings.  But it does serve as a last resort in cases where the two primary methods fail.
+
+2) The second goal is off-site storage of backups.  This is made easier by putting all of the weekly snapshots and daily updates onto a central server.  That allows us to collect the latest versions of the .BKF files and quickly move them to a removeable drive.  In addition, the speed of the removable drive matters less because it can be updated after the backup window.  The only issue you'll run into is that Windows has difficulty copying large files, so you will have to dig out the GNU Win32 tools (such as the "cp" command) in order to move these multi-gigabyte files around.
+
+So now for the gory details.  
+
+Our central backup server is called, appropriately enough, "Backup1" with a single share point called "Backups".  Under the backup folder, we have 2 subfolders, one for each week ("Weekly1" and "Weekly2").  This requires creating 2 backup jobs on each server that we want to backup, with the scheduling set to write to the appropriate folder during the proper week.  You could also do some scripting to determine which week to write to, but simpler is better for us.
+
+One trick is to store your backup specification file (.BKS) in a central location and use it for all data backups on that server.  You'll note that our backup specification file is called "Server2-DataFileBackupSpecification.bks" and gets used by all of the jobs on that server that are backing up user data.
+
+Here's our backup command for Week #1:
+
+C:\WINNT\system32\NTBACKUP.EXE backup "@D:\Data\NTBackup\Server2-DataFileBackupSpecification.bks" /n 
+"Server2-Weekly1Snapshot" /d "Server2-Weekly1Snapshot" /v:yes /r:no /rs:no /hc:off /m normal /j 
+"Server2-Weekly1Snapshot" /l:s /f "\\Domain1\Backups\Weekly1\Server2-WeeklySnapshot.bkf"
+
+And the command for Week #2: 
+
+C:\WINNT\system32\NTBACKUP.EXE backup "@D:\Data\NTBackup\Server2-DataFileBackupSpecification.bks" /n 
+"Server2-Weekly2Snapshot" /d "Server2-Weekly2Snapshot" /v:yes /r:no /rs:no /hc:off /m normal /j 
+"Server2-Weekly2Snapshot" /l:s /f "\\Domain1\Backups\Weekly2\Server2-WeeklySnapshot.bkf"
+
+Notice that the target filename is identical and the only difference is that you store it in the other folder.  This allows our offsite system to pull the latest file from <b>either</b> folder without any fancy tricks (other then comparing source/target timestamps).
+
+Microsoft reference links:
+[Windows 2003 Server - NTBackup Command](http://www.microsoft.com/technet/prodtechnol/windowsserver2003/library/ServerHelp/2b8c47c9-a769-46d2-9e26-f4d16f0261f8.mspx)
+[Windows XP - NTBackup Command](http://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/ntbackup_command.mspx)
+
+That takes care of the weekly snapshots (a full backup that also resets the archive bit).  For our daily updates, we need to set NTBackup to append to those files and only backup files that have changed since the snapshot was taken.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[19:36](http://www.tgharold.com/techblog/2005/10/ntbackup-to-disk-file.shtml)
+
+		</div>

--- a/_posts/2005/2005-10-17-imaging-a-tecra-8200-windows-2000-install-using-knoppix-ntfsclone-and-samba.md
+++ b/_posts/2005/2005-10-17-imaging-a-tecra-8200-windows-2000-install-using-knoppix-ntfsclone-and-samba.md
@@ -1,0 +1,118 @@
+---
+layout: post
+title: 'Imaging a Tecra 8200 Windows 2000 install using Knoppix, NTFSClone, and Samba'
+date: '2005-10-17T19:07:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>One of the more annoying things that our users do is to get their Windows workstations into an unworkable state after 9 months or so.  We've tried user education, we use things like spyware removers, eliminating the use of Internet Explorer, etc, but there are a lot of times where it's less time and trouble for us to reset the machine back to a known point.  Now, there are a few ways to do this such as paying for programs like Norton Ghost or Acronis True Image.  Both of those work but they cost $50/seat roughly.  But I'd like to do it for less.  Or at least take a shot at doing it for less.
+
+(I do use Acronis True Image on a few of my systems.  It's good for making more frequent snapshots without having to reboot to a seperate operating system.  It also has an incremental mode that can be used to keep a single image up to date.  For user simplicity, it's hands-down the winner over Ghost.)
+
+First off, you will need to download and burn the Knoppix Boot CD.  I'm using version 4.0.2 which hopefully has what I need (see this Slashdot comment, "[where is ntfsclone](http://linux.slashdot.org/comments.pl?sid=125853&amp;cid=10543386)", from Oct 2004).  The version that shows up on the 4.0.2 Knoppix CD is "ntfsclone v1.11.3-WIP" so I should be good to go.
+
+You should also browse the following links:
+
+[Linux NTFS Project](http://linux-ntfs.sourceforge.net/index.html)
+[Bahut:  Cloning XP with Linux and ntfsclone](http://milivoj2.blogspot.com/2005/04/cloning-xp-with-linux-and-ntfsclone.html)
+[Knoppix Rescue FAQ](http://www.knoppix.net/wiki/Rescue_FAQ)
+[Installing Ubuntu on Fujitsu ST 4000 Tablet PC](http://calkinsc.home.comcast.net/fujitsu_st_4000.html) (they used ntfsclone to backup the WinXP that was on the Tablet PC first)
+[ System Recovery with Knoppix](http://slashdot.org/article.pl?sid=04/10/15/2127244)
+
+The hardware that I'm backing up is a Toshiba Tecra 8200 with an 18GB HD that is not going to be very full.  At this point, I've finished installing all of the Windows 2000 patches along with some key tools, but it's still not 100% installed.  Still, it's a good spot to take a snapshot since everything that is installed is working fine.
+
+Steps:
+
+1. Make sure the system is connected to the network, or that there is a USB drive attached with a FAT32 file system.  You'll need a storage location where you can write the image file to.  A network folder is preferred so that you can write to an NTFS file system and avoid the 4GB limit of FAT32.
+
+2. Boot into Windows and perform last-minute housekeeping:
+
+a. Clear out any temporary folders/files.
+b. Move easily restored user files off of the system.
+c. Empty the trash folder.
+d. Do a CHKDSK of the file system (requires reboot)
+e. Defrag the hard drive.
+f. Verify connectivity
+
+Note for step "b.":  This image is not meant to be a frequent backup of user files.  There should be other tools in place for that (Second Copy 2000, rsync, tar/bzip2).  By pulling easily restored user files off of the hard drive, you'll make the image file much smaller and easier to manage.  Plus, during a restoration, you'll be overwriting user files in the image with newer user files from the most recent backup anyway.
+
+3. Boot to the Knoppix CD.  On the Tecra 8200 you are required to press the [F2] key during the bootup sequence, which will present you with a list of boot sources.  You can then press [C] for CD-ROM.  On other systems, you may need to muck with the boot order in the BIOS so that the CD-ROM comes before the hard drive.  
+
+I will assume that Knoppix boots properly on your system and that you end up at the Knoppix desktop.
+
+4a. If you are going to connect to a network shared folder to store the image file, then look for the penguin icon on the bar at the bottom of the screen labeled "KNOPPIX".  Open this menu, go to "Utilities" and then "Samba Network Neighborhood".  If Samba (SMB) is working properly, then you should see your local Windows domain and you can browse to your network share.
+
+4b. If you are going to connect to a USB drive for storage of the image, then look for (FIXME).
+
+5.  Fire up the command line.  To do this in Knoppix, go back to the "KNOPPIX" (penguin) icon and click on the "Root Shell" option.  You will see a terminal window open up with a prompt that looks like:
+
+<code>root@1[knoppix]#</code>
+
+6. Familiarize yourself with the partitions on the system:
+
+<code>root@1[knoppix]# cat /proc/partitions
+major minor  #blocks  name
+   3     0   19535040 hda
+   3     1   19535008 hda1
+   8     0   60051600 sda
+   8     1   32764536 sda1
+ 240     0    1942016 cloop0
+root@1[knoppix]# </code>
+
+The above listing shows that there is a ~18GB hard drive installed (hda) with a single partition (hda1) that fills most of the drive.  This drive (hda) is what we plan on backing up, if your system uses a different drive letter for the operating system drive, then you will need to adjust later commands.  Most ATA/IDE disk drives used for booting Windows are labeled as "hda".  You will generally only see "sda" used as the boot drive on systems that boot from SCSI drives.
+
+Notice that there is also a 60GB USB drive attached (sda) with a single 32GB partition (sda1).  If I want, I could mount this 32GB FAT32 partition as my destination media to the /tmp/imagedest mount point (see step 7b).
+
+7a. Create a mount point (/tmp/imagedest) and mount the Samba network share that you browsed to earlier.  Note the name as shown in the Konqueror browse window (smb://DOMAIN\account@servername/foldername).  This is typically case-sensitive, so you'll need to pay close attention to that.  Or you could mount the USB drive at this location.
+
+<code>root@1[knoppix]# mkdir /tmp/imagedest
+root@1[knoppix]# mount -t smbfs -o username=DOMAIN\\account //servername/foldername /tmp/imagedest
+Password: ******
+root@1[knoppix]#</code>
+
+Notes:
+- You'll need a double-backslash between your domain name and your account name in the Windows domain.
+- Domain names in Samba are almost always all upper-case.
+- Account names are almost always all lower-case.
+- Samba is picky about case.
+- You will be prompted for your password.
+- The <b>mount</b> command does not give feedback.  You can check that there is now a new mount point by repeating the <b>mount</b> command without any arguments.
+
+7b. (FIXME) Show how to mount the USB as the target point.
+
+8. Save the partition table and the master boot record (MBR).
+
+<b>Warning: VERIFY your commands before using them.</b>  It's very easy to blow away your operating system by accident when using the following tools.
+
+<code>root@1[knoppix]# sfdisk -d /dev/hda &gt; /tmp/imagedest/myuser-hda.dump
+root@1[knoppix]# dd if=/dev/hda bs=512 count=1 of=/tmp/imagedest/myuser-hda.mbr
+1+0 records in
+1+0 records out
+512 bytes transferred in 0.426934 seconds (1199 bytes/sec)
+root@1[knoppix]#</code>
+
+Notes:
+- I'd recommend replacing "myuser" in the output filenames with a minimum of the date, the model/make of the system being imaged, and possibly the username associated with the system.
+
+9. Use <b>ntfsclone</b> to backup the individual NTFS partitions.  Note that this only works for NTFS partitions and may have unpredictable effects if you try to backup a FAT16 or FAT32 partition.  You will need to repeat this command for each NTFS partition that you want to save.  Notice that we are breaking the image into 4000MB chunks to allow these chunks to be easily placed onto DVD media for archival.  You can use smaller chunk sizes if you run into other issues, but it makes it slightly more difficult later to reconstruct the image.
+
+<code>root@1[knoppix]# ntfsclone -s -o - /dev/hda1 | gzip | split -b 1000m - /tmp/imagedest/myuser-diskimage-hda1.img.gz_
+root@1[knoppix]#</code>
+
+Notes:
+- There are two places in the command where a "-" appears by itself.  These are critical as they tell <b>ntfsclone</b> to pipe to standard output ("-o -") and that the <b>split</b> command should pull from standard input ("-" by itself).
+- You'll probably want to use the underscore ("_") on the end of the image filename so that split adds the 2-letter suffix (aa, ab, ac, etc) in a way that is not confusing.
+- Note, I also hit the 2GB limit (even though I was writing to a share on an NTFS volume).  So I went ahead and backed off to 1GB splits.
+
+(FIXME) (to be continued)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[19:07](http://www.tgharold.com/techblog/2005/10/imaging-tecra-8200-windows-2000.shtml)
+
+		</div>

--- a/_posts/2005/2005-10-20-gentoo-eth0-does-not-exist.md
+++ b/_posts/2005/2005-10-20-gentoo-eth0-does-not-exist.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title: 'Gentoo: eth0 does not exist'
+date: '2005-10-20T14:17:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>So, oops.  When I built my Celeron box, I didn't include the driver for my Netgear FA310TX Rev-D1 in the kernel build.  The Universal CD automatically detects the network card properly, now I just need to get it configured into my kernel build (using "make menuconfig").  The Universal CD (2005.1) detected and configured it using the Tulip driver (Lite-On 82c168).
+
+So I know it works, I just don't have it right and proper.  My original build for this kernel is:
+
+[Gentoo 2005.1 Software RAID (part 2) Celeron CPU](/techblog/2005/09/gentoo-20051-software-raid-part-2.shtml)
+
+During that build, I didn't touch network devices at all. It had automatically selected the RealTek network device driver under the EISA option. 
+
+<code># cd /usr/src/linux
+# make menuconfig</code>
+
+(D)evice drivers
+--&gt; N(e)tworking support
+--&gt; --&gt; N(e)twork device support (should already be BUILT-IN)
+--&gt; --&gt; --&gt; (E)thernet (10 or 100Mbit)
+--&gt; --&gt; --&gt; --&gt; (T)ulip family network device support
+--&gt; --&gt; --&gt; --&gt; --&gt; "(T)ulip" family network device support (turn ON as BUILT-IN)
+--&gt; --&gt; --&gt; --&gt; --&gt; --&gt; (D)ECchip Tulip (dc2114x) PCI support (turn ON as BUILT-IN)
+--&gt; --&gt; --&gt; --&gt; --&gt; --&gt; --&gt; (I left the sub-options alone)
+--&gt; --&gt; --&gt; --&gt; (E)ISA, VLB, PCI and on board controllers (turn OFF)
+
+Now, make sure that /boot is mounted, then compile your new kernel.
+
+<code># make &amp;&amp; make modules_install
+# cp arch/i386/boot/bzImage /boot/kernel-2.6.12-Oct2005
+# cp System.map /boot/System.map-2.6.12-Oct2005
+# cp .config /boot/config-2.6.12-Oct2005
+# nano -w /boot/grub/grub.conf</code>
+
+Contents of my grub.conf file:
+
+<code># Which listing to boot as default. 0 is the first, 1 the second etc.
+default 0
+timeout 30
+
+# Oct 2005 recompile kernel to add Netgear FA310TX rev D1
+title=Gentoo Linux 2.6.12 (Oct 20 2005)
+root (hd0,0)
+kernel /kernel-2.6.12-Oct2005 root=/dev/md2
+
+# Sep 2005 installation (software RAID, no LVM2)
+title=Gentoo Linux 2.6.12 (Sep 22 2005)
+root (hd0,0)
+kernel /kernel-2.6.12-Sep2005 root=/dev/md2</code>
+
+Not technically difficult, if you can find out what device driver to  use.  Which, is why I try to document as much of this stuff as possible.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[14:17](http://www.tgharold.com/techblog/2005/10/gentoo-eth0-does-not-exist.shtml)
+
+		</div>

--- a/_posts/2005/2005-10-22-unixlunix-filesystem-hierarchy-standard.md
+++ b/_posts/2005/2005-10-22-unixlunix-filesystem-hierarchy-standard.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: 'Unix/Lunix Filesystem Hierarchy Standard'
+date: '2005-10-22T10:09:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>The [Filesystem Hierarchy Standard](http://www.pathname.com/fhs/) is a set of guidelines designed to get various distrobutions of Linux/Unix all on the same page with regards to what goes where in the file system.
+
+For us laymen, it's a decent guide to what is where in the filesystem (why is there a /sbin and a /usr/local/sbin?).  It helps answer questions like, "If I have a backup script, where should I put the file?".<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[10:09](http://www.tgharold.com/techblog/2005/10/unixlunix-filesystem-hierarchy.shtml)
+
+		</div>

--- a/_posts/2005/2005-10-24-gentoo-emerge-samba-fails-while-compiling-rpctorturec.md
+++ b/_posts/2005/2005-10-24-gentoo-emerge-samba-fails-while-compiling-rpctorturec.md
@@ -1,0 +1,182 @@
+---
+layout: post
+title: 'Gentoo: emerge samba fails while compiling rpctorture.c'
+date: '2005-10-24T12:59:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Got the following error while trying to emerge samba into my Gentoo box.
+
+<code>Compiling torture/rpctorture.c
+make: *** Waiting for unfinished jobs....
+torture/rpctorture.c:27: error: `global_myname' redeclared as different kind of symbol
+include/proto.h:1019: error: previous declaration of `global_myname'
+torture/rpctorture.c:57: warning: `struct client_info' declared inside parameter list
+torture/rpctorture.c:57: warning: its scope is only this definition or declaration, which is probably not what you want
+torture/rpctorture.c: In function `rpcclient_connect':
+torture/rpctorture.c:62: error: dereferencing pointer to incomplete type
+torture/rpctorture.c:62: error: dereferencing pointer to incomplete type
+torture/rpctorture.c:63: error: dereferencing pointer to incomplete type
+torture/rpctorture.c:66: error: dereferencing pointer to incomplete type
+torture/rpctorture.c:66: error: dereferencing pointer to incomplete type
+torture/rpctorture.c:68: error: dereferencing pointer to incomplete type
+torture/rpctorture.c:68: error: dereferencing pointer to incomplete type
+torture/rpctorture.c: At top level:
+torture/rpctorture.c:90: warning: `struct client_info' declared inside parameter list
+torture/rpctorture.c: In function `run_enums_test':
+torture/rpctorture.c:96: warning: passing arg 1 of `rpcclient_connect' from incompatible pointer type
+torture/rpctorture.c:102: error: dereferencing pointer to incomplete type
+torture/rpctorture.c:102: error: dereferencing pointer to incomplete type
+torture/rpctorture.c: At top level:
+torture/rpctorture.c:134: warning: `struct client_info' declared inside parameter list
+torture/rpctorture.c: In function `run_ntlogin_test':
+torture/rpctorture.c:140: warning: passing arg 1 of `rpcclient_connect' from incompatible pointer type
+torture/rpctorture.c:146: error: dereferencing pointer to incomplete type
+torture/rpctorture.c:146: error: dereferencing pointer to incomplete type
+torture/rpctorture.c: At top level:
+torture/rpctorture.c:167: warning: `struct client_info' declared inside parameter list
+torture/rpctorture.c: In function `main':
+torture/rpctorture.c:233: error: storage size of `cli_info' isn't known
+torture/rpctorture.c:377: error: `scope' undeclared (first use in this function)
+torture/rpctorture.c:377: error: (Each undeclared identifier is reported only once
+torture/rpctorture.c:377: error: for each function it appears in.)
+torture/rpctorture.c:535: warning: passing arg 5 of `create_procs' from incompatible pointer type
+torture/rpctorture.c:539: warning: passing arg 5 of `create_procs' from incompatible pointer type
+make: *** [torture/rpctorture.o] Error 1
+ * rpctorture didn't build
+running build
+running build_py
+running build_ext
+--------------------------- ACCESS VIOLATION SUMMARY ---------------------------
+LOG FILE = "/var/log/sandbox/sandbox-net-fs_-_samba-3.0.14a-r2-21241.log"
+
+access_wr: /etc/krb5.conf
+--------------------------------------------------------------------------------
+# </code>
+
+Here are my current USE flags:
+
+<code># cat /etc/make.conf
+
+# These settings were set by the catalyst build script that automatically built this stage
+# Please consult /etc/make.conf.example for a more detailed example
+CFLAGS="-Os -mcpu=i686"
+CHOST="i386-pc-linux-gnu"
+CXXFLAGS="${CFLAGS}"
+MAKEOPTS="-j2"
+
+GENTOO_MIRRORS="http://gentoo.osuosl.org/"
+SYNC="rsync://rsync.namerica.gentoo.org/gentoo-portage"
+
+USE="apache2 kerberos ldap postgres samba -alsa -apm -arts -bitmap-fonts -gnome -gtk -gtk2 -kde -mad -mikmod -motif -opengl -oss -qt -quicktime -sdl -truetype -truetype-fonts -type1-fonts -X -xmms -xv"
+
+# cat /etc/make.profile/make.defaults
+
+# Copyright 1999-2005 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/profiles/default-linux/x86/2005.1/make.defaults,v 1.4 2005/08/29 22:20:25 wolf31o2 Exp $
+
+USE="alsa apm arts avi berkdb bitmap-fonts crypt cups eds emboss encode fortran foomaticdb gdbm gif gnome gpm gstreamer gtk gtk2 imlib ipv6 jpeg kde libg++ libwww mad mikmod motif mp3 mpeg ncurses nls ogg oggvorbis opengl oss pam pdflib perl png python qt quicktime readline sdl spell ssl tcpd truetype truetype-fonts type1-fonts vorbis X xml2 xmms xv zlib"
+#</code>
+
+I'm still searching for a solution to this issue.  I've heard it has to do with trying to use the kerberos USE flag (which is not an optional flag for me).  The closest possible solution in Google is on the Gentoo forums ([Problems upgrading to Samba 3.0.14a-r2!](http://forums.gentoo.org/viewtopic-t-367341.html)).  The user, "jpnag", posts a solution.
+
+The solution involves editing the ebuild file for Samba.  This is where you will need to become a bit more knowledgeable about how portage and emerge works (see "<b>man make.conf</b>" for details on some of this along with "<b>man portage</b>").  
+
+By default, portage downloads and installs packages under the "/usr/portage/" tree (defined by "PORTDIR=" in your "/etc/make.conf" file or "/etc/make.profile/make.defaults" file).  There is also an optional define, "PORTDIR_OVERLAY=", which you can use to point at a tree containing user-built ebuild files that are not updated by "emerge --sync".  Essentially, the second tree will overlay the first.  So if you have "package X" in both trees, only the one in the overlay tree will get compiled.
+
+Now to create the backup copy of the broken Samba ebuild.  If you have not already added "PORTDIR_OVERLAY=" to your "make.conf" file, you should also do this.
+
+<code># cd /etc
+etc # echo 'PORTDIR_OVERLAY="/usr/local/portage"' &gt;&gt; /etc/make.conf
+etc # cd /usr/local
+local # ls /usr/portage/net-fs/samba/
+local # mkdir portage ; cd portage
+portage # mkdir net-fs ; cd net-fs
+net-fs # mkdir samba ; cd samba
+samba # cp -a /usr/portage/net-fs/samba/* .
+samba # ls -l samba-3.0.14a-r2.ebuild
+samba # nano -w samba-3.0.14a-r2.ebuild</code>
+
+Now hit [Ctrl-W] and type "src_compile", which will take you straight to the following code block:
+
+<pre>rc_compile() {
+        ebegin "Running autoconf"
+                autoconf
+        eend $?
+
+        local myconf
+        local mymods
+        local mylangs
+
+        if use xml || use xml2 ;
+        then   
+                mymods="xml,${mymods}"
+        fi</pre>
+
+Somewhere towards the start of the funciton, add the line "addpredict /etc/krb5.conf".
+
+<pre>src_compile() {
+        ebegin "Running autoconf"
+                autoconf
+        eend $?
+
+        local myconf
+        local mymods
+        local mylangs
+
+        addpredict /etc/krb5.conf
+
+        if use xml || use xml2 ;
+        then
+                mymods="xml,${mymods}"
+        fi</pre>
+
+Create the ebuild digest (MD5 signatures) for the patched package.
+
+<code>samba # ebuild /usr/local/portage/net-fs/samba/samba-3.0.14a-r2.ebuild digest 
+&gt;&gt;&gt; Generating digest file...
+&lt;&lt;&lt; samba-3.0.14a.tar.gz
+&lt;&lt;&lt; samba-vscan-0.3.6.tar.bz2
+&lt;&lt;&lt; samba-3-gentoo-0.3.3.tar.bz2
+&gt;&gt;&gt; Generating manifest file...
+&lt;&lt;&lt; ChangeLog
+&lt;&lt;&lt; metadata.xml
+&lt;&lt;&lt; samba-3.0.14a-r2.ebuild
+&lt;&lt;&lt; samba-3.0.14a-r3.ebuild
+&lt;&lt;&lt; samba-3.0.20-r1.ebuild
+&lt;&lt;&lt; samba-3.0.20a.ebuild
+&lt;&lt;&lt; samba-3.0.20b.ebuild
+&lt;&lt;&lt; files/digest-samba-3.0.14a-r2
+&lt;&lt;&lt; files/README.gentoo
+&lt;&lt;&lt; files/digest-samba-3.0.14a-r3
+&lt;&lt;&lt; files/digest-samba-3.0.20-r1
+&lt;&lt;&lt; files/digest-samba-3.0.20a
+&lt;&lt;&lt; files/digest-samba-3.0.20b
+&gt;&gt;&gt; Computed message digests.
+
+samba # emerge -pv samba
+
+These are the packages that I would merge, in order:
+
+Calculating dependencies ...done!
+[ebuild  N    ] net-fs/samba-3.0.14a-r2  -acl +cups -doc +kerberos +ldap -libclamav -mysql -oav +pam +postgres +python -quotas +readline (-selinux) -winbind -xml +xml2 0 kB [1] 
+
+Total size of downloads: 0 kB
+Portage overlays:
+ [1] /usr/local/portage
+
+samba # emerge samba</code>
+
+(crosses fingers)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Samba.shtml">Samba</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[12:59](http://www.tgharold.com/techblog/2005/10/gentoo-emerge-samba-fails-while.shtml)
+
+		</div>

--- a/_posts/2005/2005-10-26-misc-ssh-as-a-vpn-links.md
+++ b/_posts/2005/2005-10-26-misc-ssh-as-a-vpn-links.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: 'Misc SSH as a VPN links'
+date: '2005-10-26T21:21:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Just collecting some links that look interesting.  My plan is to use SSH as a VPN server and I'll need to figure out how Mac and Windows clients can connect in.
+
+[Using a Linux L2TP/IPsec VPN server](http://www.jacco2.dds.nl/networking/freeswan-l2tp.html)
+
+[arstechnica - teach me about ssh, vpn, allow remote connections](http://episteme.arstechnica.com/groupee/forums/a/tpc/f/469092836/m/530001375731)
+
+[about.com - VPN Setup](http://compnetworking.about.com/cs/vpnsetup/)
+
+[Q&amp;A on using the VPN service (www.doc.ic.ac.uk/csg/faqs/)](http://www.doc.ic.ac.uk/csg/faqs/vpn.html)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VPN.shtml">VPN</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[21:21](http://www.tgharold.com/techblog/2005/10/misc-ssh-as-vpn-links.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-01-random-gentoo-tools.md
+++ b/_posts/2005/2005-11-01-random-gentoo-tools.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: 'Random Gentoo Tools'
+date: '2005-11-01T21:05:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Things that might be useful to a system administrator and which don't come pre-installed on Gentoo.
+
+curl
+denyhosts
+fail2ban
+linkx
+lynx
+nload
+screen
+
+In order to install "denyhosts", you'll probably have to muck with application specific keywords.  See [USE flags (gentoo.org)](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=2&amp;chap=2) or [FAQ USE Flags (Gentoo Linux Wiki)](http://gentoo-wiki.com/FAQ_USE_Flags).  Look for information on editing the "/etc/portage/package.keywords" file.  The current version of denyhosts is tagged with "~x86" (indicating that it compiles, but has not been verified?).<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[21:05](http://www.tgharold.com/techblog/2005/11/random-gentoo-tools.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-04-gentoo-20051-on-athlon64-3200-and-asus-a8v-deluxe.md
+++ b/_posts/2005/2005-11-04-gentoo-20051-on-athlon64-3200-and-asus-a8v-deluxe.md
@@ -1,0 +1,92 @@
+---
+layout: post
+title: 'Gentoo 2005.1 on Athlon64 3200+ and Asus A8V Deluxe'
+date: '2005-11-04T18:24:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>So, I was going to rebuild my 1Ghz Athlon machine with 640MB, but in the process of transplating hard drives and installing a new (quieter) CPU fan, I seem to have put it down for the count.  Moderate annoyance only as it's an older motherboard and was nearing the end of its lifespan.  (I may try and troubleshoot it next week.)
+
+Instead, I replaced with an Asus A8V Deluxe (VIA chipset, BIOS version 08.00.09 05/19/05) motherboard with an Athlon64 3200+ and 2GB of RAM.  In addition, I have (8) 300GB hard drives hooked up to this unit.  The (2) RAID1 boot drives are 7200rpm (hooked to the primary IDE port and the 2nd one on the Promise FastTrak RAID port).  The other (6) drives are 5400rpm drives hooked up to a Promise SX6000 card.
+
+Now, I'm not sure that I can have both the onboard FastTrak and the SX6000 running at the same time.  (If not, I have a 1-port ATA/133 PCI HighPoint card that I can use for the 2nd boot drive.)
+
+Tossed the Gentoo 2005.1 boot CD in.  The graphical splash screen loads, and it starts counting through devices.  At "Booting the system (64%)", I get a kernel panic and it stops booting.  The screen now reads (approximately):
+
+<code>kernel BUG at &lt;bad filename&gt;:55433!
+Invalid operand: 0000 [#1]
+PREEMPT SMP
+Modules linked in: ...
+(bunch of registers)
+Process swapper (pid: 0 ...
+(trace dump)
+&lt;0&gt; Kernel panic - not syncing: Fatal exception in interrupt</code>
+
+Pressing [F2] does nothing at this point.
+
+Attempting to boot Knoppix 4.0.2 CD results in the boot CD hanging during device initialization.  But if I boot the Knoppix CD as "failsafe" it loads correctly.
+
+<b>Attempted fix #1:</b>
+
+Disable the onboard Promise FastTrak controller (since I have a Promise SX6000 installed in a PCI slot).  In past Windows systems (FastTrak66 and FastTrak100 cards), their documentation indicates that you should not have two FastTrak cards installed at the same time.  Whether this applies to a SuperTrak and FastTrak pairing, I'm unsure.
+
+Still got the error.  It's probably not the Promise cards.
+
+<b>Attempted fix #2:</b>
+
+Re-enable the Promise FastTrak controller (setting it as "IDE mode"), and check boot options on the Gentoo Universal LiveCD.  Since this is a single-core Athlon64, I'm going to try the NOSMP flag.  This involves intervening in the boot process when the LiveCD reaches the "boot:" prompt.  You can then type "<b>gentoo nosmp</b>" to boot the kernel without SMP support.
+
+No luck, system hangs when initializing the kernel (I'm wondering if NOSMP is even a boot option on the LiveCD).
+
+<b>Attempted fix #3:</b>
+
+Check for a newer version of the BIOS at [Asus Support](http://support.asus.com/default.aspx?SLanguage=en-us).  ([One person's experience with flashing an A8V](http://www.planetamd64.com/lofiversion/index.php/t11803.html).)
+
+No luck.  System still bombs out with a kernel error.
+
+<b>Attempted fix #4:</b>
+
+Downloaded the AMD64 version of the 2005.1 Universal LiveCD.  This still gives me a kernel bug, but it bombs out with a more descriptive error (rather then saying "bad filename".)  The kernel is bombing on "include/linux/i2o.h:517".
+
+One note indicates that it's a bug between the SX6000 card and the Linux kernel.  One suggestion indicates that you should go into the SX6000 BIOS (hitting Ctrl-F when prompted after it scans the arrays) and set the operating system type to "Other OS".  (Tried this, no luck.)
+
+Currently, I'm using 1.10 build 15 version of the BIOS (B77 from June 2002), and I see that there is a newer 1.20.0.27 from April 2004 on the Promise.com website.  So I'll go ahead and try patching up the Promise BIOS.  (Tried this as well, the SX6000 refuses to flash in this system.  I'm getting an error message while trying to usethe flash tool.  I'll try the card in another system and see if that works better.)
+
+<b>Attempted fix #5:</b>
+
+Ripped the SX6000 out.  I replaced it with (1) FastTrak133 TX2 PCI card and (3) HighPoint Rocket133 PCI cards.  I also converted one of the drives over to SATA, using the on-board SATA port.  (Think of this as a poor-man's setup.)  I had a bunch of the Rocket133 cards laying around, and the system doesn't seem to care that I have multiple cards installed.
+
+(My first attempt, used a pair of FastTrak133 TX2 PCI cards, but that caused the system to lockup when I went into the BIOS setup.)
+
+I'm currently running DBaN at the moment to test the configuration (PRNG mode, multiple passes, verifying all passes).  It identified 7 of the 8 drives (the onboard Promise RAID chip is unknown to this version of DBaN) and is writing to all 7 at the same time with no errors.  I'm getting 10MB/s to each drive with a load average of around 8.0.  Once I let that run for another hour or two, I'll switch back to trying the AMD64 Gentoo CD.
+
+Booted into the AMD64 Gentoo CD with zero issues.  My drives are:
+
+<code>livecd ~ # cat /proc/partitions
+major minor  #blocks  name
+
+   7     0      49712 loop0
+  33     0  292970160 hde
+  34     0  292970160 hdg
+  57     0  292970160 hdk
+  89     0  292970160 hdo
+  91     0  292970160 hds
+   3     0  293057352 hda
+   8     0  293057352 sda
+   8    16  199148544 sdb
+livecd ~ #</code>
+
+Basically, hda &amp; sda are my (2) 7200rpm 300GB drives that I'm going to use as my primary RAID1.  The sdb drive is my 200GB 7200rpm SATA which I plan on using for a scratch drive.  The rest of the drives (all ending in "160" blocks) are 5400rpm 300GB IDEs hooked to the Highpoint / Promise PCI cards.
+
+Now I can go ahead and build my system.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[18:24](http://www.tgharold.com/techblog/2005/11/gentoo-20051-on-athlon64-3200-and-asus.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-08-gentoo-20051-software-raid-part-2-amd64-on-asus-a8v.md
+++ b/_posts/2005/2005-11-08-gentoo-20051-software-raid-part-2-amd64-on-asus-a8v.md
@@ -1,0 +1,155 @@
+---
+layout: post
+title: 'Gentoo 2005.1 Software RAID (part 2) AMD64 on Asus A8V'
+date: '2005-11-08T17:06:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>This is a record of the kernel flags that I'm going to use for my AMD64 system.  It's an Asus A8V (K8T800Pro and VT8237) with an Athlon64 3200+ chip along with 2GB of RAM.  Hard drives are hooked up to the onboard Promise controller (PDC20378), the onboard SATA controller and the onboard IDE controller.  Plus the motherboard has an onboard gigabit ethernet NIC (Marvell 88E8001).
+
+In addition, I have even more hard drives hooked up to a Promise Ultra133 TX2 PCI card (PDC20269) and some HighPoint Rocket133SB PCI cards (HPT302).
+
+<code># emerge mdadm
+# emerge lvm2
+# cd /usr/src/linux
+# make menuconfig</code>
+
+Linux Kernel v2.6.13-gentoo-r5 Configuration
+(C)ode maturity level options
+(G)eneral setup
+(L)oadable module support
+(P)rocessor type and features
+--&gt; (P)rocessor family (changed to "AMD-Opteron/Athlon64")
+--&gt; (S)ymetric multi-processing support (turned this one OFF)
+(P)ower management options (ACPI, APM)
+(B)us options (PCI, etc.)
+(E)xecutable file formats
+(D)evice drivers
+--&gt; ATA/ATAPI/MFM/RLL support
+--&gt; --&gt; (g)eneric/default IDE chipset support (should already be ON)
+--&gt; (S)CSI device support
+--&gt; --&gt; (S)CSI generic support (turn this ON)
+--&gt; --&gt; (S)CSI low-level drivers
+--&gt; --&gt; --&gt; (S)erial ATA (SATA) support (should already be ON)
+--&gt; --&gt; --&gt; --&gt; (I)ntel PIIX/ICH SATA support (turn OFF)
+--&gt; --&gt; --&gt; --&gt; (P)romise SATA TX2/TX4 support (turn ON as BUILT-IN)
+--&gt; M(u)lti-device support (should already be ON)
+--&gt; --&gt; (R)AID support (turn it ON as BUILT-IN)
+--&gt; --&gt; --&gt; (R)AID-1 mirroring mode (turn it ON as BUILT-IN)
+--&gt; --&gt; (D)evice mapper support (set to MODULE or BUILT-IN)
+--&gt; N(e)tworking support
+--&gt; --&gt; (E)thernet (10 or 100Mbit)
+--&gt; --&gt; --&gt; (E)thernet (10 or 100Mbit) (Turn OFF)
+--&gt; --&gt; (E)thernet (1000Mbit)
+--&gt; --&gt; --&gt; (I)ntel(R) PRO/1000 Gigabit Ethernet support (turn OFF)
+--&gt; --&gt; --&gt; N(e)w SysKonnect GigaEthernet support (EXPERIMENTAL) (turn ON as BUILT-IN)
+--&gt; --&gt; --&gt; (B)roadcom Tigon3 support (turn OFF)
+--&gt; (C)haracter Devices
+--&gt; --&gt; (I)ntel/AMD/VIA HW Random Number Generator (should be ON)
+--&gt; --&gt; (I)ntel 440LX/BX/GX, I8xx and E7x05 chipset support (turn it OFF)
+--&gt; (S)ound
+--&gt; --&gt; (S)ound card support (turn OFF)
+(F)ile systems
+--&gt; N(e)twork File Systems
+--&gt; --&gt; (S)MB file system support (turn ON as BUILT-IN)
+--&gt; --&gt; (C)IFS support (turn ON as BUILT-IN)
+(P)rofiling support
+(K)ernel hacking
+(S)ecurity options
+(C)ryptographic options
+--&gt; (C)ryptographic API (turn ON)
+--&gt; --&gt; HM(A)C support (NEW) (turn ON as BUILT-IN)
+--&gt; --&gt; (turn ON all other options as MODULE)
+(L)ibrary routines
+
+Exit and save your configuration. Then build the kernel (the following command is for 2.6 kernels). Expect the compile to take almost no time at all on an AMD64 chip.  I used to wait an hour for all this to happen on my old VIA EPIA.
+
+<code># make &amp;&amp; make modules_install</code>
+
+Once the code finishes compiling, you need to copy the kernel to your /boot partition.
+
+<code># mount /boot
+# ls -l /boot
+# ls -l arch/x86_64/boot
+# df
+# cp arch/x86_64/boot/bzImage /boot/kernel-2.6.13-9Nov2005
+# cp System.map /boot/System.map-2.6.13-9Nov2005
+# cp .config /boot/config-2.6.13-9Nov2005
+# ls -l /boot
+# nano -w /boot/grub/grub.conf</code>
+
+Add your new kernel.  I'd recommend always leaving the configuration for your old kernel in place and inserting the new config above the old one.  That way you get (2) benefits:
+
+1) The "default 0" command will boot the new kernel automatically (because it appears first in the grub.conf file).
+
+2) Your old kernel is still in place, in case the new kernel doesn't boot.  There's probably no reason to remove old kernels from the system unless you are running out of space on the /boot partition.  (Which is why I use the "df" command to check space.)
+
+<b>Bugs and goofs</b>:
+
+1) The disks attached to the onboard Promise PDC20378 RAID controller are not recognized by my first kernel (although they show up when I booted the LiveCD).  So I'm missing a kernel option.  Possibly I haven't [turned SCSI on](http://www.gentoo-wiki.com/index.php?title=HARDWARE_SATA&amp;redirect=no) which allows me to pick the Promise SATA driver.
+
+This is fixed by adding:
+
+(D)evice drivers
+--&gt; (S)CSI device support
+--&gt; --&gt; (S)CSI low-level drivers
+--&gt; --&gt; --&gt; (S)erial ATA (SATA) support (should already be ON)
+--&gt; --&gt; --&gt; --&gt; (P)romise SATA TX2/TX4 support (turn ON as BUILT-IN)
+
+1b) However, once you've turned on that particular driver (CONFIG_SCSI_SATA_PROMISE=y), your system will slow down and become very sluggish anytime that mdadm is rebuilding an array with drives attached to that controller.  You will also start to see the following messages in your "dmesg" output:
+
+<code>warning: many lost ticks.
+Your time source seems to be instable or some driver is hogging interupts
+rip __do_softirq+0x48/0xb0</code>
+
+2) The disks attached to the PCI Rocket133 cards did not show up after the first boot.  Same deal as #1, worked with the LiveCD, but I didn't get the driver selection right when I built the first kernel.  On the upside, it allowed me to identify the (2) disks that are attached to the Promise PCI controller without any effort (hde and hdg are on the Promise card).
+
+(I'm still troubleshooting the Rocket133.)
+
+Key things to look for in menuconfig for Rocket133 might be:
+
+(D)evice drivers
+--&gt; ATA/ATAPI/MFM/RLL support                                                                     
+--&gt; --&gt; SCSI emulation support                                                                    
+--&gt; --&gt; generic/default IDE chipset support                                                       
+--&gt; --&gt; PCI IDE chipset support                                                                   
+--&gt; --&gt; Generic PCI IDE Chipset Support
+
+Probably the only one that matters is (CONFIG_BLK_DEV_HPT366=y):
+
+--&gt; --&gt; HPT36X/37X chipset support (turn this ON as BUILT-IN)
+
+Yes, the Rocket 133SB (Rocket133SB) HPT302 chip is apparently supported by the HPT366.c file.  You can find this by grepping the kernel sources:
+
+<code># cd /usr/src/linux
+# find . -print | xargs grep -i 'hpt302'
+# grep -i 'hpt366' .config</code>
+
+...
+
+So, after turning on the two drivers I have all 8 drives showing up against in /proc/partitions:
+
+hde / hdg -- Promise PCI card
+hdk, hdo, hds -- Highpoint Rocket133 cards
+hda -- motherboard IDE
+sda -- Promise motherboard RAID PATA
+sdb -- motherboard SATA
+
+Performance is still slow, so now I'm digging through the kernel configs trying to find lines that contain "irq".
+
+One key line that look interesting:
+
+Sharing PCI IDE interrupts support (CONFIG_IDEPCI_SHARE_IRQ)
+
+Turned that on, but still haven't fixed the sluggishness or the lost ticks issue.  I'm very tempted to give up on the PDC20378 chip, except that I know it worked on the LiveCD.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[17:06](http://www.tgharold.com/techblog/2005/11/gentoo-20051-software-raid-part-2.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-09-sluggish-linux-box-losing-some-ticks.md
+++ b/_posts/2005/2005-11-09-sluggish-linux-box-losing-some-ticks.md
@@ -1,0 +1,56 @@
+---
+layout: post
+title: 'Sluggish linux box (losing some ticks)'
+date: '2005-11-09T10:33:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Messages seen in my "# dmesg" output.
+
+<code>Losing some ticks... checking if CPU frequency changed.
+kjournald starting.  Commit interval 5 seconds
+EXT3 FS on dm-2, internal journal
+EXT3-fs: mounted filesystem with ordered data mode.
+kjournald starting.  Commit interval 5 seconds
+EXT3 FS on dm-3, internal journal
+EXT3-fs: mounted filesystem with ordered data mode.
+kjournald starting.  Commit interval 5 seconds
+EXT3 FS on dm-4, internal journal
+EXT3-fs: mounted filesystem with ordered data mode.
+kjournald starting.  Commit interval 5 seconds
+EXT3 FS on dm-5, internal journal
+EXT3-fs: mounted filesystem with ordered data mode.
+skge eth0: enabling interface
+skge eth0: Link is up at 1000 Mbps, full duplex, flow control tx and rx
+eth0: no IPv6 routers present
+warning: many lost ticks.
+Your time source seems to be instable or some driver is hogging interupts
+rip __do_softirq+0x48/0xb0</code>
+
+The system is very sluggish, even at the console.  In addition, the rebuild of my one mirror set is only proceeding at a sedate 3MB/s rather then 10-20MB/s.  Looking at "top -n1" shows CPU utilization issues.  Compare the first example here (a normal working system) with my trouble system (2nd example):
+
+Cpu(s):  0.2% us,  0.0% sy,  0.0% ni, 99.7% id,  0.0% wa,  0.0% hi,  0.0% si
+
+Cpu(s):  0.9% us, 39.8% sy,  0.0% ni,  6.0% id,  0.3% wa,  1.0% hi, 52.0% si
+
+Key (also see kernel_stat.h):
+us = user
+sy = system
+ni = nice
+id = idle (CPU not doing any work)
+wa = iowait (time spent waiting for IO to complete)
+hi = hardware interrupts (time spent within hardware interrupt handlers)
+si = softirq (time spent within other critical sections within the kernel)
+
+You can see the 40% "sy" (system) and 52% "si" (softirq) utilizations on the problem box, with only 6% idle.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[10:33](http://www.tgharold.com/techblog/2005/11/sluggish-linux-box-losing-some-ticks.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-12-sluggish-linux-box-troubleshooting-steps.md
+++ b/_posts/2005/2005-11-12-sluggish-linux-box-troubleshooting-steps.md
@@ -1,0 +1,137 @@
+---
+layout: post
+title: 'Sluggish linux box, troubleshooting steps'
+date: '2005-11-12T12:06:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Time to sit down and jot some things down so I can figure out which device/driver in my Gentoo AMD64 box is causing issues.  This gets a little complex because I have (5) 5400rpm 300GB PATA drives, (2) 7200rpm 300GB PATA drives and (1) 7200rpm 200GB SATA drive installed.
+
+Back when I finally booted into the AMD64 LiveCD, I got the following information from /proc/partitions:
+
+<code>livecd ~ # cat /proc/partitions
+major minor #blocks name
+
+7 0 49712 loop0
+33 0 292970160 hde - 300GB 5400rpm PATA (PDC20269)
+34 0 292970160 hdg - 300GB 5400rpm PATA (PDC20269)
+57 0 292970160 hdk - 300GB 5400rpm PATA (HPT302)
+89 0 292970160 hdo - 300GB 5400rpm PATA (HPT302)
+91 0 292970160 hds - 300GB 5400rpm PATA (HPT302)
+3 0 293057352 hda - 300GB 7200rpm PATA (motherboard primary IDE)
+8 0 293057352 sda - 300GB 7200rpm PATA (PDC20378 m/b)
+8 16 199148544 sdb - 200GB 7200rpm SATA (m/b SATA)
+livecd ~ #</code>
+
+Key:
+HPT302 = HighPoint Rocket133SB PCI cards (1 PATA port per card)
+PDC20269 = Promise Ultra133 TX2 PCI card (2 PATA ports)
+PDC20378 = Promise RAID controller on A8V motherboard
+
+So, that tells me that if I manage to get my kernel configured properly, I should be seeing all (8) drives with no sluggishness due to oddball drivers.  The question of the moment is how do I find out what configuration was used to build the Linux kernel on the LiveCD?  That, or I should look into attempting to use "genkernel" to create my settings semi-automatically.
+
+I found the kernel configuration for the LiveCD by booting the LiveCD and looking at the compressed file /proc/config.gz.  You can see the contents of this file by using the command:
+
+<code># cat /proc/config.gz | gzip -d | less</code>
+
+So I went and looked at the differences between my Nov 8th kernel (which works, except for support for the onboard Promise chip and the HPT302s) and my problematic Nov 9th kernel.
+
+<code>nogitsune linux # diff /boot/config-2.6.13-8Nov2005 /boot/config-2.6.13-9Nov2005
+4c4
+&lt; # Tue Nov  8 18:19:03 2005
+---
+&gt; # Wed Nov  9 05:13:43 2005
+416c416
+&lt; # CONFIG_CHR_DEV_SG is not set
+---
+&gt; CONFIG_CHR_DEV_SG=y
+456c456
+&lt; # CONFIG_SCSI_SATA_PROMISE is not set
+---
+&gt; CONFIG_SCSI_SATA_PROMISE=y
+nogitsune linux #</code>
+
+That's it.  Just two changes to the .config file.  So I'm currently undoing the "CONFIG_CHR_DEV_SG=y" line and leaving the Promise SATA line in.  I've recompiled and I'm getting ready to reboot to see if it recognizes the PATA disk connected to the PDC20378 chip on the motherboard.
+
+It did, but still didn't fix the issue of sluggishness.
+
+Useful steps to know about when booting off the LiveCD for my system.  I manually reassemble the RAID items and mount all of my LVM2 partitions.
+
+<code>livecd ~ # modprobe md
+livecd ~ # modprobe dm-mod
+livecd ~ # modprobe raid1
+livecd ~ # for i in 0 1 2 3; do mknod /dev/md$i b 9 $i; done
+livecd ~ # swapon /dev/md1
+swapon: /dev/md1: Invalid argument
+livecd ~ # mdadm --assemble /dev/md0 /dev/hda1 /dev/sda1
+mdadm: /dev/md0 has been started with 2 drives.
+livecd ~ # mdadm --assemble /dev/md1 /dev/hda2 /dev/sda2
+mdadm: /dev/md1 has been started with 2 drives.
+livecd ~ # mdadm --assemble /dev/md2 /dev/hda3 /dev/sda3
+mdadm: /dev/md2 has been started with 2 drives.
+livecd ~ # mdadm --assemble /dev/md3 /dev/hda4 /dev/sda4
+mdadm: /dev/md3 has been started with 1 drive (out of 2) and 1 spare.
+livecd ~ # swapon /dev/md1
+livecd ~ # mount /dev/md2 /mnt/gentoo
+livecd ~ # mount /dev/md0 /mnt/gentoo/boot
+livecd ~ # vgchange -ay vgmirror
+  6 logical volume(s) in volume group "vgmirror" now active
+livecd ~ # mount /dev/vgmirror/opt /mnt/gentoo/opt
+livecd ~ # mount /dev/vgmirror/usr /mnt/gentoo/usr
+livecd ~ # mount /dev/vgmirror/var /mnt/gentoo/var
+livecd ~ # mount /dev/vgmirror/home /mnt/gentoo/home
+livecd ~ # mount /dev/vgmirror/tmp /mnt/gentoo/tmp
+livecd ~ # chmod 1777 /mnt/gentoo/tmp
+livecd ~ # mount /dev/vgmirror/vartmp /mnt/gentoo/var/tmp
+livecd ~ # chmod 1777 /mnt/gentoo/var/tmp
+livecd ~ # mount -t proc none /mnt/gentoo/proc
+livecd ~ # chroot /mnt/gentoo /bin/bash
+livecd / # env-update
+&gt;&gt;&gt; Regenerating /etc/ld.so.cache...
+livecd / # source /etc/profile</code>
+
+Modules that get loaded on the 2005.1 AMD64 LiveCD on my system:
+
+<code>livecd linux # cat /proc/modules
+raid1 14720 4 - Live 0xffffffff880f9000
+md 36480 5 raid1, Live 0xffffffff880ef000
+ipv6 212928 10 - Live 0xffffffff880ba000
+floppy 52824 0 - Live 0xffffffff880ac000
+pcspkr 4056 0 - Live 0xffffffff880aa000
+skge 30224 0 - Live 0xffffffff880a1000
+dm_mod 39264 7 - Live 0xffffffff88096000
+ata_piix 7812 0 - Live 0xffffffff88093000
+ahci 9348 0 - Live 0xffffffff8808f000
+sata_qstor 8068 0 - Live 0xffffffff8808c000
+sata_vsc 6788 0 - Live 0xffffffff88089000
+sata_uli 6144 0 - Live 0xffffffff88086000
+sata_sis 5888 0 - Live 0xffffffff88083000
+sata_sx4 11396 0 - Live 0xffffffff8807f000
+sata_nv 7556 0 - Live 0xffffffff8807c000
+sata_via 7172 0 - Live 0xffffffff88079000
+sata_svw 6404 0 - Live 0xffffffff88076000
+sata_sil 7940 0 - Live 0xffffffff88073000
+sata_promise 9092 4 - Live 0xffffffff8806f000
+libata 30856 12 ata_piix,ahci,sata_qstor,sata_vsc,sata_uli,sata_sis,sata_sx4,sata_nv,sata_via,sata_svw,sata_sil,sata_promise, Live 0xffffffff88066000
+sbp2 19080 0 - Live 0xffffffff88060000
+ohci1394 27596 0 - Live 0xffffffff88058000
+ieee1394 63096 2 sbp2,ohci1394, Live 0xffffffff88047000
+sl811_hcd 11392 0 - Live 0xffffffff88043000
+ohci_hcd 17156 0 - Live 0xffffffff8803d000
+uhci_hcd 26528 0 - Live 0xffffffff88035000
+usb_storage 55616 0 - Live 0xffffffff88026000
+usbhid 27680 0 - Live 0xffffffff8801e000
+ehci_hcd 25864 0 - Live 0xffffffff88016000
+usbcore 86008 7 sl811_hcd,ohci_hcd,uhci_hcd,usb_storage,usbhid,ehci_hcd, Live 0xffffffff88000000
+livecd linux #</code><div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[12:06](http://www.tgharold.com/techblog/2005/11/sluggish-linux-box-troubleshooting.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-13-amd64-broken-kernel-config-file.md
+++ b/_posts/2005/2005-11-13-amd64-broken-kernel-config-file.md
@@ -1,0 +1,1522 @@
+---
+layout: post
+title: 'AMD64 broken kernel config file'
+date: '2005-11-13T20:25:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Current broken configuration.  Here is the diff between my current configuration and what was on the LiveCD.  Left side is the LiveCD config file, right side is my kernel's config file.
+
+[AMD64 2005.1 Gentoo LiveCD Kernel Config](/techblog/Gentoo/AMD64/2005_1-LiveCDConfig.txt)
+
+I'm still trying to puzzle out what is different on the LiveCD (which works, and which options are causing me grief on the installed kernel).  I've even tried adding the "noapic notsc" to my kernel line in grub.conf, but it doesn't fix the issue of sluggishness (it just hides the error).
+
+3,4c3,4
+&lt; # Linux kernel version: 2.6.12-gentoo-r6
+&lt; # Mon Aug  1 14:21:03 2005
+---
+&gt; # Linux kernel version: 2.6.13-gentoo-r5
+&gt; # Sun Nov 13 14:44:42 2005
+22c22
+&lt; CONFIG_LOCK_KERNEL=y
+---
+&gt; CONFIG_BROKEN_ON_SMP=y
+31c31
+&lt; # CONFIG_POSIX_MQUEUE is not set
+---
+&gt; CONFIG_POSIX_MQUEUE=y
+35c35
+&lt; CONFIG_HOTPLUG=y
+---
+&gt; # CONFIG_HOTPLUG is not set
+39,41c39,42
+&lt; CONFIG_CPUSETS=y
+&lt; CONFIG_EMBEDDED=y
+&lt; # CONFIG_KALLSYMS is not set
+---
+&gt; # CONFIG_EMBEDDED is not set
+&gt; CONFIG_KALLSYMS=y
+&gt; CONFIG_KALLSYMS_ALL=y
+&gt; # CONFIG_KALLSYMS_EXTRA_PASS is not set
+47d47
+&lt; CONFIG_CC_OPTIMIZE_FOR_SIZE=y
+61c61
+&lt; # CONFIG_MODULE_FORCE_UNLOAD is not set
+---
+&gt; CONFIG_MODULE_FORCE_UNLOAD=y
+63c63
+&lt; CONFIG_MODVERSIONS=y
+---
+&gt; # CONFIG_MODVERSIONS is not set
+65,66c65
+&lt; CONFIG_KMOD=y
+&lt; CONFIG_STOP_MACHINE=y
+---
+&gt; # CONFIG_KMOD is not set
+71c70
+&lt; # CONFIG_MK8 is not set
+---
+&gt; CONFIG_MK8=y
+73,75c72,74
+&lt; CONFIG_GENERIC_CPU=y
+&lt; CONFIG_X86_L1_CACHE_BYTES=128
+&lt; CONFIG_X86_L1_CACHE_SHIFT=7
+---
+&gt; # CONFIG_GENERIC_CPU is not set
+&gt; CONFIG_X86_L1_CACHE_BYTES=64
+&gt; CONFIG_X86_L1_CACHE_SHIFT=6
+79,81c78,79
+&lt; # CONFIG_X86_MSR is not set
+&lt; # CONFIG_X86_CPUID is not set
+&lt; CONFIG_X86_HT=y
+---
+&gt; CONFIG_X86_MSR=y
+&gt; CONFIG_X86_CPUID=y
+85,90c83,86
+&lt; CONFIG_SMP=y
+&lt; CONFIG_PREEMPT=y
+&lt; CONFIG_PREEMPT_BKL=y
+&lt; CONFIG_SCHED_SMT=y
+&lt; # CONFIG_K8_NUMA is not set
+&lt; # CONFIG_NUMA_EMU is not set
+---
+&gt; # CONFIG_SMP is not set
+&gt; CONFIG_PREEMPT_NONE=y
+&gt; # CONFIG_PREEMPT_VOLUNTARY is not set
+&gt; # CONFIG_PREEMPT is not set
+92,93c88,95
+&lt; CONFIG_HAVE_DEC_LOCK=y
+&lt; CONFIG_NR_CPUS=8
+---
+&gt; CONFIG_ARCH_FLATMEM_ENABLE=y
+&gt; CONFIG_SELECT_MEMORY_MODEL=y
+&gt; CONFIG_FLATMEM_MANUAL=y
+&gt; # CONFIG_DISCONTIGMEM_MANUAL is not set
+&gt; # CONFIG_SPARSEMEM_MANUAL is not set
+&gt; CONFIG_FLATMEM=y
+&gt; CONFIG_FLAT_NODE_MEM_MAP=y
+&gt; CONFIG_HAVE_ARCH_EARLY_PFN_TO_NID=y
+95,99c97,104
+&lt; # CONFIG_X86_PM_TIMER is not set
+&lt; # CONFIG_HPET_EMULATE_RTC is not set
+&lt; # CONFIG_GART_IOMMU is not set
+&lt; CONFIG_DUMMY_IOMMU=y
+&lt; # CONFIG_X86_MCE is not set
+---
+&gt; CONFIG_X86_PM_TIMER=y
+&gt; CONFIG_HPET_EMULATE_RTC=y
+&gt; CONFIG_GART_IOMMU=y
+&gt; CONFIG_SWIOTLB=y
+&gt; CONFIG_X86_MCE=y
+&gt; CONFIG_X86_MCE_INTEL=y
+&gt; CONFIG_PHYSICAL_START=0x100000
+&gt; # CONFIG_KEXEC is not set
+100a106,109
+&gt; # CONFIG_HZ_100 is not set
+&gt; CONFIG_HZ_250=y
+&gt; # CONFIG_HZ_1000 is not set
+&gt; CONFIG_HZ=250
+110c119,120
+&lt; # CONFIG_SOFTWARE_SUSPEND is not set
+---
+&gt; CONFIG_SOFTWARE_SUSPEND=y
+&gt; CONFIG_PM_STD_PARTITION=""
+119,120c129,130
+&lt; CONFIG_ACPI_AC=m
+&lt; CONFIG_ACPI_BATTERY=m
+---
+&gt; # CONFIG_ACPI_AC is not set
+&gt; # CONFIG_ACPI_BATTERY is not set
+122a133
+&gt; # CONFIG_ACPI_HOTKEY is not set
+126,129c137,140
+&lt; CONFIG_ACPI_ASUS=m
+&lt; CONFIG_ACPI_IBM=m
+&lt; CONFIG_ACPI_TOSHIBA=m
+&lt; CONFIG_ACPI_BLACKLIST_YEAR=0
+---
+&gt; # CONFIG_ACPI_ASUS is not set
+&gt; # CONFIG_ACPI_IBM is not set
+&gt; # CONFIG_ACPI_TOSHIBA is not set
+&gt; CONFIG_ACPI_BLACKLIST_YEAR=2001
+136c147
+&lt; CONFIG_ACPI_CONTAINER=m
+---
+&gt; # CONFIG_ACPI_CONTAINER is not set
+142c153
+&lt; CONFIG_CPU_FREQ_TABLE=m
+---
+&gt; CONFIG_CPU_FREQ_TABLE=y
+144c155
+&lt; CONFIG_CPU_FREQ_STAT=m
+---
+&gt; CONFIG_CPU_FREQ_STAT=y
+149,152c160,163
+&lt; CONFIG_CPU_FREQ_GOV_POWERSAVE=m
+&lt; CONFIG_CPU_FREQ_GOV_USERSPACE=m
+&lt; CONFIG_CPU_FREQ_GOV_ONDEMAND=m
+&lt; CONFIG_CPU_FREQ_GOV_CONSERVATIVE=m
+---
+&gt; # CONFIG_CPU_FREQ_GOV_POWERSAVE is not set
+&gt; # CONFIG_CPU_FREQ_GOV_USERSPACE is not set
+&gt; # CONFIG_CPU_FREQ_GOV_ONDEMAND is not set
+&gt; CONFIG_CPU_FREQ_GOV_CONSERVATIVE=y
+157,161c168,170
+&lt; CONFIG_X86_POWERNOW_K8=m
+&lt; CONFIG_X86_POWERNOW_K8_ACPI=y
+&lt; CONFIG_X86_SPEEDSTEP_CENTRINO=m
+&lt; CONFIG_X86_SPEEDSTEP_CENTRINO_ACPI=y
+&lt; CONFIG_X86_ACPI_CPUFREQ=m
+---
+&gt; CONFIG_X86_POWERNOW_K8=y
+&gt; # CONFIG_X86_SPEEDSTEP_CENTRINO is not set
+&gt; # CONFIG_X86_ACPI_CPUFREQ is not set
+166,168c175
+&lt; # CONFIG_X86_ACPI_CPUFREQ_PROC_INTF is not set
+&lt; CONFIG_X86_P4_CLOCKMOD=m
+&lt; CONFIG_X86_SPEEDSTEP_LIB=m
+---
+&gt; # CONFIG_X86_SPEEDSTEP_LIB is not set
+177c184
+&lt; CONFIG_PCIEPORTBUS=y
+---
+&gt; # CONFIG_PCIEPORTBUS is not set
+186,198c193
+&lt; CONFIG_PCCARD=m
+&lt; # CONFIG_PCMCIA_DEBUG is not set
+&lt; CONFIG_PCMCIA=m
+&lt; CONFIG_CARDBUS=y
+&lt; 
+&lt; #
+&lt; # PC-card bridges
+&lt; #
+&lt; CONFIG_YENTA=m
+&lt; CONFIG_PD6729=m
+&lt; CONFIG_I82092=m
+&lt; CONFIG_TCIC=m
+&lt; CONFIG_PCCARD_NONSTATIC=m
+---
+&gt; # CONFIG_PCCARD is not set
+211c206
+&lt; # CONFIG_IA32_AOUT is not set
+---
+&gt; CONFIG_IA32_AOUT=y
+216a212,277
+&gt; # Networking
+&gt; #
+&gt; CONFIG_NET=y
+&gt; 
+&gt; #
+&gt; # Networking options
+&gt; #
+&gt; CONFIG_PACKET=y
+&gt; # CONFIG_PACKET_MMAP is not set
+&gt; CONFIG_UNIX=y
+&gt; # CONFIG_NET_KEY is not set
+&gt; CONFIG_INET=y
+&gt; CONFIG_IP_MULTICAST=y
+&gt; # CONFIG_IP_ADVANCED_ROUTER is not set
+&gt; CONFIG_IP_FIB_HASH=y
+&gt; # CONFIG_IP_PNP is not set
+&gt; # CONFIG_NET_IPIP is not set
+&gt; # CONFIG_NET_IPGRE is not set
+&gt; # CONFIG_IP_MROUTE is not set
+&gt; # CONFIG_ARPD is not set
+&gt; # CONFIG_SYN_COOKIES is not set
+&gt; # CONFIG_INET_AH is not set
+&gt; # CONFIG_INET_ESP is not set
+&gt; # CONFIG_INET_IPCOMP is not set
+&gt; # CONFIG_INET_TUNNEL is not set
+&gt; CONFIG_IP_TCPDIAG=y
+&gt; CONFIG_IP_TCPDIAG_IPV6=y
+&gt; # CONFIG_TCP_CONG_ADVANCED is not set
+&gt; CONFIG_TCP_CONG_BIC=y
+&gt; CONFIG_IPV6=y
+&gt; # CONFIG_IPV6_PRIVACY is not set
+&gt; # CONFIG_INET6_AH is not set
+&gt; # CONFIG_INET6_ESP is not set
+&gt; # CONFIG_INET6_IPCOMP is not set
+&gt; # CONFIG_INET6_TUNNEL is not set
+&gt; # CONFIG_IPV6_TUNNEL is not set
+&gt; # CONFIG_NETFILTER is not set
+&gt; 
+&gt; #
+&gt; # SCTP Configuration (EXPERIMENTAL)
+&gt; #
+&gt; # CONFIG_IP_SCTP is not set
+&gt; # CONFIG_ATM is not set
+&gt; # CONFIG_BRIDGE is not set
+&gt; # CONFIG_VLAN_8021Q is not set
+&gt; # CONFIG_DECNET is not set
+&gt; # CONFIG_LLC2 is not set
+&gt; # CONFIG_IPX is not set
+&gt; # CONFIG_ATALK is not set
+&gt; # CONFIG_X25 is not set
+&gt; # CONFIG_LAPB is not set
+&gt; # CONFIG_NET_DIVERT is not set
+&gt; # CONFIG_ECONET is not set
+&gt; # CONFIG_WAN_ROUTER is not set
+&gt; # CONFIG_NET_SCHED is not set
+&gt; # CONFIG_NET_CLS_ROUTE is not set
+&gt; 
+&gt; #
+&gt; # Network testing
+&gt; #
+&gt; # CONFIG_NET_PKTGEN is not set
+&gt; # CONFIG_HAMRADIO is not set
+&gt; # CONFIG_IRDA is not set
+&gt; # CONFIG_BT is not set
+&gt; 
+&gt; #
+225c286
+&lt; CONFIG_FW_LOADER=m
+---
+&gt; # CONFIG_FW_LOADER is not set
+236,244c297
+&lt; CONFIG_PARPORT=m
+&lt; CONFIG_PARPORT_PC=m
+&lt; CONFIG_PARPORT_SERIAL=m
+&lt; CONFIG_PARPORT_PC_FIFO=y
+&lt; CONFIG_PARPORT_PC_SUPERIO=y
+&lt; CONFIG_PARPORT_PC_PCMCIA=m
+&lt; CONFIG_PARPORT_NOT_PC=y
+&lt; # CONFIG_PARPORT_GSC is not set
+&lt; CONFIG_PARPORT_1284=y
+---
+&gt; # CONFIG_PARPORT is not set
+260,295c313,317
+&lt; CONFIG_BLK_DEV_FD=m
+&lt; CONFIG_PARIDE=m
+&lt; CONFIG_PARIDE_PARPORT=m
+&lt; 
+&lt; #
+&lt; # Parallel IDE high-level drivers
+&lt; #
+&lt; CONFIG_PARIDE_PD=m
+&lt; CONFIG_PARIDE_PCD=m
+&lt; CONFIG_PARIDE_PF=m
+&lt; CONFIG_PARIDE_PT=m
+&lt; CONFIG_PARIDE_PG=m
+&lt; 
+&lt; #
+&lt; # Parallel IDE protocol modules
+&lt; #
+&lt; CONFIG_PARIDE_ATEN=m
+&lt; CONFIG_PARIDE_BPCK=m
+&lt; CONFIG_PARIDE_COMM=m
+&lt; CONFIG_PARIDE_DSTR=m
+&lt; CONFIG_PARIDE_FIT2=m
+&lt; CONFIG_PARIDE_FIT3=m
+&lt; CONFIG_PARIDE_EPAT=m
+&lt; CONFIG_PARIDE_EPATC8=y
+&lt; CONFIG_PARIDE_EPIA=m
+&lt; CONFIG_PARIDE_FRIQ=m
+&lt; CONFIG_PARIDE_FRPW=m
+&lt; CONFIG_PARIDE_KBIC=m
+&lt; CONFIG_PARIDE_KTTI=m
+&lt; CONFIG_PARIDE_ON20=m
+&lt; CONFIG_PARIDE_ON26=m
+&lt; CONFIG_BLK_CPQ_DA=m
+&lt; CONFIG_BLK_CPQ_CISS_DA=m
+&lt; # CONFIG_CISS_SCSI_TAPE is not set
+&lt; CONFIG_BLK_DEV_DAC960=m
+&lt; CONFIG_BLK_DEV_UMEM=m
+---
+&gt; CONFIG_BLK_DEV_FD=y
+&gt; # CONFIG_BLK_CPQ_DA is not set
+&gt; # CONFIG_BLK_CPQ_CISS_DA is not set
+&gt; # CONFIG_BLK_DEV_DAC960 is not set
+&gt; # CONFIG_BLK_DEV_UMEM is not set
+299,300c321,322
+&lt; CONFIG_BLK_DEV_NBD=m
+&lt; CONFIG_BLK_DEV_SX8=m
+---
+&gt; # CONFIG_BLK_DEV_NBD is not set
+&gt; # CONFIG_BLK_DEV_SX8 is not set
+304c326
+&lt; CONFIG_BLK_DEV_RAM_SIZE=8192
+---
+&gt; CONFIG_BLK_DEV_RAM_SIZE=4096
+316c338
+&lt; # CONFIG_IOSCHED_CFQ is not set
+---
+&gt; CONFIG_IOSCHED_CFQ=y
+332d353
+&lt; CONFIG_BLK_DEV_IDECS=m
+335c356
+&lt; CONFIG_BLK_DEV_IDEFLOPPY=m
+---
+&gt; # CONFIG_BLK_DEV_IDEFLOPPY is not set
+343,345c364,365
+&lt; CONFIG_BLK_DEV_CMD640=y
+&lt; CONFIG_BLK_DEV_CMD640_ENHANCED=y
+&lt; CONFIG_BLK_DEV_IDEPNP=y
+---
+&gt; # CONFIG_BLK_DEV_CMD640 is not set
+&gt; # CONFIG_BLK_DEV_IDEPNP is not set
+350,351c370,371
+&lt; CONFIG_BLK_DEV_OPTI621=y
+&lt; CONFIG_BLK_DEV_RZ1000=y
+---
+&gt; # CONFIG_BLK_DEV_OPTI621 is not set
+&gt; # CONFIG_BLK_DEV_RZ1000 is not set
+356,358c376,377
+&lt; CONFIG_BLK_DEV_AEC62XX=y
+&lt; CONFIG_BLK_DEV_ALI15X3=y
+&lt; # CONFIG_WDC_ALI15X3 is not set
+---
+&gt; # CONFIG_BLK_DEV_AEC62XX is not set
+&gt; # CONFIG_BLK_DEV_ALI15X3 is not set
+360,367c379,385
+&lt; CONFIG_BLK_DEV_ATIIXP=y
+&lt; CONFIG_BLK_DEV_CMD64X=y
+&lt; CONFIG_BLK_DEV_TRIFLEX=y
+&lt; CONFIG_BLK_DEV_CY82C693=y
+&lt; CONFIG_BLK_DEV_CS5520=y
+&lt; CONFIG_BLK_DEV_CS5530=y
+&lt; CONFIG_BLK_DEV_HPT34X=y
+&lt; # CONFIG_HPT34X_AUTODMA is not set
+---
+&gt; # CONFIG_BLK_DEV_ATIIXP is not set
+&gt; # CONFIG_BLK_DEV_CMD64X is not set
+&gt; # CONFIG_BLK_DEV_TRIFLEX is not set
+&gt; # CONFIG_BLK_DEV_CY82C693 is not set
+&gt; # CONFIG_BLK_DEV_CS5520 is not set
+&gt; # CONFIG_BLK_DEV_CS5530 is not set
+&gt; # CONFIG_BLK_DEV_HPT34X is not set
+369,374c387,391
+&lt; CONFIG_BLK_DEV_SC1200=y
+&lt; CONFIG_BLK_DEV_PIIX=y
+&lt; CONFIG_BLK_DEV_IT821X=y
+&lt; CONFIG_BLK_DEV_NS87415=y
+&lt; CONFIG_BLK_DEV_PDC202XX_OLD=y
+&lt; # CONFIG_PDC202XX_BURST is not set
+---
+&gt; # CONFIG_BLK_DEV_SC1200 is not set
+&gt; # CONFIG_BLK_DEV_PIIX is not set
+&gt; # CONFIG_BLK_DEV_IT821X is not set
+&gt; # CONFIG_BLK_DEV_NS87415 is not set
+&gt; # CONFIG_BLK_DEV_PDC202XX_OLD is not set
+377,382c394,399
+&lt; CONFIG_BLK_DEV_SVWKS=y
+&lt; CONFIG_BLK_DEV_SIIMAGE=m
+&lt; CONFIG_BLK_DEV_SIS5513=y
+&lt; CONFIG_BLK_DEV_SLC90E66=y
+&lt; CONFIG_BLK_DEV_TRM290=y
+&lt; CONFIG_BLK_DEV_VIA82CXXX=y
+---
+&gt; # CONFIG_BLK_DEV_SVWKS is not set
+&gt; # CONFIG_BLK_DEV_SIIMAGE is not set
+&gt; # CONFIG_BLK_DEV_SIS5513 is not set
+&gt; # CONFIG_BLK_DEV_SLC90E66 is not set
+&gt; # CONFIG_BLK_DEV_TRM290 is not set
+&gt; # CONFIG_BLK_DEV_VIA82CXXX is not set
+401,403c418,420
+&lt; CONFIG_BLK_DEV_SR=y
+&lt; CONFIG_BLK_DEV_SR_VENDOR=y
+&lt; CONFIG_CHR_DEV_SG=m
+---
+&gt; # CONFIG_BLK_DEV_SR is not set
+&gt; # CONFIG_CHR_DEV_SG is not set
+&gt; # CONFIG_CHR_DEV_SCH is not set
+415,416c432,433
+&lt; CONFIG_SCSI_SPI_ATTRS=m
+&lt; CONFIG_SCSI_FC_ATTRS=m
+---
+&gt; # CONFIG_SCSI_SPI_ATTRS is not set
+&gt; # CONFIG_SCSI_FC_ATTRS is not set
+422,431c439,443
+&lt; CONFIG_BLK_DEV_3W_XXXX_RAID=m
+&lt; CONFIG_SCSI_3W_9XXX=m
+&lt; CONFIG_SCSI_ACARD=m
+&lt; CONFIG_SCSI_AACRAID=m
+&lt; CONFIG_SCSI_AIC7XXX=m
+&lt; CONFIG_AIC7XXX_CMDS_PER_DEVICE=32
+&lt; CONFIG_AIC7XXX_RESET_DELAY_MS=5000
+&lt; # CONFIG_AIC7XXX_DEBUG_ENABLE is not set
+&lt; CONFIG_AIC7XXX_DEBUG_MASK=0
+&lt; CONFIG_AIC7XXX_REG_PRETTY_PRINT=y
+---
+&gt; # CONFIG_BLK_DEV_3W_XXXX_RAID is not set
+&gt; # CONFIG_SCSI_3W_9XXX is not set
+&gt; # CONFIG_SCSI_ACARD is not set
+&gt; # CONFIG_SCSI_AACRAID is not set
+&gt; # CONFIG_SCSI_AIC7XXX is not set
+433,443c445,447
+&lt; CONFIG_SCSI_AIC79XX=m
+&lt; CONFIG_AIC79XX_CMDS_PER_DEVICE=32
+&lt; CONFIG_AIC79XX_RESET_DELAY_MS=5000
+&lt; # CONFIG_AIC79XX_ENABLE_RD_STRM is not set
+&lt; # CONFIG_AIC79XX_DEBUG_ENABLE is not set
+&lt; CONFIG_AIC79XX_DEBUG_MASK=0
+&lt; # CONFIG_AIC79XX_REG_PRETTY_PRINT is not set
+&lt; CONFIG_MEGARAID_NEWGEN=y
+&lt; CONFIG_MEGARAID_MM=m
+&lt; CONFIG_MEGARAID_MAILBOX=m
+&lt; CONFIG_MEGARAID_LEGACY=m
+---
+&gt; # CONFIG_SCSI_AIC79XX is not set
+&gt; # CONFIG_MEGARAID_NEWGEN is not set
+&gt; # CONFIG_MEGARAID_LEGACY is not set
+445,484c449,472
+&lt; CONFIG_SCSI_SATA_AHCI=m
+&lt; CONFIG_SCSI_SATA_SVW=m
+&lt; CONFIG_SCSI_ATA_PIIX=m
+&lt; CONFIG_SCSI_SATA_NV=m
+&lt; CONFIG_SCSI_SATA_PROMISE=m
+&lt; CONFIG_SCSI_SATA_QSTOR=m
+&lt; CONFIG_SCSI_SATA_SX4=m
+&lt; CONFIG_SCSI_SATA_SIL=m
+&lt; CONFIG_SCSI_SATA_SIS=m
+&lt; CONFIG_SCSI_SATA_ULI=m
+&lt; CONFIG_SCSI_SATA_VIA=m
+&lt; CONFIG_SCSI_SATA_VITESSE=m
+&lt; CONFIG_SCSI_BUSLOGIC=m
+&lt; # CONFIG_SCSI_OMIT_FLASHPOINT is not set
+&lt; CONFIG_SCSI_DMX3191D=m
+&lt; CONFIG_SCSI_EATA=m
+&lt; CONFIG_SCSI_EATA_TAGGED_QUEUE=y
+&lt; CONFIG_SCSI_EATA_LINKED_COMMANDS=y
+&lt; CONFIG_SCSI_EATA_MAX_TAGS=16
+&lt; CONFIG_SCSI_FUTURE_DOMAIN=m
+&lt; CONFIG_SCSI_GDTH=m
+&lt; CONFIG_SCSI_IPS=m
+&lt; CONFIG_SCSI_INITIO=m
+&lt; CONFIG_SCSI_INIA100=m
+&lt; CONFIG_SCSI_PPA=m
+&lt; CONFIG_SCSI_IMM=m
+&lt; # CONFIG_SCSI_IZIP_EPP16 is not set
+&lt; # CONFIG_SCSI_IZIP_SLOW_CTR is not set
+&lt; CONFIG_SCSI_SYM53C8XX_2=m
+&lt; CONFIG_SCSI_SYM53C8XX_DMA_ADDRESSING_MODE=1
+&lt; CONFIG_SCSI_SYM53C8XX_DEFAULT_TAGS=16
+&lt; CONFIG_SCSI_SYM53C8XX_MAX_TAGS=64
+&lt; # CONFIG_SCSI_SYM53C8XX_IOMAPPED is not set
+&lt; CONFIG_SCSI_IPR=m
+&lt; # CONFIG_SCSI_IPR_TRACE is not set
+&lt; # CONFIG_SCSI_IPR_DUMP is not set
+&lt; CONFIG_SCSI_QLOGIC_FC=m
+&lt; # CONFIG_SCSI_QLOGIC_FC_FIRMWARE is not set
+&lt; CONFIG_SCSI_QLOGIC_1280=m
+&lt; CONFIG_SCSI_QLOGIC_1280_1040=y
+---
+&gt; # CONFIG_SCSI_SATA_AHCI is not set
+&gt; # CONFIG_SCSI_SATA_SVW is not set
+&gt; # CONFIG_SCSI_ATA_PIIX is not set
+&gt; # CONFIG_SCSI_SATA_NV is not set
+&gt; CONFIG_SCSI_SATA_PROMISE=y
+&gt; # CONFIG_SCSI_SATA_QSTOR is not set
+&gt; # CONFIG_SCSI_SATA_SX4 is not set
+&gt; # CONFIG_SCSI_SATA_SIL is not set
+&gt; # CONFIG_SCSI_SATA_SIS is not set
+&gt; # CONFIG_SCSI_SATA_ULI is not set
+&gt; CONFIG_SCSI_SATA_VIA=y
+&gt; # CONFIG_SCSI_SATA_VITESSE is not set
+&gt; # CONFIG_SCSI_BUSLOGIC is not set
+&gt; # CONFIG_SCSI_DMX3191D is not set
+&gt; # CONFIG_SCSI_EATA is not set
+&gt; # CONFIG_SCSI_FUTURE_DOMAIN is not set
+&gt; # CONFIG_SCSI_GDTH is not set
+&gt; # CONFIG_SCSI_IPS is not set
+&gt; # CONFIG_SCSI_INITIO is not set
+&gt; # CONFIG_SCSI_INIA100 is not set
+&gt; # CONFIG_SCSI_SYM53C8XX_2 is not set
+&gt; # CONFIG_SCSI_IPR is not set
+&gt; # CONFIG_SCSI_QLOGIC_FC is not set
+&gt; # CONFIG_SCSI_QLOGIC_1280 is not set
+486,493c474,482
+&lt; CONFIG_SCSI_QLA21XX=m
+&lt; CONFIG_SCSI_QLA22XX=m
+&lt; CONFIG_SCSI_QLA2300=m
+&lt; CONFIG_SCSI_QLA2322=m
+&lt; CONFIG_SCSI_QLA6312=m
+&lt; CONFIG_SCSI_LPFC=m
+&lt; CONFIG_SCSI_DC395x=m
+&lt; CONFIG_SCSI_DC390T=m
+---
+&gt; # CONFIG_SCSI_QLA21XX is not set
+&gt; # CONFIG_SCSI_QLA22XX is not set
+&gt; # CONFIG_SCSI_QLA2300 is not set
+&gt; # CONFIG_SCSI_QLA2322 is not set
+&gt; # CONFIG_SCSI_QLA6312 is not set
+&gt; # CONFIG_SCSI_QLA24XX is not set
+&gt; # CONFIG_SCSI_LPFC is not set
+&gt; # CONFIG_SCSI_DC395x is not set
+&gt; # CONFIG_SCSI_DC390T is not set
+497,503d485
+&lt; # PCMCIA SCSI adapter support
+&lt; #
+&lt; CONFIG_PCMCIA_FDOMAIN=m
+&lt; CONFIG_PCMCIA_QLOGIC=m
+&lt; CONFIG_PCMCIA_SYM53C500=m
+&lt; 
+&lt; #
+507c489
+&lt; CONFIG_BLK_DEV_MD=m
+---
+&gt; CONFIG_BLK_DEV_MD=y
+510c492
+&lt; CONFIG_MD_RAID1=m
+---
+&gt; CONFIG_MD_RAID1=y
+516c498
+&lt; CONFIG_BLK_DEV_DM=m
+---
+&gt; CONFIG_BLK_DEV_DM=y
+528,531c510,512
+&lt; CONFIG_FUSION=m
+&lt; CONFIG_FUSION_MAX_SGE=40
+&lt; CONFIG_FUSION_CTL=m
+&lt; CONFIG_FUSION_LAN=m
+---
+&gt; # CONFIG_FUSION is not set
+&gt; # CONFIG_FUSION_SPI is not set
+&gt; # CONFIG_FUSION_FC is not set
+536c517
+&lt; CONFIG_IEEE1394=m
+---
+&gt; CONFIG_IEEE1394=y
+543,544c524,525
+&lt; CONFIG_IEEE1394_EXTRA_CONFIG_ROMS=y
+&lt; CONFIG_IEEE1394_CONFIG_ROM_IP1394=y
+---
+&gt; # CONFIG_IEEE1394_EXTRA_CONFIG_ROMS is not set
+&gt; # CONFIG_IEEE1394_EXPORT_FULL_API is not set
+553c534
+&lt; CONFIG_IEEE1394_OHCI1394=m
+---
+&gt; # CONFIG_IEEE1394_OHCI1394 is not set
+558,565c539,542
+&lt; CONFIG_IEEE1394_VIDEO1394=m
+&lt; CONFIG_IEEE1394_SBP2=m
+&lt; # CONFIG_IEEE1394_SBP2_PHYS_DMA is not set
+&lt; CONFIG_IEEE1394_ETH1394=m
+&lt; CONFIG_IEEE1394_DV1394=m
+&lt; CONFIG_IEEE1394_RAWIO=m
+&lt; CONFIG_IEEE1394_CMP=m
+&lt; # CONFIG_IEEE1394_AMDTP is not set
+---
+&gt; # CONFIG_IEEE1394_SBP2 is not set
+&gt; # CONFIG_IEEE1394_ETH1394 is not set
+&gt; # CONFIG_IEEE1394_RAWIO is not set
+&gt; # CONFIG_IEEE1394_CMP is not set
+570,638c547
+&lt; CONFIG_I2O=m
+&lt; CONFIG_I2O_CONFIG=m
+&lt; CONFIG_I2O_BLOCK=m
+&lt; CONFIG_I2O_SCSI=m
+&lt; CONFIG_I2O_PROC=m
+&lt; 
+&lt; #
+&lt; # Networking support
+&lt; #
+&lt; CONFIG_NET=y
+&lt; 
+&lt; #
+&lt; # Networking options
+&lt; #
+&lt; CONFIG_PACKET=y
+&lt; # CONFIG_PACKET_MMAP is not set
+&lt; CONFIG_UNIX=y
+&lt; # CONFIG_NET_KEY is not set
+&lt; CONFIG_INET=y
+&lt; # CONFIG_IP_MULTICAST is not set
+&lt; # CONFIG_IP_ADVANCED_ROUTER is not set
+&lt; # CONFIG_IP_PNP is not set
+&lt; # CONFIG_NET_IPIP is not set
+&lt; # CONFIG_NET_IPGRE is not set
+&lt; # CONFIG_ARPD is not set
+&lt; # CONFIG_SYN_COOKIES is not set
+&lt; # CONFIG_INET_AH is not set
+&lt; # CONFIG_INET_ESP is not set
+&lt; # CONFIG_INET_IPCOMP is not set
+&lt; # CONFIG_INET_TUNNEL is not set
+&lt; CONFIG_IP_TCPDIAG=y
+&lt; # CONFIG_IP_TCPDIAG_IPV6 is not set
+&lt; CONFIG_IPV6=m
+&lt; CONFIG_IPV6_PRIVACY=y
+&lt; CONFIG_INET6_AH=m
+&lt; CONFIG_INET6_ESP=m
+&lt; CONFIG_INET6_IPCOMP=m
+&lt; CONFIG_INET6_TUNNEL=m
+&lt; CONFIG_IPV6_TUNNEL=m
+&lt; # CONFIG_NETFILTER is not set
+&lt; CONFIG_XFRM=y
+&lt; # CONFIG_XFRM_USER is not set
+&lt; 
+&lt; #
+&lt; # SCTP Configuration (EXPERIMENTAL)
+&lt; #
+&lt; # CONFIG_IP_SCTP is not set
+&lt; CONFIG_ATM=m
+&lt; # CONFIG_ATM_CLIP is not set
+&lt; # CONFIG_ATM_LANE is not set
+&lt; # CONFIG_ATM_BR2684 is not set
+&lt; # CONFIG_BRIDGE is not set
+&lt; CONFIG_VLAN_8021Q=m
+&lt; # CONFIG_DECNET is not set
+&lt; CONFIG_LLC=y
+&lt; # CONFIG_LLC2 is not set
+&lt; # CONFIG_IPX is not set
+&lt; # CONFIG_ATALK is not set
+&lt; # CONFIG_X25 is not set
+&lt; # CONFIG_LAPB is not set
+&lt; # CONFIG_NET_DIVERT is not set
+&lt; # CONFIG_ECONET is not set
+&lt; # CONFIG_WAN_ROUTER is not set
+&lt; 
+&lt; #
+&lt; # QoS and/or fair queueing
+&lt; #
+&lt; # CONFIG_NET_SCHED is not set
+&lt; # CONFIG_NET_CLS_ROUTE is not set
+---
+&gt; # CONFIG_I2O is not set
+641c550
+&lt; # Network testing
+---
+&gt; # Network device support
+643,675d551
+&lt; # CONFIG_NET_PKTGEN is not set
+&lt; # CONFIG_NETPOLL is not set
+&lt; # CONFIG_NET_POLL_CONTROLLER is not set
+&lt; # CONFIG_HAMRADIO is not set
+&lt; # CONFIG_IRDA is not set
+&lt; CONFIG_BT=m
+&lt; CONFIG_BT_L2CAP=m
+&lt; CONFIG_BT_SCO=m
+&lt; CONFIG_BT_RFCOMM=m
+&lt; CONFIG_BT_RFCOMM_TTY=y
+&lt; CONFIG_BT_BNEP=m
+&lt; CONFIG_BT_BNEP_MC_FILTER=y
+&lt; CONFIG_BT_BNEP_PROTO_FILTER=y
+&lt; # CONFIG_BT_CMTP is not set
+&lt; CONFIG_BT_HIDP=m
+&lt; 
+&lt; #
+&lt; # Bluetooth device drivers
+&lt; #
+&lt; CONFIG_BT_HCIUSB=m
+&lt; CONFIG_BT_HCIUSB_SCO=y
+&lt; CONFIG_BT_HCIUART=m
+&lt; CONFIG_BT_HCIUART_H4=y
+&lt; CONFIG_BT_HCIUART_BCSP=y
+&lt; CONFIG_BT_HCIUART_BCSP_TXCRC=y
+&lt; CONFIG_BT_HCIBCM203X=m
+&lt; CONFIG_BT_HCIBPA10X=m
+&lt; CONFIG_BT_HCIBFUSB=m
+&lt; CONFIG_BT_HCIDTL1=m
+&lt; CONFIG_BT_HCIBT3C=m
+&lt; CONFIG_BT_HCIBLUECARD=m
+&lt; CONFIG_BT_HCIBTUART=m
+&lt; CONFIG_BT_HCIVHCI=m
+680,681c556,557
+&lt; # CONFIG_TUN is not set
+&lt; CONFIG_NET_SB1000=m
+---
+&gt; CONFIG_TUN=y
+&gt; # CONFIG_NET_SB1000 is not set
+691,739c567
+&lt; CONFIG_NET_ETHERNET=y
+&lt; CONFIG_MII=m
+&lt; CONFIG_HAPPYMEAL=m
+&lt; CONFIG_SUNGEM=m
+&lt; CONFIG_NET_VENDOR_3COM=y
+&lt; CONFIG_VORTEX=m
+&lt; CONFIG_TYPHOON=m
+&lt; 
+&lt; #
+&lt; # Tulip family network device support
+&lt; #
+&lt; CONFIG_NET_TULIP=y
+&lt; CONFIG_DE2104X=m
+&lt; CONFIG_TULIP=m
+&lt; CONFIG_TULIP_MWI=y
+&lt; CONFIG_TULIP_MMIO=y
+&lt; CONFIG_TULIP_NAPI=y
+&lt; CONFIG_TULIP_NAPI_HW_MITIGATION=y
+&lt; CONFIG_DE4X5=m
+&lt; CONFIG_WINBOND_840=m
+&lt; CONFIG_DM9102=m
+&lt; CONFIG_PCMCIA_XIRCOM=m
+&lt; CONFIG_HP100=m
+&lt; CONFIG_NET_PCI=y
+&lt; CONFIG_PCNET32=m
+&lt; CONFIG_AMD8111_ETH=m
+&lt; # CONFIG_AMD8111E_NAPI is not set
+&lt; CONFIG_ADAPTEC_STARFIRE=m
+&lt; # CONFIG_ADAPTEC_STARFIRE_NAPI is not set
+&lt; CONFIG_B44=m
+&lt; CONFIG_FORCEDETH=m
+&lt; CONFIG_DGRS=m
+&lt; # CONFIG_EEPRO100 is not set
+&lt; CONFIG_E100=m
+&lt; CONFIG_FEALNX=m
+&lt; CONFIG_NATSEMI=m
+&lt; CONFIG_NE2K_PCI=m
+&lt; CONFIG_8139CP=m
+&lt; CONFIG_8139TOO=m
+&lt; # CONFIG_8139TOO_PIO is not set
+&lt; CONFIG_8139TOO_TUNE_TWISTER=y
+&lt; CONFIG_8139TOO_8129=y
+&lt; # CONFIG_8139_OLD_RX_RESET is not set
+&lt; CONFIG_SIS900=m
+&lt; CONFIG_EPIC100=m
+&lt; CONFIG_SUNDANCE=m
+&lt; CONFIG_SUNDANCE_MMIO=y
+&lt; CONFIG_VIA_RHINE=m
+&lt; CONFIG_VIA_RHINE_MMIO=y
+---
+&gt; # CONFIG_NET_ETHERNET is not set
+744,759c572,582
+&lt; CONFIG_ACENIC=m
+&lt; # CONFIG_ACENIC_OMIT_TIGON_I is not set
+&lt; CONFIG_DL2K=m
+&lt; CONFIG_E1000=m
+&lt; # CONFIG_E1000_NAPI is not set
+&lt; CONFIG_NS83820=m
+&lt; CONFIG_HAMACHI=m
+&lt; CONFIG_YELLOWFIN=m
+&lt; CONFIG_R8169=m
+&lt; # CONFIG_R8169_NAPI is not set
+&lt; CONFIG_R8169_VLAN=y
+&lt; CONFIG_SKGE=m
+&lt; CONFIG_SK98LIN=m
+&lt; CONFIG_VIA_VELOCITY=m
+&lt; CONFIG_TIGON3=m
+&lt; CONFIG_BNX2=m
+---
+&gt; # CONFIG_ACENIC is not set
+&gt; # CONFIG_DL2K is not set
+&gt; # CONFIG_E1000 is not set
+&gt; # CONFIG_NS83820 is not set
+&gt; # CONFIG_HAMACHI is not set
+&gt; # CONFIG_YELLOWFIN is not set
+&gt; # CONFIG_R8169 is not set
+&gt; CONFIG_SKGE=y
+&gt; # CONFIG_SK98LIN is not set
+&gt; # CONFIG_TIGON3 is not set
+&gt; # CONFIG_BNX2 is not set
+764,765c587
+&lt; CONFIG_IXGB=m
+&lt; # CONFIG_IXGB_NAPI is not set
+---
+&gt; # CONFIG_IXGB is not set
+773,778c595
+&lt; CONFIG_TR=y
+&lt; CONFIG_IBMOL=m
+&lt; CONFIG_3C359=m
+&lt; CONFIG_TMS380TR=m
+&lt; CONFIG_TMSPCI=m
+&lt; CONFIG_ABYSS=m
+---
+&gt; # CONFIG_TR is not set
+783,828c600
+&lt; CONFIG_NET_RADIO=y
+&lt; 
+&lt; #
+&lt; # Obsolete Wireless cards support (pre-802.11)
+&lt; #
+&lt; CONFIG_STRIP=m
+&lt; CONFIG_PCMCIA_WAVELAN=m
+&lt; CONFIG_PCMCIA_NETWAVE=m
+&lt; 
+&lt; #
+&lt; # Wireless 802.11 Frequency Hopping cards support
+&lt; #
+&lt; CONFIG_PCMCIA_RAYCS=m
+&lt; 
+&lt; #
+&lt; # Wireless 802.11b ISA/PCI cards support
+&lt; #
+&lt; # CONFIG_HERMES is not set
+&lt; CONFIG_ATMEL=m
+&lt; CONFIG_PCI_ATMEL=m
+&lt; 
+&lt; #
+&lt; # Wireless 802.11b Pcmcia/Cardbus cards support
+&lt; #
+&lt; CONFIG_AIRO_CS=m
+&lt; CONFIG_PCMCIA_ATMEL=m
+&lt; CONFIG_PCMCIA_WL3501=m
+&lt; 
+&lt; #
+&lt; # Prism GT/Duette 802.11(a/b/g) PCI/Cardbus support
+&lt; #
+&lt; CONFIG_PRISM54=m
+&lt; CONFIG_NET_WIRELESS=y
+&lt; 
+&lt; #
+&lt; # PCMCIA network device support
+&lt; #
+&lt; CONFIG_NET_PCMCIA=y
+&lt; CONFIG_PCMCIA_3C589=m
+&lt; CONFIG_PCMCIA_3C574=m
+&lt; CONFIG_PCMCIA_FMVJ18X=m
+&lt; CONFIG_PCMCIA_PCNET=m
+&lt; CONFIG_PCMCIA_NMCLAN=m
+&lt; CONFIG_PCMCIA_SMC91C92=m
+&lt; CONFIG_PCMCIA_XIRC2PS=m
+&lt; CONFIG_PCMCIA_AXNET=m
+---
+&gt; # CONFIG_NET_RADIO is not set
+833,893c605,610
+&lt; CONFIG_WAN=y
+&lt; CONFIG_DSCC4=m
+&lt; CONFIG_DSCC4_PCISYNC=y
+&lt; CONFIG_DSCC4_PCI_RST=y
+&lt; CONFIG_LANMEDIA=m
+&lt; CONFIG_SYNCLINK_SYNCPPP=m
+&lt; CONFIG_HDLC=m
+&lt; CONFIG_HDLC_RAW=y
+&lt; CONFIG_HDLC_RAW_ETH=y
+&lt; CONFIG_HDLC_CISCO=y
+&lt; CONFIG_HDLC_FR=y
+&lt; CONFIG_HDLC_PPP=y
+&lt; 
+&lt; #
+&lt; # X.25/LAPB support is disabled
+&lt; #
+&lt; CONFIG_PCI200SYN=m
+&lt; CONFIG_WANXL=m
+&lt; CONFIG_PC300=m
+&lt; CONFIG_PC300_MLPPP=y
+&lt; CONFIG_FARSYNC=m
+&lt; CONFIG_DLCI=m
+&lt; CONFIG_DLCI_COUNT=24
+&lt; CONFIG_DLCI_MAX=8
+&lt; CONFIG_SBNI=m
+&lt; CONFIG_SBNI_MULTILINE=y
+&lt; 
+&lt; #
+&lt; # ATM drivers
+&lt; #
+&lt; # CONFIG_ATM_TCP is not set
+&lt; # CONFIG_ATM_LANAI is not set
+&lt; # CONFIG_ATM_ENI is not set
+&lt; # CONFIG_ATM_FIRESTREAM is not set
+&lt; # CONFIG_ATM_ZATM is not set
+&lt; # CONFIG_ATM_IDT77252 is not set
+&lt; # CONFIG_ATM_AMBASSADOR is not set
+&lt; # CONFIG_ATM_HORIZON is not set
+&lt; # CONFIG_ATM_FORE200E_MAYBE is not set
+&lt; # CONFIG_ATM_HE is not set
+&lt; CONFIG_FDDI=y
+&lt; CONFIG_DEFXX=m
+&lt; CONFIG_SKFP=m
+&lt; CONFIG_HIPPI=y
+&lt; CONFIG_ROADRUNNER=m
+&lt; # CONFIG_ROADRUNNER_LARGE_RINGS is not set
+&lt; CONFIG_PLIP=m
+&lt; CONFIG_PPP=m
+&lt; CONFIG_PPP_MULTILINK=y
+&lt; CONFIG_PPP_FILTER=y
+&lt; CONFIG_PPP_ASYNC=m
+&lt; CONFIG_PPP_SYNC_TTY=m
+&lt; CONFIG_PPP_DEFLATE=m
+&lt; CONFIG_PPP_BSDCOMP=m
+&lt; CONFIG_PPPOE=m
+&lt; CONFIG_PPPOATM=m
+&lt; CONFIG_SLIP=m
+&lt; CONFIG_SLIP_COMPRESSED=y
+&lt; CONFIG_SLIP_SMART=y
+&lt; CONFIG_SLIP_MODE_SLIP6=y
+&lt; CONFIG_NET_FC=y
+---
+&gt; # CONFIG_WAN is not set
+&gt; # CONFIG_FDDI is not set
+&gt; # CONFIG_HIPPI is not set
+&gt; # CONFIG_PPP is not set
+&gt; # CONFIG_SLIP is not set
+&gt; # CONFIG_NET_FC is not set
+895c612,616
+&lt; # CONFIG_NETCONSOLE is not set
+---
+&gt; CONFIG_NETCONSOLE=y
+&gt; CONFIG_NETPOLL=y
+&gt; # CONFIG_NETPOLL_RX is not set
+&gt; # CONFIG_NETPOLL_TRAP is not set
+&gt; CONFIG_NET_POLL_CONTROLLER=y
+900,941c621
+&lt; CONFIG_ISDN=m
+&lt; 
+&lt; #
+&lt; # Old ISDN4Linux
+&lt; #
+&lt; # CONFIG_ISDN_I4L is not set
+&lt; 
+&lt; #
+&lt; # CAPI subsystem
+&lt; #
+&lt; CONFIG_ISDN_CAPI=m
+&lt; # CONFIG_ISDN_DRV_AVMB1_VERBOSE_REASON is not set
+&lt; CONFIG_ISDN_CAPI_MIDDLEWARE=y
+&lt; CONFIG_ISDN_CAPI_CAPI20=m
+&lt; CONFIG_ISDN_CAPI_CAPIFS_BOOL=y
+&lt; CONFIG_ISDN_CAPI_CAPIFS=m
+&lt; 
+&lt; #
+&lt; # CAPI hardware drivers
+&lt; #
+&lt; 
+&lt; #
+&lt; # Active AVM cards
+&lt; #
+&lt; CONFIG_CAPI_AVM=y
+&lt; CONFIG_ISDN_DRV_AVMB1_B1PCI=m
+&lt; CONFIG_ISDN_DRV_AVMB1_B1PCIV4=y
+&lt; CONFIG_ISDN_DRV_AVMB1_B1PCMCIA=m
+&lt; CONFIG_ISDN_DRV_AVMB1_AVM_CS=m
+&lt; CONFIG_ISDN_DRV_AVMB1_T1PCI=m
+&lt; CONFIG_ISDN_DRV_AVMB1_C4=m
+&lt; 
+&lt; #
+&lt; # Active Eicon DIVA Server cards
+&lt; #
+&lt; CONFIG_CAPI_EICON=y
+&lt; CONFIG_ISDN_DIVAS=m
+&lt; CONFIG_ISDN_DIVAS_BRIPCI=y
+&lt; CONFIG_ISDN_DIVAS_PRIPCI=y
+&lt; CONFIG_ISDN_DIVAS_DIVACAPI=m
+&lt; CONFIG_ISDN_DIVAS_USERIDI=m
+&lt; CONFIG_ISDN_DIVAS_MAINT=m
+---
+&gt; # CONFIG_ISDN is not set
+970,973c650,653
+&lt; CONFIG_KEYBOARD_SUNKBD=m
+&lt; CONFIG_KEYBOARD_LKKBD=m
+&lt; CONFIG_KEYBOARD_XTKBD=m
+&lt; CONFIG_KEYBOARD_NEWTON=m
+---
+&gt; # CONFIG_KEYBOARD_SUNKBD is not set
+&gt; # CONFIG_KEYBOARD_LKKBD is not set
+&gt; # CONFIG_KEYBOARD_XTKBD is not set
+&gt; # CONFIG_KEYBOARD_NEWTON is not set
+976c656
+&lt; CONFIG_MOUSE_SERIAL=m
+---
+&gt; # CONFIG_MOUSE_SERIAL is not set
+980,982c660
+&lt; CONFIG_INPUT_MISC=y
+&lt; CONFIG_INPUT_PCSPKR=m
+&lt; # CONFIG_INPUT_UINPUT is not set
+---
+&gt; # CONFIG_INPUT_MISC is not set
+989,992c667,669
+&lt; CONFIG_SERIO_SERPORT=m
+&lt; CONFIG_SERIO_CT82C710=m
+&lt; CONFIG_SERIO_PARKBD=m
+&lt; CONFIG_SERIO_PCIPS2=m
+---
+&gt; # CONFIG_SERIO_SERPORT is not set
+&gt; # CONFIG_SERIO_CT82C710 is not set
+&gt; # CONFIG_SERIO_PCIPS2 is not set
+1010,1011c687
+&lt; CONFIG_SERIAL_8250_CS=m
+&lt; CONFIG_SERIAL_8250_ACPI=y
+---
+&gt; # CONFIG_SERIAL_8250_ACPI is not set
+1013,1018c689
+&lt; CONFIG_SERIAL_8250_EXTENDED=y
+&lt; CONFIG_SERIAL_8250_MANY_PORTS=y
+&lt; CONFIG_SERIAL_8250_SHARE_IRQ=y
+&lt; # CONFIG_SERIAL_8250_DETECT_IRQ is not set
+&lt; CONFIG_SERIAL_8250_MULTIPORT=y
+&lt; CONFIG_SERIAL_8250_RSA=y
+---
+&gt; # CONFIG_SERIAL_8250_EXTENDED is not set
+1027,1030c698,699
+&lt; # CONFIG_LEGACY_PTYS is not set
+&lt; # CONFIG_PRINTER is not set
+&lt; CONFIG_PPDEV=m
+&lt; # CONFIG_TIPAR is not set
+---
+&gt; CONFIG_LEGACY_PTYS=y
+&gt; CONFIG_LEGACY_PTY_COUNT=256
+1041,1042c710,711
+&lt; # CONFIG_HW_RANDOM is not set
+&lt; CONFIG_NVRAM=m
+---
+&gt; CONFIG_HW_RANDOM=y
+&gt; # CONFIG_NVRAM is not set
+1050c719,722
+&lt; # CONFIG_AGP is not set
+---
+&gt; # CONFIG_FTAPE is not set
+&gt; CONFIG_AGP=y
+&gt; CONFIG_AGP_AMD64=y
+&gt; # CONFIG_AGP_INTEL is not set
+1052,1059c724,729
+&lt; 
+&lt; #
+&lt; # PCMCIA character devices
+&lt; #
+&lt; # CONFIG_SYNCLINK_CS is not set
+&lt; CONFIG_MWAVE=m
+&lt; # CONFIG_RAW_DRIVER is not set
+&lt; # CONFIG_HPET is not set
+---
+&gt; # CONFIG_MWAVE is not set
+&gt; CONFIG_RAW_DRIVER=y
+&gt; CONFIG_HPET=y
+&gt; # CONFIG_HPET_RTC_IRQ is not set
+&gt; CONFIG_HPET_MMAP=y
+&gt; CONFIG_MAX_RAW_DEVS=256
+1070a741
+&gt; # CONFIG_I2C_SENSOR is not set
+1077a749,754
+&gt; # Hardware Monitoring support
+&gt; #
+&gt; CONFIG_HWMON=y
+&gt; # CONFIG_HWMON_DEBUG_CHIP is not set
+&gt; 
+&gt; #
+1095,1111c772
+&lt; CONFIG_FB=y
+&lt; CONFIG_FB_CFB_FILLRECT=y
+&lt; CONFIG_FB_CFB_COPYAREA=y
+&lt; CONFIG_FB_CFB_IMAGEBLIT=y
+&lt; CONFIG_FB_SOFT_CURSOR=y
+&lt; # CONFIG_FB_MACMODES is not set
+&lt; # CONFIG_FB_MODE_HELPERS is not set
+&lt; # CONFIG_FB_TILEBLITTING is not set
+&lt; # CONFIG_FB_CIRRUS is not set
+&lt; # CONFIG_FB_PM2 is not set
+&lt; # CONFIG_FB_CYBER2000 is not set
+&lt; # CONFIG_FB_ASILIANT is not set
+&lt; # CONFIG_FB_IMSTT is not set
+&lt; # CONFIG_FB_VGA16 is not set
+&lt; CONFIG_FB_VESA=y
+&lt; CONFIG_FB_VESA_STD=y
+&lt; # CONFIG_FB_VESA_TNG is not set
+---
+&gt; # CONFIG_FB is not set
+1113,1130d773
+&lt; # CONFIG_FB_HGA is not set
+&lt; # CONFIG_FB_NVIDIA is not set
+&lt; # CONFIG_FB_RIVA is not set
+&lt; # CONFIG_FB_MATROX is not set
+&lt; # CONFIG_FB_RADEON_OLD is not set
+&lt; # CONFIG_FB_RADEON is not set
+&lt; # CONFIG_FB_ATY128 is not set
+&lt; # CONFIG_FB_ATY is not set
+&lt; # CONFIG_FB_SAVAGE is not set
+&lt; # CONFIG_FB_SIS is not set
+&lt; # CONFIG_FB_NEOMAGIC is not set
+&lt; # CONFIG_FB_KYRO is not set
+&lt; # CONFIG_FB_3DFX is not set
+&lt; # CONFIG_FB_VOODOO1 is not set
+&lt; # CONFIG_FB_TRIDENT is not set
+&lt; # CONFIG_FB_GEODE is not set
+&lt; # CONFIG_FB_S1D13XXX is not set
+&lt; # CONFIG_FB_VIRTUAL is not set
+1137,1147d779
+&lt; CONFIG_FRAMEBUFFER_CONSOLE=y
+&lt; # CONFIG_FONTS is not set
+&lt; CONFIG_FONT_8x8=y
+&lt; CONFIG_FONT_8x16=y
+&lt; 
+&lt; #
+&lt; # Logo configuration
+&lt; #
+&lt; # CONFIG_LOGO is not set
+&lt; # CONFIG_BACKLIGHT_LCD_SUPPORT is not set
+&lt; CONFIG_FB_SPLASH=y
+1152,1170c784
+&lt; CONFIG_SPEAKUP=y
+&lt; CONFIG_SPEAKUP_ACNTSA=y
+&lt; CONFIG_SPEAKUP_ACNTPC=y
+&lt; CONFIG_SPEAKUP_APOLLO=y
+&lt; CONFIG_SPEAKUP_AUDPTR=y
+&lt; CONFIG_SPEAKUP_BNS=y
+&lt; CONFIG_SPEAKUP_DECTLK=y
+&lt; CONFIG_SPEAKUP_DECEXT=y
+&lt; # CONFIG_SPEAKUP_DECPC is not set
+&lt; CONFIG_SPEAKUP_DTLK=y
+&lt; CONFIG_SPEAKUP_KEYPC=y
+&lt; CONFIG_SPEAKUP_LTLK=y
+&lt; CONFIG_SPEAKUP_SFTSYN=y
+&lt; CONFIG_SPEAKUP_SPKOUT=y
+&lt; CONFIG_SPEAKUP_TXPRT=y
+&lt; 
+&lt; #
+&lt; # Enter the 3 to 6 character keyword from the list above, or none for no default synthesizer on boot up.
+&lt; #
+---
+&gt; # CONFIG_SPEAKUP is not set
+1176,1186c790
+&lt; CONFIG_SOUND=y
+&lt; 
+&lt; #
+&lt; # Advanced Linux Sound Architecture
+&lt; #
+&lt; # CONFIG_SND is not set
+&lt; 
+&lt; #
+&lt; # Open Sound System
+&lt; #
+&lt; # CONFIG_SOUND_PRIME is not set
+---
+&gt; # CONFIG_SOUND is not set
+1193c797
+&lt; CONFIG_USB=m
+---
+&gt; CONFIG_USB=y
+1208c812
+&lt; CONFIG_USB_EHCI_HCD=m
+---
+&gt; CONFIG_USB_EHCI_HCD=y
+1211c815,816
+&lt; CONFIG_USB_OHCI_HCD=m
+---
+&gt; # CONFIG_USB_ISP116X_HCD is not set
+&gt; CONFIG_USB_OHCI_HCD=y
+1214,1216c819,820
+&lt; CONFIG_USB_UHCI_HCD=m
+&lt; CONFIG_USB_SL811_HCD=m
+&lt; CONFIG_USB_SL811_CS=m
+---
+&gt; CONFIG_USB_UHCI_HCD=y
+&gt; CONFIG_USB_SL811_HCD=y
+1221,1228c825,827
+&lt; CONFIG_USB_AUDIO=m
+&lt; 
+&lt; #
+&lt; # USB Bluetooth TTY can only be used with disabled Bluetooth subsystem
+&lt; #
+&lt; # CONFIG_USB_MIDI is not set
+&lt; CONFIG_USB_ACM=m
+&lt; # CONFIG_USB_PRINTER is not set
+---
+&gt; # CONFIG_USB_BLUETOOTH_TTY is not set
+&gt; # CONFIG_USB_ACM is not set
+&gt; CONFIG_USB_PRINTER=y
+1233c832
+&lt; CONFIG_USB_STORAGE=m
+---
+&gt; CONFIG_USB_STORAGE=y
+1235,1242c834,841
+&lt; CONFIG_USB_STORAGE_DATAFAB=y
+&lt; CONFIG_USB_STORAGE_FREECOM=y
+&lt; CONFIG_USB_STORAGE_ISD200=y
+&lt; CONFIG_USB_STORAGE_DPCM=y
+&lt; CONFIG_USB_STORAGE_USBAT=y
+&lt; CONFIG_USB_STORAGE_SDDR09=y
+&lt; CONFIG_USB_STORAGE_SDDR55=y
+&lt; CONFIG_USB_STORAGE_JUMPSHOT=y
+---
+&gt; # CONFIG_USB_STORAGE_DATAFAB is not set
+&gt; # CONFIG_USB_STORAGE_FREECOM is not set
+&gt; # CONFIG_USB_STORAGE_ISD200 is not set
+&gt; # CONFIG_USB_STORAGE_DPCM is not set
+&gt; # CONFIG_USB_STORAGE_USBAT is not set
+&gt; # CONFIG_USB_STORAGE_SDDR09 is not set
+&gt; # CONFIG_USB_STORAGE_SDDR55 is not set
+&gt; # CONFIG_USB_STORAGE_JUMPSHOT is not set
+1247,1250c846
+&lt; CONFIG_USB_HID=m
+&lt; CONFIG_USB_HIDINPUT=y
+&lt; # CONFIG_HID_FF is not set
+&lt; CONFIG_USB_HIDDEV=y
+---
+&gt; # CONFIG_USB_HID is not set
+1257,1259c853,856
+&lt; CONFIG_USB_AIPTEK=m
+&lt; CONFIG_USB_WACOM=m
+&lt; CONFIG_USB_KBTAB=m
+---
+&gt; # CONFIG_USB_AIPTEK is not set
+&gt; # CONFIG_USB_WACOM is not set
+&gt; # CONFIG_USB_ACECAD is not set
+&gt; # CONFIG_USB_KBTAB is not set
+1261,1264c858,863
+&lt; CONFIG_USB_MTOUCH=m
+&lt; CONFIG_USB_EGALAX=m
+&lt; CONFIG_USB_XPAD=m
+&lt; CONFIG_USB_ATI_REMOTE=m
+---
+&gt; # CONFIG_USB_MTOUCH is not set
+&gt; # CONFIG_USB_ITMTOUCH is not set
+&gt; # CONFIG_USB_EGALAX is not set
+&gt; # CONFIG_USB_XPAD is not set
+&gt; # CONFIG_USB_ATI_REMOTE is not set
+&gt; # CONFIG_USB_KEYSPAN_REMOTE is not set
+1284,1314c883,888
+&lt; CONFIG_USB_CATC=m
+&lt; CONFIG_USB_KAWETH=m
+&lt; CONFIG_USB_PEGASUS=m
+&lt; CONFIG_USB_RTL8150=m
+&lt; CONFIG_USB_USBNET=m
+&lt; 
+&lt; #
+&lt; # USB Host-to-Host Cables
+&lt; #
+&lt; CONFIG_USB_ALI_M5632=y
+&lt; CONFIG_USB_AN2720=y
+&lt; CONFIG_USB_BELKIN=y
+&lt; CONFIG_USB_GENESYS=y
+&lt; CONFIG_USB_NET1080=y
+&lt; CONFIG_USB_PL2301=y
+&lt; CONFIG_USB_KC2190=y
+&lt; 
+&lt; #
+&lt; # Intelligent USB Devices/Gadgets
+&lt; #
+&lt; # CONFIG_USB_ARMLINUX is not set
+&lt; # CONFIG_USB_EPSON2888 is not set
+&lt; # CONFIG_USB_ZAURUS is not set
+&lt; CONFIG_USB_CDCETHER=y
+&lt; 
+&lt; #
+&lt; # USB Network Adapters
+&lt; #
+&lt; CONFIG_USB_AX8817X=y
+&lt; CONFIG_USB_ZD1201=m
+&lt; # CONFIG_USB_MON is not set
+---
+&gt; # CONFIG_USB_CATC is not set
+&gt; # CONFIG_USB_KAWETH is not set
+&gt; # CONFIG_USB_PEGASUS is not set
+&gt; # CONFIG_USB_RTL8150 is not set
+&gt; # CONFIG_USB_USBNET is not set
+&gt; CONFIG_USB_MON=y
+1319d892
+&lt; CONFIG_USB_USS720=m
+1324,1352c897
+&lt; CONFIG_USB_SERIAL=m
+&lt; CONFIG_USB_SERIAL_GENERIC=y
+&lt; CONFIG_USB_SERIAL_AIRPRIME=m
+&lt; # CONFIG_USB_SERIAL_BELKIN is not set
+&lt; # CONFIG_USB_SERIAL_DIGI_ACCELEPORT is not set
+&lt; CONFIG_USB_SERIAL_CP2101=m
+&lt; # CONFIG_USB_SERIAL_CYPRESS_M8 is not set
+&lt; # CONFIG_USB_SERIAL_EMPEG is not set
+&lt; # CONFIG_USB_SERIAL_FTDI_SIO is not set
+&lt; # CONFIG_USB_SERIAL_VISOR is not set
+&lt; # CONFIG_USB_SERIAL_IPAQ is not set
+&lt; # CONFIG_USB_SERIAL_IR is not set
+&lt; # CONFIG_USB_SERIAL_EDGEPORT is not set
+&lt; # CONFIG_USB_SERIAL_EDGEPORT_TI is not set
+&lt; # CONFIG_USB_SERIAL_GARMIN is not set
+&lt; CONFIG_USB_SERIAL_IPW=m
+&lt; # CONFIG_USB_SERIAL_KEYSPAN_PDA is not set
+&lt; # CONFIG_USB_SERIAL_KEYSPAN is not set
+&lt; # CONFIG_USB_SERIAL_KLSI is not set
+&lt; # CONFIG_USB_SERIAL_KOBIL_SCT is not set
+&lt; # CONFIG_USB_SERIAL_MCT_U232 is not set
+&lt; # CONFIG_USB_SERIAL_PL2303 is not set
+&lt; # CONFIG_USB_SERIAL_HP4X is not set
+&lt; # CONFIG_USB_SERIAL_SAFE is not set
+&lt; # CONFIG_USB_SERIAL_TI is not set
+&lt; # CONFIG_USB_SERIAL_CYBERJACK is not set
+&lt; # CONFIG_USB_SERIAL_XIRCOM is not set
+&lt; CONFIG_USB_SERIAL_OPTION=m
+&lt; CONFIG_USB_SERIAL_OMNINET=m
+---
+&gt; # CONFIG_USB_SERIAL is not set
+1359c904
+&lt; CONFIG_USB_AUERSWALD=m
+---
+&gt; # CONFIG_USB_AUERSWALD is not set
+1368c913,914
+&lt; CONFIG_USB_SISUSBVGA=m
+---
+&gt; # CONFIG_USB_SISUSBVGA is not set
+&gt; # CONFIG_USB_LD is not set
+1372c918
+&lt; # USB ATM/DSL drivers
+---
+&gt; # USB DSL modem support
+1374,1375d919
+&lt; CONFIG_USB_ATM=m
+&lt; CONFIG_USB_SPEEDTOUCH=m
+1385,1388c929
+&lt; CONFIG_MMC=m
+&lt; # CONFIG_MMC_DEBUG is not set
+&lt; CONFIG_MMC_BLOCK=m
+&lt; CONFIG_MMC_WBSD=m
+---
+&gt; # CONFIG_MMC is not set
+1393,1397c934,938
+&lt; CONFIG_INFINIBAND=m
+&lt; CONFIG_INFINIBAND_MTHCA=m
+&lt; # CONFIG_INFINIBAND_MTHCA_DEBUG is not set
+&lt; CONFIG_INFINIBAND_IPOIB=m
+&lt; # CONFIG_INFINIBAND_IPOIB_DEBUG is not set
+---
+&gt; # CONFIG_INFINIBAND is not set
+&gt; 
+&gt; #
+&gt; # SN Devices
+&gt; #
+1410a952
+&gt; # CONFIG_EXT2_FS_XIP is not set
+1424,1428c966
+&lt; CONFIG_JFS_FS=m
+&lt; CONFIG_JFS_POSIX_ACL=y
+&lt; # CONFIG_JFS_SECURITY is not set
+&lt; # CONFIG_JFS_DEBUG is not set
+&lt; # CONFIG_JFS_STATISTICS is not set
+---
+&gt; # CONFIG_JFS_FS is not set
+1434,1439c972
+&lt; CONFIG_XFS_FS=y
+&lt; CONFIG_XFS_EXPORT=y
+&lt; CONFIG_XFS_RT=y
+&lt; CONFIG_XFS_QUOTA=y
+&lt; CONFIG_XFS_SECURITY=y
+&lt; CONFIG_XFS_POSIX_ACL=y
+---
+&gt; # CONFIG_XFS_FS is not set
+1444d976
+&lt; CONFIG_QUOTACTL=y
+1446c978
+&lt; # CONFIG_AUTOFS_FS is not set
+---
+&gt; CONFIG_AUTOFS_FS=y
+1463c995
+&lt; CONFIG_MSDOS_FS=m
+---
+&gt; CONFIG_MSDOS_FS=y
+1467,1469c999
+&lt; CONFIG_NTFS_FS=m
+&lt; # CONFIG_NTFS_DEBUG is not set
+&lt; # CONFIG_NTFS_RW is not set
+---
+&gt; # CONFIG_NTFS_FS is not set
+1477d1006
+&lt; # CONFIG_DEVFS_FS is not set
+1480,1483c1009,1011
+&lt; CONFIG_TMPFS_XATTR=y
+&lt; CONFIG_TMPFS_SECURITY=y
+&lt; # CONFIG_HUGETLBFS is not set
+&lt; # CONFIG_HUGETLB_PAGE is not set
+---
+&gt; # CONFIG_TMPFS_XATTR is not set
+&gt; CONFIG_HUGETLBFS=y
+&gt; CONFIG_HUGETLB_PAGE=y
+1497c1025
+&lt; CONFIG_SQUASHFS=y
+---
+&gt; # CONFIG_SQUASHFS is not set
+1507c1035
+&lt; CONFIG_NFS_FS=m
+---
+&gt; CONFIG_NFS_FS=y
+1508a1037
+&gt; # CONFIG_NFS_V3_ACL is not set
+1511c1040
+&lt; CONFIG_NFSD=m
+---
+&gt; CONFIG_NFSD=y
+1512a1042
+&gt; # CONFIG_NFSD_V3_ACL is not set
+1515c1045
+&lt; CONFIG_LOCKD=m
+---
+&gt; CONFIG_LOCKD=y
+1518c1048,1049
+&lt; CONFIG_SUNRPC=m
+---
+&gt; CONFIG_NFS_COMMON=y
+&gt; CONFIG_SUNRPC=y
+1521,1524c1052,1057
+&lt; CONFIG_SMB_FS=m
+&lt; CONFIG_SMB_NLS_DEFAULT=y
+&lt; CONFIG_SMB_NLS_REMOTE="cp437"
+&lt; # CONFIG_CIFS is not set
+---
+&gt; CONFIG_SMB_FS=y
+&gt; # CONFIG_SMB_NLS_DEFAULT is not set
+&gt; CONFIG_CIFS=y
+&gt; # CONFIG_CIFS_STATS is not set
+&gt; # CONFIG_CIFS_XATTR is not set
+&gt; # CONFIG_CIFS_EXPERIMENTAL is not set
+1532,1537c1065
+&lt; CONFIG_PARTITION_ADVANCED=y
+&lt; # CONFIG_ACORN_PARTITION is not set
+&lt; # CONFIG_OSF_PARTITION is not set
+&lt; # CONFIG_AMIGA_PARTITION is not set
+&lt; # CONFIG_ATARI_PARTITION is not set
+&lt; # CONFIG_MAC_PARTITION is not set
+---
+&gt; # CONFIG_PARTITION_ADVANCED is not set
+1539,1548d1066
+&lt; # CONFIG_BSD_DISKLABEL is not set
+&lt; # CONFIG_MINIX_SUBPARTITION is not set
+&lt; # CONFIG_SOLARIS_X86_PARTITION is not set
+&lt; # CONFIG_UNIXWARE_DISKLABEL is not set
+&lt; CONFIG_LDM_PARTITION=y
+&lt; # CONFIG_LDM_DEBUG is not set
+&lt; # CONFIG_SGI_PARTITION is not set
+&lt; # CONFIG_ULTRIX_PARTITION is not set
+&lt; # CONFIG_SUN_PARTITION is not set
+&lt; # CONFIG_EFI_PARTITION is not set
+1578c1096
+&lt; # CONFIG_NLS_ASCII is not set
+---
+&gt; CONFIG_NLS_ASCII=y
+1589c1107
+&lt; # CONFIG_NLS_ISO8859_15 is not set
+---
+&gt; CONFIG_NLS_ISO8859_15=y
+1597c1115,1116
+&lt; # CONFIG_PROFILING is not set
+---
+&gt; CONFIG_PROFILING=y
+&gt; CONFIG_OPROFILE=y
+1605c1124
+&lt; CONFIG_LOG_BUF_SHIFT=15
+---
+&gt; CONFIG_LOG_BUF_SHIFT=18
+1608d1126
+&lt; CONFIG_DEBUG_PREEMPT=y
+1613a1132
+&gt; # CONFIG_CHECKING is not set
+1614a1134
+&gt; # CONFIG_IOMMU_DEBUG is not set
+1628,1630c1148,1150
+&lt; # CONFIG_CRYPTO_NULL is not set
+&lt; # CONFIG_CRYPTO_MD4 is not set
+&lt; CONFIG_CRYPTO_MD5=y
+---
+&gt; CONFIG_CRYPTO_NULL=m
+&gt; CONFIG_CRYPTO_MD4=m
+&gt; CONFIG_CRYPTO_MD5=m
+1634,1636c1154,1156
+&lt; # CONFIG_CRYPTO_WP512 is not set
+&lt; # CONFIG_CRYPTO_TGR192 is not set
+&lt; CONFIG_CRYPTO_DES=y
+---
+&gt; CONFIG_CRYPTO_WP512=m
+&gt; CONFIG_CRYPTO_TGR192=m
+&gt; CONFIG_CRYPTO_DES=m
+1640c1160
+&lt; CONFIG_CRYPTO_AES=m
+---
+&gt; CONFIG_CRYPTO_AES_X86_64=m
+1645,1646c1165,1166
+&lt; # CONFIG_CRYPTO_KHAZAD is not set
+&lt; # CONFIG_CRYPTO_ANUBIS is not set
+---
+&gt; CONFIG_CRYPTO_KHAZAD=m
+&gt; CONFIG_CRYPTO_ANUBIS=m
+1650c1170
+&lt; # CONFIG_CRYPTO_TEST is not set
+---
+&gt; CONFIG_CRYPTO_TEST=m
+1661c1181
+&lt; CONFIG_LIBCRC32C=m
+---
+&gt; CONFIG_LIBCRC32C=y<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[20:25](http://www.tgharold.com/techblog/2005/11/amd64-broken-kernel-config-file.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-14-more-troubleshooting-steps.md
+++ b/_posts/2005/2005-11-14-more-troubleshooting-steps.md
@@ -1,0 +1,47 @@
+---
+layout: post
+title: 'More troubleshooting steps'
+date: '2005-11-14T14:28:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>A) [AMD64 / Athlon X2 Opinions](http://forums.gentoo.org/viewtopic-t-385651-highlight-lost+ticks.html) - Recommends adding "clock=pmtmr notsc" to the kernel parameters in the grub.conf file.  It probably won't help with the sluggishness and lost ticks since those arguments are not being passed on the LiveCD boot.
+
+The LiveCD boots with:
+
+<code>livecd / # dmesg
+Bootdata ok (command line is initrd=gentoo.igz root=/dev/ram0 init=/linuxrc looptype=squashfs loop=/livecd.squashfs udev nodevfs dokeymap cdroot vga=791 splash=silent,theme:livecd-2005.1 CONSOLE=/dev/tty1 quiet BOOT_IMAGE=gentoo )
+Linux version 2.6.12-gentoo-r6 (root@poseidon) (gcc version 3.4.3 20041125 (Gentoo 3.4.3-r1, ssp-3.4.3-0, pie-8.7.7)) #1 SMP Mon Aug 1 14:22:17 UTC 2005
+(snip)</code>
+
+B) [Abit AN8 config file](http://home.earthlink.net/~paulsdead/config-vanilla) from [Help with kernel .config (amd64 3000+, s939 nforce4)](http://forums.gentoo.org/viewtopic-t-383692-highlight-lost+ticks.html).  The poster is also using "pci=biosirq pci=irqroute clock=pmtmr notsc" in their kernel config line.
+
+(haven't tried yet)
+
+C) Config file for an [Abit AN8-Ultra](http://people.clemson.edu/~rbjohns/linux/config-2.6.12-gentoo-r10).  No reported issues by the poster (same thread as #B above).
+
+(haven't tried yet)
+
+D) Turning off power management and CPU frequency options (in both the kernel and the BIOS).  A somewhat drastic step, but will allow me to hopefully rule this in/out.  This kernel will be my Nov 14th 1500 kernel.
+
+I'm in the process of building this kernel.  But after booting and testing with it, no change in the issue.
+
+E) Going to try flipping back to an earlier kernel.  I went back to my Nov 8th kernel and merely added in the driver support for sata_promise, the HPT302 chip and the TX2 card (even though the latter two are not installed at the moment).  I now have a slightly different "ticks" message:
+
+Losing some ticks... checking if CPU frequency changed.
+warning: many lost ticks.
+Your time source seems to be instable or some driver is hogging interupts
+rip scsi_dispatch_cmd+0x1f3/0x250
+
+I had not seen "rip scsi_dispatch_cmd+0x1f3/0x250" yet.  The old message was "rip __do_softirq+0x48/0xb0".  Wow, no google hit for the scsi_dispatch_cmd line.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[14:28](http://www.tgharold.com/techblog/2005/11/more-troubleshooting-steps.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-21-success-at-fixing-sluggishness.md
+++ b/_posts/2005/2005-11-21-success-at-fixing-sluggishness.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: 'Success at fixing sluggishness'
+date: '2005-11-21T23:54:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Hah, I finally flipped the right bit on my AMD64 Gentoo server to eliminate the issue with sluggishness while mdadm is rebuilding a RAID array.  So, without further ado, here is my current .config file for a 2.6.13 kernel along with the diff between the last unsuccessful kernel and the kernel that worked.
+
+[KernelConfig-1122-0030.txt](/techblog/Gentoo/AMD64/KernelConfig-1122-0030.txt)
+
+[KernelConfig-1122-0030-diff.txt](/techblog/Gentoo/AMD64/KernelConfig-1122-0030-diff.txt)
+
+I changed close to a dozen flags when I built the last kernel.  One (or more) of them was key in getting rid of the sluggishness.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[23:54](http://www.tgharold.com/techblog/2005/11/success-at-fixing-sluggishness.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-21-troubleshooting-comparison-of-kernel-configs.md
+++ b/_posts/2005/2005-11-21-troubleshooting-comparison-of-kernel-configs.md
@@ -1,0 +1,101 @@
+---
+layout: post
+title: 'Troubleshooting (comparison of kernel configs)'
+date: '2005-11-21T22:05:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>I now have a few sample kernel configs from kind folks in alt.os.linux.gentoo.  There are two that I've focused in on (mostly because they posted first and they gave background on the config files).
+
+[2005_1-LiveCDConfig.txt](/techblog/Gentoo/AMD64/2005_1-LiveCDConfig.txt) - This is the .config file from the AMD64 2005.1 LiveCD.  Since I know this kernel works, it's a prime starting point for researching why I'm having the issues that I'm having.
+
+[Anton-AsusK8VSE-Sep2005-config.txt](/techblog/Gentoo/AMD64/Anton-AsusK8VSE-Sep2005-config.txt) - This kernel config is for an Asus K8VSE, which isn't exactly the board that I'm using (an Asus A8V).  However, it is at least a VIA chipset so is pretty relevant.  Comparing against this helps to narrow what is different between my kernel, Anton's kernel and the kernel config on the LiveCD.
+
+[Scharf-AsusA8V-Aug2005-config.txt](/techblog/Gentoo/AMD64/Scharf-AsusA8V-Aug2005-config.txt) - This is a kernel config for an Asus A8V (same motherboard as me).  So it will help me verify my particular configuration.
+
+Now for the comparison files.  These were created by GNU's diff3 tool on my WinXP laptop, but the output should be pretty standard diff3 output.  File #1 is always the LiveCD, file #2 is my current kernel config and file #3 is whatever .config file that I'm comparing against.
+
+[LiveCD-vs-Kernel11141600-vs-Anton.txt](/techblog/Gentoo/AMD64/LiveCD-vs-Kernel11141600-vs-Anton.txt)
+
+[LiveCD-vs-Kernel11141600-vs-Scharf.txt](/techblog/Gentoo/AMD64/LiveCD-vs-Kernel11141600-vs-Scharf.txt)
+
+Lines that are the same between the LiveCD and the sample config, but *different* on my config would show up as:
+
+<pre>1:35c
+3:35c
+  CONFIG_HOTPLUG=y
+2:36c
+  # CONFIG_HOTPLUG is not set</pre>
+
+CONFIG_HOTPLUG is set as "y" in both the LiveCD kernel config and Anton's kernel config, but not defined in my kernel config.  Naturally, my first pass through the comparison is looking for instances like this and then researching the option to understand whether it should be uniquely set on my system.
+
+Now for the details, I've identified a few troublespots in my kernel config that could be causing issues (these are comparisons against the Scharf config).  What I'm finding is that there are very few places in my config where I'm doing something different then the Scharf config (but the LiveCD is the same as the Scharf config).:
+
+<pre>1:35c
+3:35c
+  CONFIG_HOTPLUG=y
+2:36c
+  # CONFIG_HOTPLUG is not set</pre>
+
+Both Anton/Scharf configs set this the same way as the LiveCD.
+
+<pre>1:61c
+3:60c
+  # CONFIG_MODULE_FORCE_UNLOAD is not set
+2:62c
+  CONFIG_MODULE_FORCE_UNLOAD=y</pre>
+
+Both Anton/Scharf configs set this the same way as the LiveCD.
+
+<pre>1:110c
+3:102c
+  # CONFIG_SOFTWARE_SUSPEND is not set
+2:120,121c
+  CONFIG_SOFTWARE_SUSPEND=y
+  CONFIG_PM_STD_PARTITION=""</pre>
+
+The software suspend option is probably not the cause of my troubles.  Anton's config uses software suspend to a dedicated partition.  However, I should still plan on turning this off since I'm not going to use software suspend.
+
+<pre>1:211c
+3:189c
+  # CONFIG_IA32_AOUT is not set
+2:211c
+  CONFIG_IA32_AOUT=y</pre>
+
+Anton configuration has this set to "Y", the Scharf has it not set.
+
+<pre>1:895c
+3:613c
+  # CONFIG_NETCONSOLE is not set
+2:591,595c
+  CONFIG_NETCONSOLE=y
+  CONFIG_NETPOLL=y
+  # CONFIG_NETPOLL_RX is not set
+  # CONFIG_NETPOLL_TRAP is not set
+  CONFIG_NET_POLL_CONTROLLER=y</pre>
+
+Mine is the only config to set this to "Y".
+
+<pre>1:1597c
+3:1334c
+  # CONFIG_PROFILING is not set
+2:1089,1090c
+  CONFIG_PROFILING=y
+  CONFIG_OPROFILE=y</pre>
+
+Probably not an issue.  The Anton config sets this to "Y"/"M" instead of "Y"/"Y".
+
+Updates:
+
+None of the above settings seem to have made any difference.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[22:05](http://www.tgharold.com/techblog/2005/11/troubleshooting-comparison-of-kernel.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-23-ntp-daemons-for-gentoo.md
+++ b/_posts/2005/2005-11-23-ntp-daemons-for-gentoo.md
@@ -1,0 +1,68 @@
+---
+layout: post
+title: 'NTP daemons for Gentoo'
+date: '2005-11-23T09:18:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Looks like there are two basic choices (according to "emerge -s ntp"), [ntp](http://www.ntp.org/) and [openntpd](http://openntpd.org/).
+
+<pre>*  net-misc/ntp
+      Latest version available: 4.2.0.20040617-r3
+      Latest version installed: [ Not Installed ]
+      Size of downloaded files: 2,403 kB
+      Homepage:    http://www.ntp.org/
+      Description: Network Time Protocol suite/programs
+      License:     as-is
+
+*  net-misc/openntpd
+      Latest version available: 3.7_p1
+      Latest version installed: 3.7_p1
+      Size of downloaded files: 133 kB
+      Homepage:    http://www.openntpd.org/
+      Description: Lightweight NTP server ported from OpenBSD
+      License:     BSD</pre>
+
+I decided to go with OpenNTPD because it seemed to be smaller and less troublesome then the official NTP daemon.  (As one of the lines on the OpenNTPD page says... I'm not after microsecond accuracy.)
+
+If you want to use OpenNTPD, you should dig through the [presentations / papers](http://openntpd.org/papers.html) for a brief overview of the project (such as [matching time against random servers](http://unduli.bsws.de/papers/opencon04/ntpd/mgp00005.html)).
+
+Note that if you're in North America, you'll probably want to change the "servers" line in /etc/ntpd.conf.  NTP.org has a [list of server pools that you can pick from](http://ntp.isc.org/bin/view/Servers/NTPPoolServers), divided by geography.  I chose to use "north-america.pool.ntp.org" as my servers pool.
+
+(I am still evaluating OpenNTPD... and I may switch over to the official NTP server instead.)
+
+Useful links:
+[Gentoo Linux Localization Guide](http://www.gentoo.org/doc/en/guide-localization.xml)
+[Jeff McCoy | Time](http://www.jeffmccoy.info/linux/config/time.php)
+
+Useful commands:
+
+<code># hwclock --show
+# zdump GMT
+# zdump EST5EDT
+# date</code>
+
+These commands should show you a hardware clock that matches either GMT (if you have things set to UTC) or your local timezone.  I had a misconfigured hardware clock that was set to localtime, while my system was thinking it was UTC/GMT time.
+
+Note that when you look at /var/log/messages, the OpenNTPD messages can be a bit confusing.  You will see lines like:
+
+<code>Dec 19 21:33:10 localhost ntpd[5673]: adjusting local clock by -11.800044s
+Dec 19 21:36:23 localhost ntpd[5673]: adjusting local clock by -11.691234s
+Dec 19 21:39:36 localhost ntpd[5673]: adjusting local clock by -11.621488s</code>
+
+What this actually means is that your clock is currently off by approximately 12 seconds.  Eventually, OpenNTPD will adjust your clock to be as close as possible to the official time, but it won't make that adjustment suddenly (all at once).  Instead, it will slowly reduce the error amount to the minimum possible for your system.
+
+If you want your server to synchronize at a faster rate, you should manually set the time using the 'date' command to as close to proper time as you can.  Otherwise, it may take a few days for OpenNTPD to finish synchronizing your machine's local clock.
+
+You should also look up the "hwclock" command, especially the --hctosys and --systohc options.  Also look at "nano -w /etc/conf.d/clock", you should probably set the CLOCK_SYSTOHC flag to "yes" so that your system time gets written to the hardware clock during shutdown.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NTP.shtml">NTP</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[09:18](http://www.tgharold.com/techblog/2005/11/ntp-daemons-for-gentoo.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-25-visual-basic-rnd-issues-take-2.md
+++ b/_posts/2005/2005-11-25-visual-basic-rnd-issues-take-2.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title: 'Visual Basic RND issues, take 2'
+date: '2005-11-25T14:39:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>I talked about this a few months ago in [Visual Basic Rnd() function tricks and traps](/techblog/2005/08/visual-basic-rnd-function-tricks-and.shtml), where I discovered that I wasn't getting a full 32bits of randomness out of VB's Rnd() function in my VBScript/Visual Basic pages.  At the time, I thought it was simply due to Rnd() returning a 32bit IEEE floating point value which really only has 30bits of data.
+
+In reality, the situation is even worse:
+
+[PRNG (Pseudo Random Number Generator) By Michael Meelis](http://www.codeproject.com/tools/prngmit.asp)
+[ Microsoft Visual Basic: Pseudo Random Number Generator](http://www.noesis.net.au/prng.php)
+[Using and Creating Cryptographic-Quality Random Numbers By Jon Callas](http://www.merrymeet.com/jon/usingrandom.html)
+[True random number generators](http://www.robertnz.net/true_rng.html)
+
+VB's Rnd() function only provides 24bits of randomness.  After the 2^24th sample, it starts repeating.  (See [INFO: How Visual Basic Generates Pseudo-Random Numbers for the RND Function](http://support.microsoft.com/support/kb/articles/Q231/8/47.asp).)
+
+Randomize() just contributes to the problem.  See [An Examination of Visual Basic's Random Number Generation By Mark Hutchinson](http://www.15seconds.com/issue/051110.htm) and notice that calling Randomize() is based on the time of the day and only provides around 2^16 different starting points within the 2^24 stream.  So if you're calling Randomize() before every Rnd(), you're only getting 16bits of randomness.  (It's actually worse, because you'll get identical starting points at the same time of day.)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[14:39](http://www.tgharold.com/techblog/2005/11/visual-basic-rnd-issues-take-2.shtml)
+
+		</div>

--- a/_posts/2005/2005-11-28-lm_sensors-and-gigabyte-ga-6va7.md
+++ b/_posts/2005/2005-11-28-lm_sensors-and-gigabyte-ga-6va7.md
@@ -1,0 +1,318 @@
+---
+layout: post
+title: 'lm_sensors and Gigabyte GA-6VA7+'
+date: '2005-11-28T20:47:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Working on setting up lm_sensors on my Gigabyte GA-6VA7+ (Intel Celeron Coppermine 566Mhz CPU) system.  [First step](http://secure.netroedge.com/~lm78/kernel26.html) is to turn on I2C support in the 2.6 kernel configuration.
+
+<code># cd /usr/src/linux
+# make menuconfig</code>
+
+Device drivers
+--&gt; I2C Support
+--&gt; --&gt; I2C Support (turn ON as BUILT-IN)
+--&gt; --&gt; --&gt; I2C device interface
+--&gt; --&gt; --&gt; --&gt; (turn all sub-options on as MODULE)
+--&gt; --&gt; --&gt; I2C Algorithms
+--&gt; --&gt; --&gt; --&gt; (turn all sub-options on as MODULE)
+--&gt; --&gt; --&gt; I2C Hardware Bus support  
+--&gt; --&gt; --&gt; --&gt; (turn all sub-options on as MODULE)
+--&gt; --&gt; Miscellaneous I2C Chip support
+--&gt; --&gt; --&gt; (turn all sub-options on as MODULE)
+--&gt; --&gt; I2C Core debugging messages (turn ON as BUILT-IN)
+--&gt; --&gt; I2C Algorithm debugging messages (turn ON as BUILT-IN)
+--&gt; --&gt; I2C Bus debugging messages (turn ON as BUILT-IN)
+--&gt; --&gt; I2C Chip debugging messages (turn ON as BUILT-IN)
+
+Now, make sure that /boot is mounted, then compile your new kernel.
+
+<code># make &amp;&amp; make modules_install
+# mount /boot
+# cp arch/i386/boot/bzImage /boot/kernel-2.6.13-28Nov2005-2037
+# cp System.map /boot/System.map-2.6.13-28Nov2005-2037
+# cp .config /boot/config-2.6.13-28Nov2005-2037
+# nano -w /boot/grub/grub.conf</code>
+
+Now, this is just a testing configuration and not my final configuration.  After the boot, I'll have to figure out what sensors are actually available and which ones I need to keep.
+
+<code># emerge -pv lm_sensors
+# emerge lm_sensors</code>
+
+While that's compiling, read the [lm_sensors FAQ](http://www2.lm-sensors.nu/~lm78/cvs/lm_sensors2/doc/lm_sensors-FAQ.html).  Section 3.1 (Why so many modules, and how do I cope with them?) explains the basics of how to get started with lm_sensors.
+
+(Notice the warnings at the end of the ebuild.)
+
+<code>&gt;&gt;&gt; /etc/init.d/lm_sensors
+ * 
+ * Next you need to run:
+ *   /usr/sbin/sensors-detect
+ * to detect the I2C hardware of your system and create the file:
+ *   /etc/conf.d/lm_sensors
+ * 
+ * You will also need to run the above command if you're upgrading from
+ * &lt;=lm_sensors-2.9.0, as the needed entries in /etc/conf.d/lm_sensors has
+ * changed.
+ * 
+ * Be warned, the probing of hardware in your system performed by
+ * sensors-detect could freeze your system. Also make sure you read
+ * the documentation before running lm_sensors on IBM ThinkPads.
+ * 
+ * Please see the lm_sensors documentation and website for more information.
+ * 
+&gt;&gt;&gt; Regenerating /etc/ld.so.cache...
+&gt;&gt;&gt; sys-apps/lm_sensors-2.9.2 merged.
+(snip)
+
+# /usr/sbin/sensors-detect</code>
+
+The following is output from my Gigabyte motherboard:
+
+<code># sensors-detect revision 1.393 (2005/08/30 18:51:18)
+
+This program will help you determine which I2C/SMBus modules you need to
+load to use lm_sensors most effectively. You need to have i2c and
+lm_sensors installed before running this program.
+Also, you need to be `root', or at least have access to the /dev/i2c-*
+files, for most things.
+If you have patched your kernel and have some drivers built in, you can
+safely answer NO if asked to load some modules. In this case, things may
+seem a bit confusing, but they will still work.
+
+It is generally safe and recommended to accept the default answers to all
+questions, unless you know what you're doing.
+
+ We can start with probing for (PCI) I2C or SMBus adapters.
+ You do not need any special privileges for this.
+ Do you want to probe now? (YES/no): yes
+Probing for PCI bus adapters...
+Use driver `i2c-matroxfb' for device 01:00.0: MGA G200 AGP
+Use driver `i2c-viapro' for device 00:07.3: VIA Technologies VT82C596 Apollo ACPI
+Probe succesfully concluded.
+
+We will now try to load each adapter module in turn.
+Load `i2c-matroxfb' (say NO if built into your kernel)? (YES/no): yes
+FATAL: Module i2c_matroxfb not found.
+Loading failed... skipping.
+Load `i2c-viapro' (say NO if built into your kernel)? (YES/no): yes
+Module loaded succesfully.
+If you have undetectable or unsupported adapters, you can have them
+scanned by manually loading the modules before running this script.
+
+ To continue, we need module `i2c-dev' to be loaded.
+ If it is built-in into your kernel, you can safely skip this.
+ i2c-dev is not loaded. Do you want to load it now? (YES/no): yes
+ Module loaded succesfully.
+
+ We are now going to do the adapter probings. Some adapters may hang halfway
+ through; we can't really help that. Also, some chips will be double detected;
+ we choose the one with the highest confidence value in that case.
+ If you found that the adapter hung after probing a certain address, you can
+ specify that address to remain unprobed. That often
+ includes address 0x69 (clock chip).
+
+Next adapter: SMBus Via Pro adapter at 5000
+Do you want to scan it? (YES/no/selectively): yes
+Client found at address 0x50
+Probing for `SPD EEPROM'... Success!
+    (confidence 8, driver `eeprom')
+Probing for `DDC monitor'... Failed!
+Probing for `Maxim MAX6900'... Failed!
+Client found at address 0x51
+Probing for `SPD EEPROM'... Success!
+    (confidence 8, driver `eeprom')
+Client found at address 0x52
+Probing for `SPD EEPROM'... Success!
+    (confidence 8, driver `eeprom')
+Client found at address 0x69
+
+Some chips are also accessible through the ISA bus. ISA probes are
+typically a bit more dangerous, as we have to write to I/O ports to do
+this. This is usually safe though.
+
+Do you want to scan the ISA bus? (YES/no): yes
+Probing for `National Semiconductor LM78'
+  Trying address 0x0290... Failed!
+Probing for `National Semiconductor LM78-J'
+  Trying address 0x0290... Failed!
+Probing for `National Semiconductor LM79'
+  Trying address 0x0290... Failed!
+Probing for `Winbond W83781D'
+  Trying address 0x0290... Failed!
+Probing for `Winbond W83782D'
+  Trying address 0x0290... Failed!
+Probing for `Winbond W83627HF'
+  Trying address 0x0290... Failed!
+Probing for `Winbond W83627EHF'
+  Trying address 0x0290... Failed!
+Probing for `Winbond W83697HF'
+  Trying address 0x0290... Failed!
+Probing for `Silicon Integrated Systems SIS5595'
+  Trying general detect... Failed!
+Probing for `VIA Technologies VT82C686 Integrated Sensors'
+  Trying general detect... Failed!
+Probing for `VIA Technologies VT8231 Integrated Sensors'
+  Trying general detect... Failed!
+Probing for `ITE IT8712F'
+  Trying address 0x0290... Failed!
+Probing for `ITE IT8705F / SiS 950'
+  Trying address 0x0290... Failed!
+Probing for `IPMI BMC KCS'
+  Trying address 0x0ca0... Failed!
+Probing for `IPMI BMC SMIC'
+  Trying address 0x0ca8... Failed!
+
+Some Super I/O chips may also contain sensors. Super I/O probes are
+typically a bit more dangerous, as we have to write to I/O ports to do
+this. This is usually safe though.
+
+Do you want to scan for Super I/O sensors? (YES/no): yes
+Probing for `ITE 8702F Super IO Sensors'
+  Failed! (skipping family)
+Probing for `Nat. Semi. PC87351 Super IO Fan Sensors'
+  Failed! (skipping family)
+Probing for `SMSC 47B27x Super IO Fan Sensors'
+  Failed! (skipping family)
+Probing for `VT1211 Super IO Sensors'
+  Failed! (skipping family)
+Probing for `Winbond W83627EHF/EHG Super IO Sensors'
+  Failed! (skipping family)
+
+Do you want to scan for secondary Super I/O sensors? (YES/no): yes
+Probing for `ITE 8702F Super IO Sensors'
+  Failed! (skipping family)
+Probing for `Nat. Semi. PC87351 Super IO Fan Sensors'
+  Failed! (skipping family)
+Probing for `SMSC 47B27x Super IO Fan Sensors'
+  Failed! (skipping family)
+Probing for `VT1211 Super IO Sensors'
+  Failed! (skipping family)
+Probing for `Winbond W83627EHF/EHG Super IO Sensors'
+  Failed! (skipping family)
+
+ Now follows a summary of the probes I have just done.
+ Just press ENTER to continue: 
+
+Driver `eeprom' (should be inserted):
+  Detects correctly:
+  * Bus `SMBus Via Pro adapter at 5000'
+    Busdriver `i2c-viapro', I2C address 0x50
+    Chip `SPD EEPROM' (confidence: 8)
+  * Bus `SMBus Via Pro adapter at 5000'
+    Busdriver `i2c-viapro', I2C address 0x51
+    Chip `SPD EEPROM' (confidence: 8)
+  * Bus `SMBus Via Pro adapter at 5000'
+    Busdriver `i2c-viapro', I2C address 0x52
+    Chip `SPD EEPROM' (confidence: 8)
+
+ I will now generate the commands needed to load the I2C modules.
+ Sometimes, a chip is available both through the ISA bus and an I2C bus.
+ ISA bus access is faster, but you need to load an additional driver module
+ for it. If you have the choice, do you want to use the ISA bus or the
+ I2C/SMBus (ISA/smbus)? isa
+
+If you want to load the modules at startup, generate a config file
+below and make sure lm_sensors gets started; e.g
+$ rc-update add lm_sensors default.
+
+To make the sensors modules behave correctly, add these lines to
+/etc/modules.conf:
+
+#----cut here----
+# I2C module options
+alias char-major-89 i2c-dev
+#----end cut here----
+
+WARNING! If you have some things built into your kernel, the list above
+will contain too many modules. Skip the appropriate ones! You really should
+try these commands right now to make sure everything is working properly.
+Monitoring programs won't work until it's done.
+To load everything that is needed, execute the commands above...
+
+#----cut here----
+# I2C adapter drivers
+modprobe i2c-viapro
+# I2C chip drivers
+modprobe eeprom
+# sleep 2 # optional
+/usr/bin/sensors -s # recommended
+
+Do you want to generate /etc/conf.d/lm_sensors? Enter s to specify other file name?
+  (YES/no/s): yes
+Done.</code>
+
+I had to add the rc-update command, but the /etc/modules.conf file already had the proper I2C line.
+
+Hmm... got the "No sensors found!" error message.  Yet I'm 95% sure that I did everything according to directions.  Well, it is an older motherboard so I might be better off retrying setting up lm_sensors on a newer system.
+
+Output from dmesg:
+
+<code>vt596_smbus 0000:00:07.3: using Interrupt SMI# for SMBus.
+vt596_smbus 0000:00:07.3: SMBREV = 0x0
+vt596_smbus 0000:00:07.3: VT596_smba = 0x5000
+i2c_adapter i2c-0: registered as adapter #0
+i2c-core: driver eeprom registered.
+i2c_adapter i2c-0: found normal i2c entry for adapter 0, addr 50
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=a0, DAT0=06, DAT1=00
+i2c_adapter i2c-0: SMBus busy (0x02). Resetting...
+i2c_adapter i2c-0: Successfull!
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=a0, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=a0, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=a0, DAT0=06, DAT1=00
+i2c_adapter i2c-0: client [eeprom] registered to adapter
+registering 0-0050
+i2c_adapter i2c-0: found normal i2c entry for adapter 0, addr 51
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=a2, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=a2, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=a2, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=a2, DAT0=06, DAT1=00
+i2c_adapter i2c-0: client [eeprom] registered to adapter
+registering 0-0051
+i2c_adapter i2c-0: found normal i2c entry for adapter 0, addr 52
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=a4, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=a4, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=a4, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=a4, DAT0=06, DAT1=00
+i2c_adapter i2c-0: client [eeprom] registered to adapter
+registering 0-0052
+i2c_adapter i2c-0: found normal i2c entry for adapter 0, addr 53
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=a6, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Error: no response!
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=a6, DAT0=06, DAT1=00
+i2c_adapter i2c-0: found normal i2c entry for adapter 0, addr 54
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=a8, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Error: no response!
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=a8, DAT0=06, DAT1=00
+i2c_adapter i2c-0: found normal i2c entry for adapter 0, addr 55
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=aa, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Error: no response!
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=aa, DAT0=06, DAT1=00
+i2c_adapter i2c-0: found normal i2c entry for adapter 0, addr 56
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=ac, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Error: no response!
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=ac, DAT0=06, DAT1=00
+i2c_adapter i2c-0: found normal i2c entry for adapter 0, addr 57
+i2c_adapter i2c-0: Transaction (pre): CNT=00, CMD=3f, ADD=ae, DAT0=06, DAT1=00
+i2c_adapter i2c-0: Error: no response!
+i2c_adapter i2c-0: Transaction (post): CNT=00, CMD=3f, ADD=ae, DAT0=06, DAT1=00</code>
+
+Output from lsmod:
+
+<code># lsmod
+Module                  Size  Used by
+eeprom                  5528  - 
+i2c_sensor              2984  - 
+i2c_viapro              7640  - 
+dm_mod                 45340  - </code><div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[20:47](http://www.tgharold.com/techblog/2005/11/lmsensors-and-gigabyte-ga-6va7.shtml)
+
+		</div>

--- a/_posts/2005/2005-12-12-resizing-an-ext3-partition-in-an-lvm2-volume.md
+++ b/_posts/2005/2005-12-12-resizing-an-ext3-partition-in-an-lvm2-volume.md
@@ -1,0 +1,39 @@
+---
+layout: post
+title: 'Resizing an ext3 partition in an LVM2 volume'
+date: '2005-12-12T11:31:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+[Extending a Logical Volume](http://www.netadmintools.com/art366.html)
+
+The basic (3) commands are:
+
+lvextend
+e2fsck 
+resize2fs
+
+For example, I have /home that is currently a 4GB partition mounted in my vgmirror volume group.  In order to turn /home into a 64GB partition, I need to use the following commands.
+
+<code># pvscan
+# lvscan
+# umount /home
+(if you can't unmount the volume, you may need to boot the LiveCD)
+# lvextend -L+60G /dev/vgmirror/home
+# e2fsck -f /dev/vgmirror/home
+# resize2fs /dev/vgmirror/home
+# mount /home</code>
+
+Now, for /home, odds are high that you will have to boot a LiveCD due to the volume being in use.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/ext3.shtml">ext3</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[11:31](http://www.tgharold.com/techblog/2005/12/resizing-ext3-partition-in-lvm2-volume.shtml)
+
+		</div>

--- a/_posts/2005/2005-12-19-windows-domain-time-server-w32time.md
+++ b/_posts/2005/2005-12-19-windows-domain-time-server-w32time.md
@@ -1,0 +1,106 @@
+---
+layout: post
+title: 'Windows domain time server (W32Time)'
+date: '2005-12-19T21:21:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>I'm not going to get into the full details of configuring a time server for your Windows 2000 or Windows 2003 domains, but the basic idea is that your PDC (Primary Domain Controller) at the root of your Active Directory forest should be synchronized with an external time source.  Microsoft includes a service to do this called "Windows Time" (a.k.a. W32Time).  It's not as nice as the official NTPD service that you can get from ntp.org, but it generally works.
+
+By default, Windows client computers that are members of a domain should get their time from the domain controllers within the domain.  So once you get the domain controllers keeping time properly you won't have to deal with bad time on the desktops.
+
+Microsoft Articles:
+[Registry entries for the W32Time service](http://support.microsoft.com/support/kb/articles/q223/1/84.asp%20)
+[Basic Operation of the Windows Time Service](http://support.microsoft.com/default.aspx?scid=kb;EN-US;224799)
+
+An extremely good page that shows you [whether W32Time is configured properly to sync against an external server](http://www.anotherurl.com/library/network_time.htm).  The basic idea is that you <b>stop</b> the "Windows Time" service and the execute the following command at the prompt.
+
+<pre>w32tm -once
+... (content snipped for brevity) ...
+W32Time: BEGIN:TimeSync
+W32Time:    BEGIN:FGetType
+W32Time:    END  Line 254
+W32Time:    BEGIN:FDoTimeNTPType
+W32Time:       BEGIN:ChooseNTPServer
+W32Time:       END  Line 2178
+W32Time:       BEGIN:GetSocketForSynch
+W32Time:          NTP: ntpptrs[0] - US.POOL.NTP.ORG
+W32Time:          rgbNTPServer US.POOL.NTP.ORG
+W32Time:          BEGIN:TsUpTheThread
+W32Time:          END  Line 1407
+W32Time:          NTP(S): waiting for datagram...
+W32Time:          Port Pinging to - 123
+W32Time:          Connecting to "US.POOL.NTP.ORG" (216.52.237.152)
+W32Time:       END:Line 1170
+W32Time:       BEGIN:GetDefaultRid
+W32Time:       END  Line 2359
+W32Time:       BEGIN:ComputeDelay
+W32Time:          BEGIN:NTPTry -- init
+W32Time:          END  Line 1683
+W32Time:          BEGIN:NTPTry -- try
+W32Time:             BEGIN:ComputeInterval
+W32Time:             END  Line 2479
+W32Time:             Sending to server  48 bytes...
+W32Time:             Recv'ed from server  48 Bytes...
+W32Time:          END  Line 1885
+W32Time:          BEGIN:NTPTry -- delay
+W32Time:          END  Line 2012
+W32Time:          Round trip was 90ms
+W32Time:          BEGIN:NTPTry -- try
+W32Time:             BEGIN:ComputeInterval
+W32Time:             END  Line 2479
+W32Time:             Sending to server  48 bytes...
+W32Time:             Recv'ed from server  48 Bytes...
+W32Time:          END  Line 1885
+W32Time:          BEGIN:NTPTry -- delay
+W32Time:          END  Line 2012
+W32Time:          Round trip was 90ms
+W32Time:          BEGIN:NTPTry -- gettime
+W32Time:             BEGIN:Fgmtimetonttime
+W32Time:             END  Line 2563
+W32Time:          END  Line 1998
+W32Time:          one-way delay is 45ms
+W32Time:       END  Line 1645
+W32Time:    END  Line 368
+W32Time:    BEGIN:TimeDiff
+W32Time:       ClockError --45702
+W32Time:    END  Line 2542
+W32Time:    BEGIN:FCheckTimeSanity
+W32Time:       Adjusting time by 45702 ms. No eventlog messages since time diffe
+rence is 0 &lt;1 minute
+W32Time:    END  Line 570
+W32Time:    BEGIN:SetTimeNow
+W32Time:       Time 12/20/2005   2:20:53:970
+W32Time:       *****SetSystemTime()*****
+W32Time:    END  Line 1280
+W32Time:    Time was 20min 08.268s
+W32Time:    Time is  20min 53.970s
+W32Time:    Error -45702ms
+W32Time:    BEGIN:CheckLeapFlag
+W32Time:    END:Line 606
+W32Time:    BEGIN:ComputePostTimeData
+W32Time:       BEGIN:ComputeInterval
+W32Time:       END  Line 2479
+W32Time:       BEGIN:ComputeSleepStuff
+W32Time:          Computed stagger is 0ms, bias is 0ms
+W32Time:          Time until next sync - 2699.960s
+W32Time:       END:Line 816
+W32Time:    END:Line 221
+W32Time: END:Line 196</pre>
+
+The key line in the above output is "Error -45702ms" which shows us how much the Windows server's clock is going to be adjusted by.  You should also look in your System Log (filter for W32Time events) for messages after using the above command (or after stopping/starting the time service).  Those messages in the system log will help you determine why you may not be able to synchronize to an external time server (via 123/udp).
+
+In my opinion, W32Time is "good enough" for most purposes.  At least for small offices or home networks.  If you're going to be dealing with more then a dozen servers or 50 workstations, then you should definitely look into setting up a real "ntpd" server.  (In reality, you should have at least 4 ntpd servers in your infrastructure so that they can keep an eye on each other and alert you to ntpd servers that are not keeping time properly.)
+
+Here's my previous posting dealing with time issues: [NTP daemons for Gentoo](http://www.tgharold.com/techblog/2005/11/ntp-daemons-for-gentoo.shtml)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NTP.shtml">NTP</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[21:21](http://www.tgharold.com/techblog/2005/12/windows-domain-time-server-w32time.shtml)
+
+		</div>

--- a/_posts/2005/2005-12-20-more-handy-linux-console-tools.md
+++ b/_posts/2005/2005-12-20-more-handy-linux-console-tools.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: 'More handy Linux console tools'
+date: '2005-12-20T19:48:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>A few more tools that I've found useful for console-only Linux server administration.  All of these have Gentoo ebuilds so they can simply be emerge'd into your system.
+
+[atop](http://www.atcomputing.nl/Tools/atop) - Similar to the built-in "top" command in Linux/Unix, except that it gives additional details about what is going on with the system.  Of particular use is that it will show you individual disk utilization statistics so that you can locate spindles that are in heavy use.  (Which is much needed when tuning a database server.)
+
+[tree](http://mama.indstate.edu/users/ice/tree/) - Allows you to output a hierachial display of all files and directories on your system in a "tree" view.  Which is useful for documenting the directory layout of your system.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Linux.shtml">Linux</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[19:48](http://www.tgharold.com/techblog/2005/12/more-handy-linux-console-tools.shtml)
+
+		</div>


### PR DESCRIPTION
## Summary
This PR converts all Blogger archive posts from 2005 to Jekyll markdown format, making them available for the blog.

## Changes
- Added 53 new blog posts in `_posts/2005/` directory
- All posts converted from `_archives/techblog/2005/*.shtml` files
- Maintains original content while converting to proper Jekyll format with frontmatter
- Follows existing conversion patterns established in the codebase

## Test plan
- All converted posts follow the standard Jekyll format
- Posts are properly categorized under the 2005 year
- Content integrity preserved during conversion
- No existing functionality affected

## Related
Closes #24 (based on the previous merge that handled 2004 archive posts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)