### PR TITLE
feat: Convert 2010 Blogger archive post to Jekyll format

### DIFF
--- a/_posts/2010/2010-06-23-this-blog-has-moved.md
+++ b/_posts/2010/2010-06-23-this-blog-has-moved.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: 'This blog has moved'
+date: '2010-06-23T08:16:00.000-05:00'
+author: Thomas Harold
+category:
+- Tech
+tags:
+- Technology
+---
+
+
+<div style="clear:both;"></div>
+
+       This blog is now located at http://techblog.tgharold.com/.
+       You will be automatically redirected in 30 seconds, or you may click [here](http://techblog.tgharold.com/).
+
+       For feed subscribers, please update your feed subscriptions to
+       http://techblog.tgharold.com/feeds/posts/default.
+  <div style="clear:both; padding-bottom:0.25em"></div>
+		<div class="Byline">
+			posted by Thomas at 
+			[08:16](http://www.tgharold.com/techblog/2010/06/this-blog-has-moved.shtml)
+
+		</div>


### PR DESCRIPTION
## Summary
This PR converts the 2010 Blogger archive post to Jekyll markdown format.

## Changes
- Added 1 new blog post in `_posts/2010/` directory
- Post converted from `_archives/techblog/2010/06/this-blog-has-moved.shtml`
- Maintains original content while converting to proper Jekyll format with frontmatter
- Follows existing conversion patterns established in the codebase

## Test plan
- Converted post follows the standard Jekyll format
- Post is properly categorized under the 2010 year
- Content integrity preserved during conversion
- No existing functionality affected

## Related
Continues the archive conversion effort, following the pattern from previous years (2004, 2005, 2006, 2007, 2008, 2009)

🤖 Generated with [Claude Code](https://claude.com/claude-code)