### PR TITLE
feat: Convert all 2008 Blogger archive posts to Jekyll format

### DIFF
--- a/_posts/2008/2008-01-03-subversion-repository-creation-cheatsheet.md
+++ b/_posts/2008/2008-01-03-subversion-repository-creation-cheatsheet.md
@@ -1,0 +1,48 @@
+---
+layout: post
+title: 'Subversion repository creation cheatsheet'
+date: '2008-01-03T07:39:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Whenever I setup new SVN repositories, I always create a unix group for people who need read/write access to the repository.  If the repository is named "tgh-public", then I choose to name the group as "svn-tgh-public".
+
+I also generally designate a single user as the initial owner of the SVN repository folder under /var/svn.  Alternately, you could just leave the repository owned by root.
+
+# cd /var/svn
+(your repositories may be stored elsewhere)
+# /usr/sbin/groupadd svn-repositoryname
+# svnadmin create /var/svn/repositoryname
+# chmod -R 770 repositoryname
+# chmod -R g+s repositoryname/db
+# chown -R username:svn-repositoryname repositoryname
+# /usr/sbin/usermod -a -G svn-repositoryname username
+
+Notes:
+<ul>
+
+<li>You'll want to repeat the "usermod" command for each person who will have access to the new repository.
+
+</li>
+<li>The chmod value of 770 means that anyone who is either the "username" or who belongs to the "svn-repositoryname" group will be able to access this repository via SVN+SSH and make changes.
+
+</li>
+<li>If you want to allow public reads, then you should use a chmod value of 774 which allows everyone read access to the folders.
+
+</li>
+<li>Forgetting to set the sticky bit for the group will result in a repository that breaks as different users edit the contents. If you dig through the contents of the FSFS directories, you'll see that files were created with ownership username:username instead of belonging to the group who is responsible for that repository.
+
+</li>
+</ul>
+<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[07:39](http://www.tgharold.com/techblog/2008/01/subversion-repository-creation.shtml)
+
+		</div>

--- a/_posts/2008/2008-03-10-postgresql-81-under-a-nondefault-directory-with-selinux.md
+++ b/_posts/2008/2008-03-10-postgresql-81-under-a-nondefault-directory-with-selinux.md
@@ -1,0 +1,542 @@
+---
+layout: post
+title: 'Postgresql 8.1 under a nondefault directory with SELinux'
+date: '2008-03-10T13:42:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>So I like to keep my PostgreSQL install in a non-standard location.  Normally, this is as easy as setting PGDATA= in the /etc/sysconfig/pgsql/postgresql file.  But when SELinux is installed, you also have to deal with system context issues.
+
+One symptom of this is that /etc/init.d/postgresql start will fail, but starting the database interactively using the "su postgres" and pg_ctl commands will work.  This is because SELinux is a lot stricter with programs started in the startup scripts vs programs that are started from an interactive shell.
+
+If you dig through the pgsql-general mail archives, you'll find a thread titled "[GENERAL] Using an alternate PGDATA on RHEL4 with SELinux enabled" from July 2006.  Unfortunately, nobody posted the answer for how to work around this issue and the original poster merely disabled SELinux.  Tom Lane in particular says:
+
+<i>The default selinux policy prevents postgres from writing anywhere except under /var/lib/pgsql.  If you want a nondefault PGDATA location then you have to tweak the policy.</i>
+
+However, I've stumbled across this "[Just Someone Re: SELinux + CREATE TABLESPACE = ?](http://grokbase.com/profile/id:i205zPwbOTvfCFLTORsztb0iwVOTD_1h0v-YgVItCSg)" which gives some insights into the issue.  It was also posted to the pgsql-general mailing list, but about a week later. I quote "Just Someone":
+
+<i>If you rather keep SELinux on, you can still set the SELinux context
+on the directory where you want the tablespaces to one postgres will
+like.
+
+To find what is the permissions you need, you can use ls -Z. It will
+list the SELinux context. Check /var/lib/pgsql/data (or wherever
+postgres data is pointing to), and then set this same permission on
+the target dir using chcon.
+
+For example, on my FC4 system all subdirectories on the data directory have:
+root:object_r:postgresql_db_t or user_u:object_r:postgresql_db_t
+
+So if you want to chage /path/to/foo/which/is/not/under/pgdata, run
+(as root or sudo):
+
+chcon root:object_r:postgresql_db_t /path/to/foo/which/is/not/under/pgdata
+
+This way postgres can access it, and you get the SELinux security.
+
+Bye,
+
+Guy. </i>
+
+So basically, we need to look at the context of the existing /var/lib/pgsql folder and then make our new directories to match that.  We'll start by looking at /var/lib/pgsql:
+
+<pre># ls -Z /var/lib/
+drwx------  postgres  postgres system_u:object_r:var_lib_t      pgsql</pre>
+
+Let's compare this to our new location:
+
+<pre># ls -Z /var/
+drwxr-xr-x  root   root   system_u:object_r:file_t         pgsql</pre>
+
+Yeah, that's definitely not correct.  So let's fix it:
+
+<pre># chown postgres:postgres /var/pgsql
+# chmod 700 /var/pgsql
+# chcon system_u:object_r:var_t /var/pgsql
+# ls -Z /var/
+drwx------  postgres postgres system_u:object_r:var_lib_t      pgsql</pre>
+
+Which now matches exactly what we saw for /var/lib/pgsql.  Now we need to do the same thing for the contents of /var/pgsql as compared to /var/lib/pgsql.
+
+<pre># ls -Z /var/lib/pgsql
+drwx------  postgres postgres system_u:object_r:var_lib_t      backups
+drwx------  postgres postgres system_u:object_r:postgresql_db_t data
+-rw-------  postgres postgres system_u:object_r:postgresql_log_t pgstartup.log</pre>
+
+As compared to:
+
+<pre># ls -Z /var/pgsql
+drwx------  postgres postgres user_u:object_r:var_log_t        data
+drwx------  root     root     system_u:object_r:file_t         lost+found</pre>
+
+Once again, things need to be fixed up.
+
+<pre># su postgres
+$ mkdir /var/pgsql/backups
+$ chmod 700 /var/pgsql/backups
+$ chcon system_u:object_r:var_t /var/pgsql/backups
+$ chcon system_u:object_r:postgresql_db_t /var/pgsql/data
+$ touch /var/pgsql/pgstartup.log
+$ chmod 600 /var/pgsql/pgstartup.log
+$ chcon system_u:object_r:postgresql_log_t /var/pgsql/pgstartup.log
+$ ls -Z /var/pgsql
+drwx------  postgres postgres system_u:object_r:var_t        backups
+drwx------  postgres postgres system_u:object_r:postgresql_db_t data
+drwx------  root     root     system_u:object_r:file_t         lost+found
+-rw-------  postgres postgres system_u:object_r:postgresql_log_t pgstartup.log
+$ ls -Z /var/lib/pgsql
+drwx------  postgres postgres system_u:object_r:var_lib_t      backups
+drwx------  postgres postgres system_u:object_r:postgresql_db_t data
+-rw-------  postgres postgres system_u:object_r:postgresql_log_t pgstartup.log</pre>
+
+Which looks correct.  At least our ownership, file attributes and file context all match the original.  Note that I left the context of some things as system_u:object_r:var_t instead of system_u:object_r:var_lib_t.
+
+Now for the hard part, we have to look at ALL of the subdirectory contents under /var/lib/pgsql and match them up in the new location:
+
+<pre>$ cd /var/lib/pgsql ; ls -RZ
+.:
+drwx------  postgres postgres system_u:object_r:var_lib_t      backups
+drwx------  postgres postgres system_u:object_r:postgresql_db_t data
+-rw-------  postgres postgres system_u:object_r:postgresql_log_t pgstartup.log
+
+./backups:
+
+./data:
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  base
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  global
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  pg_clog
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  pg_hba.conf
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  pg_ident.conf
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  pg_log
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  pg_multixact
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  pg_subtrans
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  pg_tblspc
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  pg_twophase
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  PG_VERSION
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  pg_xlog
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  postgresql.conf
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t postmaster.opts
+
+./data/base:
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  1
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  10792
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  10793
+
+./data/base/1:
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10287
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10289
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10293
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10295
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10299
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10301
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10302
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10304
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10305
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10307
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10308
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10310
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10723
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10725
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10727
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10728
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10730
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10732
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10733
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10735
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10737
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10738
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10740
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10742
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10743
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10745
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10747
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10748
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10750
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10752
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1247
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1248
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1249
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1250
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1255
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1259
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2600
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2601
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2602
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2603
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2604
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2605
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2606
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2607
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2608
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2609
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2610
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2611
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2612
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2613
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2614
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2615
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2616
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2617
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2618
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2619
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2620
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2650
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2651
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2652
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2653
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2654
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2655
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2656
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2657
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2658
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2659
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2660
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2661
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2662
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2663
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2664
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2665
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2666
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2667
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2668
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2669
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2670
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2673
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2674
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2675
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2678
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2679
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2680
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2681
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2682
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2683
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2684
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2685
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2686
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2687
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2688
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2689
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2690
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2691
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2692
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2693
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2696
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2699
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2700
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2701
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2702
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2703
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2704
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  PG_VERSION
+
+./data/base/10792:
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10287
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10289
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10293
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10295
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10299
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10301
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10302
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10304
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10305
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10307
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10308
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10310
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10723
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10725
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10727
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10728
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10730
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10732
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10733
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10735
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10737
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10738
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10740
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10742
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10743
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10745
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10747
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10748
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10750
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10752
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1247
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1248
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1249
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1250
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1255
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1259
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2600
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2601
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2602
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2603
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2604
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2605
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2606
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2607
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2608
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2609
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2610
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2611
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2612
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2613
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2614
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2615
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2616
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2617
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2618
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2619
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2620
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2650
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2651
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2652
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2653
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2654
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2655
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2656
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2657
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2658
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2659
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2660
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2661
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2662
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2663
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2664
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2665
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2666
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2667
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2668
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2669
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2670
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2673
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2674
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2675
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2678
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2679
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2680
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2681
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2682
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2683
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2684
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2685
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2686
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2687
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2688
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2689
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2690
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2691
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2692
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2693
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2696
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2699
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2700
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2701
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2702
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2703
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2704
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  PG_VERSION
+
+./data/base/10793:
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10287
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10289
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10293
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10295
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10299
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10301
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10302
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10304
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10305
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10307
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10308
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10310
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10723
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10725
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10727
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10728
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10730
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10732
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10733
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10735
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10737
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10738
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10740
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10742
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10743
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10745
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10747
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10748
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10750
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10752
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1247
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1248
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1249
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1250
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1255
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1259
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2600
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2601
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2602
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2603
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2604
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2605
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2606
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2607
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2608
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2609
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2610
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2611
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2612
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2613
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2614
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2615
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2616
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2617
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2618
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2619
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2620
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2650
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2651
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2652
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2653
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2654
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2655
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2656
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2657
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2658
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2659
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2660
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2661
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2662
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2663
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2664
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2665
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2666
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2667
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2668
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2669
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2670
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2673
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2674
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2675
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2678
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2679
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2680
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2681
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2682
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2683
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2684
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2685
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2686
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2687
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2688
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2689
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2690
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2691
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2692
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2693
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2696
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2699
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2700
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2701
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2702
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2703
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2704
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t pg_internal.init
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  PG_VERSION
+
+./data/global:
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10290
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10292
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10296
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  10298
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1136
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1137
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1213
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1214
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1232
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1233
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1260
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1261
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  1262
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2671
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2672
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2676
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2677
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2694
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2695
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2697
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  2698
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t pg_auth
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  pg_control
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t pg_database
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t pg_fsm.cache
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t pgstat.stat
+
+./data/pg_clog:
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  0000
+
+./data/pg_log:
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t postgresql-Mon.log
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t postgresql-Sat.log
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t postgresql-Sun.log
+-rw-------  postgres postgres system_u:object_r:postgresql_db_t postgresql-Tue.log
+
+./data/pg_multixact:
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  members
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  offsets
+
+./data/pg_multixact/members:
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  0000
+
+./data/pg_multixact/offsets:
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  0000
+
+./data/pg_subtrans:
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  0000
+
+./data/pg_tblspc:
+
+./data/pg_twophase:
+
+./data/pg_xlog:
+-rw-------  postgres postgres user_u:object_r:postgresql_db_t  000000010000000000000000
+drwx------  postgres postgres user_u:object_r:postgresql_db_t  archive_status
+
+./data/pg_xlog/archive_status:
+$</pre>
+
+Keep that list open in a text editor, or something else because you'll need to refer to it frequently.  We can fix most of it by making everything set to context "user_u:object_r:postgresql_db_t" to start.  Which is a brute-force approach.
+
+$ chcon -R user_u:object_r:postgresql_db_t *
+
+Now we can go and start fixing things that should not be that particular context.  Now, it's quite probable that this is overkill, but I believe in being thorough.
+
+<pre>$ chcon system_u:object_r:postgresql_db_t postmaster.opts
+$ find . -name pg_internal.init -exec chcon system_u:object_r:postgresql_db_t {} \;
+$ chcon system_u:object_r:postgresql_db_t global/pg_auth
+$ chcon system_u:object_r:postgresql_db_t global/pg_database
+$ chcon system_u:object_r:postgresql_db_t global/pg_fsm.cache
+(file may not exist)
+$ chcon system_u:object_r:postgresql_db_t global/pgstat.stat
+$ chcon system_u:object_r:postgresql_db_t pg_log/postgresql-*.log</pre>
+
+At this point, your postgresql data directory SHOULD be configured correctly.  (No guarantees!)  So now you can restart postgresql (/etc/init.d/postgresql start) and it will work properly in the new location.
+
+Notes:
+
+- Tested on CentOS 5 (or CentOS 5.1), it should also work on RedHat Linux.
+
+- If you ever re-tag the entire filesystem with SELinux, you will (probably) have to go back and re-tag your postgresql data directory.
+
+- Because of the above note, it may be better to mount the LVM or SAN partition for PostgreSQL at the default location of /var/lib/pgsql instead of forcing it into another location.  On the other hand, as long as you know how to fix it and don't re-tag indiscriminately, SELinux should never get in the way again.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PostgreSQL.shtml">PostgreSQL</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[13:42](http://www.tgharold.com/techblog/2008/03/postgresql-81-under-nondefault.shtml)
+
+		</div>

--- a/_posts/2008/2008-04-15-methods-ofr-remote-gui-control-of-linux-servers.md
+++ b/_posts/2008/2008-04-15-methods-ofr-remote-gui-control-of-linux-servers.md
@@ -1,0 +1,41 @@
+---
+layout: post
+title: 'Methods ofr remote GUI control of Linux servers'
+date: '2008-04-15T18:53:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>There are currently (3) basic methods for getting a remote control GUI on a Linux server (like we do with Remote Desktop for Windows servers):
+
+1) X-Windows over TCP/IP
+
+All GUI operations on Unix/Linux are handled by the X-Windows sub-system.  Window interfaces like KDE, Gnome, and others are merely layered on top of the X sub-system.  One of the useful things about X is that any window can be forwarded over TCP/IP to any other X server.  So you could run an application on the linux server, but display the output window on your PC (as long as you run a local X server program).
+
+The downside of all this is that accessing remote servers requires the use of SSH port forwarding, and a bit of arcane magic.  It's nowhere near as clean of a solution as RDP (Terminal Services).  But it can be ultra-secure (by using SSH keys) and it works fairly well across the WAN.
+
+2) VNC
+
+VNC is a screen-scraper solution for GUI desktops, very similar to the old pcAnywhere and e/pop solutions that we used to use.
+
+The downsides of VNC are:
+- security is non-existent in the base spec
+- different VNC server use different encryptions
+- authentication tends to be done via plain text passwords
+- rather slow across the WAN
+
+3) NX/FreeNX
+
+A company called NoMachines came out with a different solution called "NX".  NX is a protocol that is very similar to RDP and the client works rather similar to Remote Desktop.  You used to have to pay for the product, but over the years, they've opened up the source code.  So now there are (3) different server implementations (NX, FreeNX, and another) and you can download the NX client from NoMachines for free. 
+
+The big advantage here is that security is better and performance is better over slow WAN links.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FreeNX.shtml">FreeNX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Linux.shtml">Linux</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NX.shtml">NX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VNC.shtml">VNC</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/X11.shtml">X11</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[18:53](http://www.tgharold.com/techblog/2008/04/methods-ofr-remote-gui-control-of-linux.shtml)
+
+		</div>

--- a/_posts/2008/2008-05-18-freenxnx-security.md
+++ b/_posts/2008/2008-05-18-freenxnx-security.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: 'FreeNX/NX Security'
+date: '2008-05-18T18:55:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>After mucking around with NX/FreeNX, I have a general understanding of how it works, how to lock down your server and what some of the security ramifications are.
+
+<b>First line of defense - NX user key pair</b>
+
+NX/FreeNX clients connect to your Linux server using a special user account (always named "nx") via your SSH service.  This user can login using a SSH public/private key pair, which means better security and control over who can attempt to connect to the NX server daemon.   However, the default NX server ships with a pre-defined public key pair, which renders this line of defense useless.
+
+(That statement is based on the freenx.x86_64 package (v0.7) currently available as an RPM.)
+
+The server's key files are located under the following names on CentOS/RedHat:
+
+Public Key: /etc/nxserver/server.id_dsa.pub.key
+Private Key: /etc/nxserver/client.id_dsa.key
+
+The <b>private</b> key is what needs to be handed out to your users.  They will then place this private key into their NX client configurations in order to login and talk to the NX server.
+
+The official NX server has a "--keygen" command that can be used to create a new key pair for increased security.  But FreeNX 0.7 does not currently feature that ability.  Instead, we must use the ssh-keygen command (part of OpenSSH) to create new key files.  Make sure that you make backup copies of the above key files before using the following commands.
+
+Note: DSA keys are always 1024 bits.
+
+<b># cd /etc/nxserver/
+# ssh-keygen -t dsa -f /etc/nxserver/new-dsa-key -N ''
+# mv client.id_dsa.key client.id_dsa.key.OLD
+# mv server.id_dsa.pub.key server.id_dsa.pub.key.OLD
+# mv new-dsa-key client.id_dsa.key
+# mv new-dsa-key.pub server.id_dsa.pub.key
+# service freenx-server restart
+# cat server.id_dsa.pub.key
+# /var/lib/nxserver/home/.ssh
+# vi authorized_keys2</b>
+
+You will then need to change the old key line to match the new public key.  At this point, until you update any clients with the new private key file (client.id_dsa.key), they will be unable to connect to the server.
+
+<b># cat /etc/nxserver/client.id_dsa.key</b>
+
+Note: FreeNX seemingly stores the client.id_dsa.key in two places (/etc/nxserver and under /var/lib/nxserver/home/.ssh).
+
+<b>Second line of defense - sshd_config</b>
+
+The default FreeNX install on CentOS/RedHat requires that your users can authenticate via passwords to SSH.  Obviously, not ideal, but we'll cover that in a few minutes.  For the moment, make sure that your /etc/ssh/sshd_config file contains the following settings:
+
+PermitRootLogin no
+PasswordAuthentication yes
+
+You should now be able to login using the NX client software to your server.  The username should be an account in /etc/passwd for which you know the password.
+
+<b>Locking down SSH #1 - use a non-standard port</b>
+
+For servers that face the public internet, using the default SSH port of 22 is an open invitation for people to try and crack your SSH server (dictionary attacks, brute-force, overflows).  While SSH using only public keys is very secure, all of the attack attempts will generate entries in your logs and are basically a nuisance.
+
+Probably one of the easiest fixes to avoid most brute-force attacks is to run SSH on a non-standard port.  This requires making two changes (and you'll need to let anyone else who talks to your servers via SSH know about the port change):
+
+1) Change the port number in /etc/ssh/sshd_config:
+
+#Port 22
+Port 9822
+
+2) Change /etc/nxserver/node.conf
+
+#SSHD_PORT=22
+SSHD_PORT=9822
+
+3) Restart the two services
+
+# service freenx-server restart
+# service sshd restart
+
+When you connect with the NX client, you will have to remember to specify the non-standard port number in the connection details.
+
+<b>Re-locking SSH, closing the password authentication hole</b>
+
+Key links:
+
+[[FreeNX-kNX] FreeNX, SSH, and su](http://mail.kde.org/pipermail/freenx-knx/2005-July/001596.html)
+[Re: [SLE] Resolved - Setting up NXfree to use ssh keys](http://lists.suse.de/opensuse/2006-04/msg01979.html)
+[How to remote desktop using SSH and FreeNX ](http://ubuntuforums.org/showthread.php?t=467219)
+
+Now that we've gotten NX working using password authentication, it's time to close that hole back up.  In order to do this, you have two choices:
+
+...
+
+(Someday I'll finish this post.  Probably have to run 2 copies of sshd, with different security settings.)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FreeNX.shtml">FreeNX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NX.shtml">NX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[18:55](http://www.tgharold.com/techblog/2008/05/freenxnx-security.shtml)
+
+		</div>

--- a/_posts/2008/2008-06-28-fsvs---install-on-centos-5.md
+++ b/_posts/2008/2008-06-28-fsvs---install-on-centos-5.md
@@ -1,0 +1,46 @@
+---
+layout: post
+title: 'FSVS - Install on CentOS 5'
+date: '2008-06-28T22:52:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>(Note: This has been mostly superseded by my newer post [FSVS: Install on CentOS 5.4](/techblog/2009/11/fsvs-install-on-centos-54.shtml))
+
+The following should be enough (and is probably overkill) to install all of the dependencies that FSVS 1.1.16 needs on CentOS 5 (and CentOS 5.1)
+
+# yum install subversion subversion-devel ctags apr apr-devel gcc gdbm gdbm-devel pcre pcre-devel apr-util-devel
+
+# ./configure
+configure: ***  Now configuring FSVS   ***
+checking for gcc... gcc
+checking for C compiler default output file name... a.out
+checking whether the C compiler works... yes
+checking whether we are cross compiling... no
+checking for suffix of executables... 
+checking for suffix of object files... o
+checking whether we are using the GNU C compiler... yes
+checking whether gcc accepts -g... yes
+checking for gcc option to accept ISO C89... none needed
+checking how to run the C preprocessor... gcc -E
+configure: "CFLAGS=-g -O2 -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 -idirafter /usr/local/include -idirafter /usr/include -idirafter /openpkg/include -idirafter /usr/include/apr-1"
+configure: "LDFLAGS= -L/usr/local/lib -L/openpkg/lib"
+checking for pcre_compile in -lpcre... yes
+checking for apr_md5_init in -laprutil-1... no
+configure: error: Sorry, can't find APR.
+See `config.log' for more details.
+
+Note the addition of "apr-util-devel" at the end of the "yum install" line.  This fixes the error when you run ./configure for FSVS and get the "can't find APR" error.
+
+In older versions of CentOS 5, we did not need to also specify the apr-util-devel package.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FSVS.shtml">FSVS</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[22:52](http://www.tgharold.com/techblog/2008/06/fsvs-install-on-centos-5.shtml)
+
+		</div>

--- a/_posts/2008/2008-07-14-fsvs-urls-or-fsvs-initialize-results-in-no-such-file-or-directory-2-error.md
+++ b/_posts/2008/2008-07-14-fsvs-urls-or-fsvs-initialize-results-in-no-such-file-or-directory-2-error.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title: 'fsvs urls or fsvs initialize results in No such file or directory (2) error'
+date: '2008-07-14T14:50:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>So I was setting up FSVS 1.1.16 on a new CentOS 5.1 box this week (one of the first things that I do as soon as possible before configuration starts).  And I encountered the following error:
+
+# fsvs -v urls svn+ssh://svn.example.com/sys-machinename
+
+An error occurred at 14:40:31.865: No such file or directory (2)
+  in url__output_list
+  in url__work
+  in main: action urls failed
+
+...
+
+The fix is to create the "/etc/fsvs" folder
+
+fsvs 1.1.16 was smart enough to remind me to create /var/spool/fsvs, but it apparently doesn't give a good error message when the "/etc/fsvs" folder does not exist.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FSVS.shtml">FSVS</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[14:50](http://www.tgharold.com/techblog/2008/07/fsvs-urls-or-fsvs-initialize-results-in.shtml)
+
+		</div>

--- a/_posts/2008/2008-07-28-dovecot---cmusieve-errors.md
+++ b/_posts/2008/2008-07-28-dovecot---cmusieve-errors.md
@@ -1,0 +1,41 @@
+---
+layout: post
+title: 'Dovecot - CMUSieve Errors'
+date: '2008-07-28T11:17:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>After upgrading our CentOS 5 box to the latest revisions this week (including Dovecot 1.1), we're seeing the following error message in the log files.  Sieve was working fine with Dovecot 1.0.
+
+# cat /var/vmail/dovecot-deliver.log
+
+deliver(ruth@example.com): Jul 28 11:11:44 Error: dlopen(/usr/lib64/dovecot/lda/lib90_cmusieve_plugin.so) failed: /usr/lib64/dovecot/lda/lib90_cmusieve_plugin.so: undefined symbol: message_decoder_init
+deliver(ruth@example.com): Jul 28 11:11:44 Fatal: Couldn't load required plugins
+
+# ls -l /usr/libexec/dovecot/sievec
+-rwxr-xr-x 1 root root 165152 Jun 11 03:21 /usr/libexec/dovecot/sievec
+
+# yum list | grep "dovecot"
+dovecot.x86_64                           1:1.1.1-2_76.el5       installed       
+dovecot-sieve.x86_64                     1.1.5-8.el5            installed       
+dovecot.x86_64                           1:1.1.2-2_77.el5       atrpms          
+dovecot-devel.x86_64                     1:1.1.2-2_77.el5       atrpms 
+
+Not sure yet what went wrong during the upgrade.
+
+...
+
+Update: The problem was that we had made a copy of Dovecot's "deliver" executable to make it setuid to work with virtual user local delivery.  After the update, we forgot to update this copy of the exectuable.
+
+Once we updated the setuid copy of "deliver", things worked fine.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Dovecot.shtml">Dovecot</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SMTP.shtml">SMTP</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[11:17](http://www.tgharold.com/techblog/2008/07/dovecot-cmusieve-errors.shtml)
+
+		</div>

--- a/_posts/2008/2008-08-01-nggjs-and-fggjs-site-infections.md
+++ b/_posts/2008/2008-08-01-nggjs-and-fggjs-site-infections.md
@@ -1,0 +1,41 @@
+---
+layout: post
+title: 'ngg.js and fgg.js site infections'
+date: '2008-08-01T14:51:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>One of our users visited a website that was infected with the ngg.js and fgg.js codes (they get injected into the HTML files on the server towards the end of the page).
+
+We've blocked it in our squid configuration by:
+
+# squid.conf
+
+acl blocked_urls dstdomain "/etc/squid/blocked_urls.squid"
+acl blocked_regex urlpath_regex "/etc/squid/blocked_regex.squid"
+
+# Block some URLs
+http_access deny blocked_urls
+http_access deny blocked_regex
+
+# blocked_urls.squid
+.bjxt.ru
+.njep.ru
+.uhwc.ru
+
+# blocked_regexp.squid
+/fgg\.js
+/ngg\.js
+
+I won't explain this too much except to say that the blocked_urls file is designed to block top-level domains, while the regexp file is for blocking URLs using a regular expression.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Squid.shtml">Squid</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[14:51](http://www.tgharold.com/techblog/2008/08/nggjs-and-fggjs-site-infections.shtml)
+
+		</div>

--- a/_posts/2008/2008-08-06-linux-raid-tuning-and-troubleshooting.md
+++ b/_posts/2008/2008-08-06-linux-raid-tuning-and-troubleshooting.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: 'Linux RAID tuning and troubleshooting'
+date: '2008-08-06T08:44:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Ran across this while searching another topic.
+
+[http://makarevitch.org/rant/raid/](http://makarevitch.org/rant/raid/)<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[08:44](http://www.tgharold.com/techblog/2008/08/linux-raid-tuning-and-troubleshooting.shtml)
+
+		</div>

--- a/_posts/2008/2008-08-08-debugging-ssl-connections.md
+++ b/_posts/2008/2008-08-08-debugging-ssl-connections.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: 'Debugging SSL connections'
+date: '2008-08-08T00:00:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>We're experiencing odd delays when talking to our mail server over SMTPS (SSL).  I just found this post which helps us debug it.
+
+[How to debug SSL SMTP - by S](http://www.wains.be/index.php/2007/08/11/how-to-debug-ssl-smtp/)

--- a/_posts/2008/2008-09-30-selinux---dealing-with-exceptions.md
+++ b/_posts/2008/2008-09-30-selinux---dealing-with-exceptions.md
@@ -1,0 +1,36 @@
+---
+layout: post
+title: 'SELinux - dealing with exceptions'
+date: '2008-09-30T11:38:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>So we're seeing errors in our /var/log/messages like:
+
+Sep 28 03:52:51 fvs-pri setroubleshoot: SELinux is preventing freshclam (freshclam_t) "read" to ./main.cld (var_t). For complete SEL
+inux messages. run sealert -l 10ce7bfb-6c44-473e-94a1-4691c04d2bef
+Sep 28 03:52:51 fvs-pri setroubleshoot: SELinux is preventing freshclam (freshclam_t) "write" to ./clamav (var_t). For complete SELi
+nux messages. run sealert -l 276efeb4-6990-497f-bcf0-6df0327c6f52
+
+It's fairly easy to write exceptions, using audit2allow.
+
+For example:
+
+# cd /usr/share/selinux/devel/
+
+# egrep "(clam)" /var/log/audit/audit.log /var/log/audit/audit.log.1 | audit2allow -M clam20081230
+
+# /usr/sbin/semodule -i clam20080930.pp
+
+Note: This is the very quick and dirty way of dealing with exceptions - it really doesn't fix the underlying issue.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[11:38](http://www.tgharold.com/techblog/2008/09/selinux-dealing-with-exceptions.shtml)
+
+		</div>

--- a/_posts/2008/2008-10-27-current-frustrations-with-thunderbird.md
+++ b/_posts/2008/2008-10-27-current-frustrations-with-thunderbird.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: 'Current frustrations with Thunderbird'
+date: '2008-10-27T11:00:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>I'm currently plagued by the following showing up in my error console in Thunderbird 2.0.0.17 (20080914).
+
+<code>Error: uncaught exception: [Exception... "Component returned failure code: 0x80550006 [nsIMsgFolder.getMsgDatabase]"  nsresult: "0x80550006 (<unknown>)"  location: "JS frame :: chrome://messenger/content/mailWidgets.xml :: parseFolder :: line 2061"  data: no]</unknown></code>
+
+The other thing that happens is that eventually, Thunderbird stops talking (hangs) to my IMAP mail server (over SSL).  So I'm unable to send e-mail messages over SMTP/SSL (port 465), or am I able to retrieve any messages from our IMAP (Dovecot over SSL) server until I restart Thunderbird.
+
+It can take anywhere from 5 minutes to 5 hours for this problem to occur.  Starting in safe mode fixes some of the issue, but Thunderbird still chokes up after I've hit a few dozen IMAP folders to get new headers and to download messages.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/IMAP.shtml">IMAP</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Thunderbird.shtml">Thunderbird</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[11:00](http://www.tgharold.com/techblog/2008/11/current-frustrations-with-thunderbird.shtml)
+
+		</div>

--- a/_posts/2008/2008-11-04-update-1-to-current-frustrations-with-thunderbird.md
+++ b/_posts/2008/2008-11-04-update-1-to-current-frustrations-with-thunderbird.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: 'Update #1 to Current frustrations with Thunderbird'
+date: '2008-11-04T07:28:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Well, I started up Thunderbird in safe mode.  If you have installed Thunderbird in the default location, that's as easy as pressing [Windows-R] (or Start, Run...) and entering the following:
+
+C:\Program Files\Mozilla Thunderbird\thunderbird.exe -safe-mode
+
+What I found is that, although the error still occurred, Thunderbird was a lot better about not hanging up while retrieving e-mail from large IMAP mailboxes.
+
+So I'm going to uninstall most of my add-ons and see if I can make things work better.  Disabling the add-ons didn't have any effect, so I think I'll have to completely remove most of them instead.
+
+To give you an idea of what I consider "large".  I have an IMAP account on our mail server that contains 17GB (2,000,000 messages) worth of e-mail.  I have another two accounts that contain 1.7GB (40,000 messages) and 2.5GB (200,000 messages) respectively.  However, none of the individual IMAP folders have more then 60,000 messages each.  And most of the large folders only have 15,000 to 30,000 messages.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Thunderbird.shtml">Thunderbird</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[07:28](http://www.tgharold.com/techblog/2008/11/update-1-to-current-frustrations-with.shtml)
+
+		</div>

--- a/_posts/2008/2008-11-11-new-smartphone.md
+++ b/_posts/2008/2008-11-11-new-smartphone.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: 'New smartphone?'
+date: '2008-11-11T09:07:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>I'm sorta in the market for a new smartphone.  What I have now is a Motorola Q from 2006.  I've been mostly happy with it (except that it wasn't a touchscreen device), but it's been giving me more and more trouble lately.  And the cell coverage by Verizon is, frankly, horrid at my current place of residence.  Which makes the phone rather useless for me at home.
+
+Back when I bought the MotoQ, I made the mistake of not researching software requirements before buying.  I didn't understand that the non-touchscreen version of Windows Mobile was not the same as the touchscreen version of Windows Mobile.  Which means that there are a lot of applications that I simply cannot run on the MotoQ (especially Pocket Quicken).
+
+So this time around, I'm going to go in the opposite direction and look at the software that I want to run, then decide what devices will run it.
+
+<b>[Pocket Quicken](http://landware.com/pocketquicken/)</b>
+
+Oh look, Pocket Quicken now supports the non-touchscreen phones like MotoQ.  Basically, I can go with anything except an iPhone or a Blackberry.  
+
+<b>[CityTime Alarms](http://www.codecity.net/prodctappc.htm)</b>
+
+Only works with Windows Mobile 5 &amp; 6, or the PPC 2003 version. But there are also versions for SmartPhones and Palm OS.
+
+<b>[Agenda One](http://www.developerone.com/agendaone/)</b>
+
+Windows Mobile 5 &amp; 6.
+
+<b>[IM+](http://www.shapeservices.com/en/products/details.php?product=im)</b>
+
+BlackBerry, Windows Mobile, Symbian, J2ME, Palm OS and iPhone/iPod Touch! 
+
+<b>[zaTelnet Professional](http://www.zatelnet.com/zap/main.php)</b>
+
+MS Smartphones and Pocket PC<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/MotorolaQ.shtml">MotorolaQ</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SmartPhones.shtml">SmartPhones</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[09:07](http://www.tgharold.com/techblog/2008/11/new-smartphone.shtml)
+
+		</div>

--- a/_posts/2008/2008-11-24-dovecot---upgrading-notes.md
+++ b/_posts/2008/2008-11-24-dovecot---upgrading-notes.md
@@ -1,0 +1,110 @@
+---
+layout: post
+title: 'Dovecot - Upgrading Notes'
+date: '2008-11-24T11:57:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>At the office, we're using a virtual Dovecot server where each person's mail folders are owned by an unique user in the Linux account system.  
+
+[Dovecot: Virtual Users](http://wiki.dovecot.org/VirtualUsers) - covers the basics
+
+[Dovecot: UserIds](http://wiki.dovecot.org/UserIds#mailusers) - explains why we use different UIDs for different accounts
+
+[Dovecot: LDA](http://wiki.dovecot.org/LDA) - explains how to setup the "deliver" executable to deal with multiple user IDs.
+
+<i>Multiple UIDs
+
+If you're using more than one UID for users, you're going to have problems running deliver. Most MTAs won't let you run deliver as root, so for now you'll need to make it setuid root. However it's insecure to make deliver setuid-root, especially if you have untrusted users in your system. You should take extra steps to make sure that untrusted users can't run it and potentially gain root privileges. You can do this by placing deliver into a directory where only your MTA has execution access. </i>
+
+All of which means that whenever we update Dovecot with "yum update", we need to make sure that we fix up the Dovecot "deliver" executable file (which uses setuid) to also match.
+
+So let's figure out which "deliver" we need to fix up each time:
+
+<code># find / -name deliver
+/usr/local/libexec/dovecot/lda/deliver
+/usr/libexec/dovecot/deliver</code>
+
+Alternately, look at Postfix's master.cf file:
+
+<code># grep "deliver" /etc/postfix/master.cf
+# grep "deliver" /etc/postfix/master.cf
+# Many of the following services use the Postfix pipe(8) delivery
+# The Cyrus deliver program has changed incompatibly, multiple times.
+  flags=R user=cyrus argv=/usr/lib/cyrus-imapd/deliver -e -m ${extension} ${user}
+  user=cyrus argv=/usr/lib/cyrus-imapd/deliver -e -r ${sender} -m ${extension} ${user}
+# Other external delivery methods.
+     flags=DRhu user=vmail:vmail argv=/usr/local/libexec/dovecot/lda/deliver -f ${sender} -d ${recipient}
+#    flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}</code>
+
+The key line in that jumble being:
+
+<code>flags=DRhu user=vmail:vmail argv=/usr/local/libexec/dovecot/lda/deliver -f ${sender} -d ${recipient}</code>
+
+If we take a look at the file size, ownership, attributes and security settings (for SELinux):
+
+<code># cd /usr/libexec/dovecot/
+# ls -la deliver 
+-rwxr-xr-x 1 root root 802824 Jul 24 06:32 deliver
+# ls -lZ deliver 
+-rwxr-xr-x  root root system_u:object_r:dovecot_deliver_exec_t deliver
+
+# cd /usr/local/libexec/dovecot/
+# ls -la
+total 24
+drwx------ 2 vmail vmail 4096 Jun 16 23:00 lda
+# ls -lZ
+drwx------  vmail vmail system_u:object_r:bin_t          lda
+
+# cd /usr/local/libexec/dovecot/lda/
+# ls -la deliver
+-rwsr-xr-x 1 root root 802824 Aug 12 18:12 deliver
+# ls -lZ deliver
+-rwsr-xr-x  root root system_u:object_r:dovecot_deliver_exec_t deliver</code>
+
+What we see here is a couple of things regarding how the Dovecot LDA is setup.
+
+<ol>
+
+<li>The Postfix master.cf file controls which "deliver" gets used for local delivery of e-mail.  (The "deliver" executable is part of Dovecot, so we're using Dovecot for local delivery.)</li>
+
+<li>/usr/local/libexec/dovecot//lda/deliver - this is where our "setuid" version of the "deliver" executable is located</li>
+
+<li>The "lda" folder is owned by vmail:vmail (limited access) and only the vmail user can access the contents of the folder.  Postfix knows to use the vmail user because that's what we told it to do in the master.cf file.</li>
+
+<li>Both the official "deliver" executable (in the /usr/libexec/dovecot/ directory) and our "setuid" copy have the same byte size, date/time, and are both labled as "system_u:object_r:dovecot_deliver_exec_t" for SELinux.</li>
+
+</ol>
+
+The steps that we take when we update Dovecot are then:
+
+<ol>
+
+<li>
+<b>yum update dovecot</b> - updates the Dovecot executables to the latest version over at the <b>atrpms</b> repository</li>
+
+<li>
+<b>cp --no-preserve=all /usr/libexec/dovecot/deliver /usr/local/libexec/dovecot/lda/deliver</b> - copies the new deliver executable over to the lda folder where we will setuid on it</li>
+
+<li>
+<b>chmod u+s</b> is what we use to set the setuid bit on the copy in the lda folder, but we shouldn't need to do that once we set things up initially</li>
+
+<li>
+<b>service dovecot restart</b> - restarts the Dovecot service using the new executables</li>
+
+<li>
+<b>grep "AVC" /var/log/audit/audit.log | tail -n 50</b> - look for any errors relating to Dovecot</li>
+
+</ol>
+<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Dovecot.shtml">Dovecot</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[11:57](http://www.tgharold.com/techblog/2008/11/dovecot-upgrading-notes.shtml)
+
+		</div>

--- a/_posts/2008/2008-11-25-xen---issues-with-windows-domu-client-clocks.md
+++ b/_posts/2008/2008-11-25-xen---issues-with-windows-domu-client-clocks.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: 'Xen - Issues with Windows DomU client clocks'
+date: '2008-11-25T23:10:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+[Time is off by an hour in my XEN vm](http://www.nabble.com/Time-is-off-by-an-hour-in-my-XEN-vm-td16027741.html)
+
+Quote:
+
+There is a RealTimeIsUniversal registry flag hidden in the windows registry that can be set (its not in by default) to let Windows interpret the RTC as UTC as well.
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation] "RealTimeIsUniversal"=dword:00000001 
+
+Summary:
+
+The ultimate solution is to probably run an NTP client under the Windows environment to force the software clock to slave properly.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Win2000.shtml">Win2000</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Xen.shtml">Xen</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[23:10](http://www.tgharold.com/techblog/2008/11/xen-issues-with-windows-domu-client.shtml)
+
+		</div>

--- a/_posts/2008/2008-12-31-backfilling.md
+++ b/_posts/2008/2008-12-31-backfilling.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: 'Backfilling'
+date: '2008-12-31T18:42:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>Going to do a lot of backfill posts based on what I've been working on in the past year.  Most of it has to do with CentOS 5, PostgreSQL, LVM, Software RAID, with a smattering of other issues thrown in.<div style="clear:both; padding-bottom:0.25em"></div>
+Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/News.shtml">News</a>
+		<div class="Byline">
+			posted by Thomas at 
+			[18:42](http://www.tgharold.com/techblog/2008/12/backfilling.shtml)
+
+		</div>


### PR DESCRIPTION
## Summary
This PR converts all Blogger archive posts from 2008 to Jekyll markdown format, making them available for the blog.

## Changes
- Added 20 new blog posts in `_posts/2008/` directory
- All posts converted from `_archives/techblog/2008/*.shtml` files
- Maintains original content while converting to proper Jekyll format with frontmatter
- Follows existing conversion patterns established in the codebase

## Test plan
- All converted posts follow the standard Jekyll format
- Posts are properly categorized under the 2008 year
- Content integrity preserved during conversion
- No existing functionality affected

## Related
Continues the archive conversion effort, following the pattern from previous years (2004, 2005, 2006, 2007)

🤖 Generated with [Claude Code](https://claude.com/claude-code)