### PR TITLE
feat: Update permalink structure to include date components

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ baseurl: "/blog"
 sass:
   sass_dir: _sass
   style: compressed
-permalink: /:categories/:title/
+permalink: /:year-:month-:day-:title/
 kramdown:
   toc_levels: 1..2
 highlighter: rouge

--- a/_posts/2004/2004-06-14-xenus-link-sleuth.md
+++ b/_posts/2004/2004-06-14-xenus-link-sleuth.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: 'Xenu's Link Sleuth'
+title: "Xenu's Link Sleuth"
 date: '2004-06-14T12:00:00.000-05:00'
 author: Thomas Harold
 category:

--- a/_posts/2005/2005-04-24-gentoo-cant-create-lock-file.md
+++ b/_posts/2005/2005-04-24-gentoo-cant-create-lock-file.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: 'Gentoo: Can't create lock file'
+title: "Gentoo: Can't create lock file"
 date: '2005-04-24T00:10:00.000-05:00'
 author: Thomas Harold
 category:


### PR DESCRIPTION
This PR updates the Jekyll permalink structure to include date components in the URL format.

Changes made:
- Updated permalink configuration in _config.yml from /:categories/:title/ to /:year-:month-:day-:title/
- This creates cleaner URLs like /2004-04-28-gentoo-epia-install-part-3/
- Fixed YAML parsing issues in two posts that were preventing builds
- All posts now use the new permalink structure

The new format provides better organization and SEO benefits by including publication dates in URLs.