### PR TITLE
Clean up Blogger artifacts from blog posts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,3 +60,11 @@ To convert archive posts, use the provided conversion scripts:
 ## Commit Guidelines
 When creating git commits for these conversions, please include the following co-authored by line:
 Co-Authored-By: Qwen3-Coder-30B-A3B-Instruct-MLX-6bit <Claude Code>
+
+## Blogger Cleanup
+During the migration from Blogger to Jekyll, various artifacts were left behind in the blog post content. These included:
+- Blogger taglines (Labels: with tag links)
+- Byline information (posted by Thomas at [timestamp])
+- Formatting divs (<div style="clear:both; padding-bottom:0.25em"></div>)
+
+To clean up these conversion artifacts, a Python script was created and run to remove all instances of these elements from the blog posts, leaving only the clean, original content.

--- a/_posts/2004/2004-01-03-ipsec.md
+++ b/_posts/2004/2004-01-03-ipsec.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Trying to figure out IPSec again... hopefully turning it on on our Win2000 servers so that more and more network traffic will be encrypted at the office.  However, on my Windows XP laptop, I can't find the setting to start using IPSec.  The old Win2000 servers and workstations had an option under <i>Advanced TCP/IP Settings</i> called <i>IP Security</i> that would let me choose one of the following (3) options:
+Trying to figure out IPSec again... hopefully turning it on on our Win2000 servers so that more and more network traffic will be encrypted at the office.  However, on my Windows XP laptop, I can't find the setting to start using IPSec.  The old Win2000 servers and workstations had an option under <i>Advanced TCP/IP Settings</i> called <i>IP Security</i> that would let me choose one of the following (3) options:
 
 <b>Client (Respond Only)</b>
 Windows2000 clients should have this setting turned on.
@@ -21,10 +21,4 @@ Middle-of-the-road setting for servers operating in a mixed environment, it'll e
 <b>Secure Server (Require Security)</b>
 This is the golden option, if you have complete control over the environment (or have the time to go back and fix/upgrade everyone that is going to connect to your server) that will force all traffic to/from the server to be encrypted.  Turning this on will prevent non-domain computers from communicating with the server (e.g. I have a laptop from the office that I sometimes use to remote control my home servers).
 
-[resource links](http://www.securityfocus.com/infocus/1526) - check the end of this article for a list of links<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/IPSec.shtml">IPSec</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[16:16](http://www.tgharold.com/techblog/2004/01/ipsec.shtml)
-
-		</div>
+[resource links](http://www.securityfocus.com/infocus/1526) - check the end of this article for a list of links

--- a/_posts/2004/2004-02-10-revision-control-software.md
+++ b/_posts/2004/2004-02-10-revision-control-software.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [Subversion And CVS Comparison](http://wiki.gnuarch.org/moin.cgi/SubVersionAndCvsComparison)
 
 [Version Control System Comparison](http://better-scm.berlios.de/comparison/comparison.html)
@@ -19,10 +19,4 @@ tags:
 
 [The New Breed of Version Control Systems](http://www.onlamp.com/pub/a/onlamp/2004/01/29/scm_overview.html)
 
-[Version Control System Comparison](http://better-scm.berlios.de/comparison/comparison.html)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:45](http://www.tgharold.com/techblog/2004/02/revision-control-software.shtml)
-
-		</div>
+[Version Control System Comparison](http://better-scm.berlios.de/comparison/comparison.html)

--- a/_posts/2004/2004-03-11-bequest-scam-e-mail.md
+++ b/_posts/2004/2004-03-11-bequest-scam-e-mail.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Now here's a really new one... a message that Mozilla Thunderbird 0.4 thinks is spam, where the sender claims that I'm eligible for a 2.5 million bequest by some bloke who passed away last year.  I've been digging through the message text a few times trying to find the "gotcha" and it doesn't seem to be real obvious as to what the intent is other then them trying to find easy marks for further attempts.
+Now here's a really new one... a message that Mozilla Thunderbird 0.4 thinks is spam, where the sender claims that I'm eligible for a 2.5 million bequest by some bloke who passed away last year.  I've been digging through the message text a few times trying to find the "gotcha" and it doesn't seem to be real obvious as to what the intent is other then them trying to find easy marks for further attempts.
 
 The message is in HTML format, but I'm going to strip the codes and merely post the text version.
 
@@ -116,5 +116,4 @@ Other useful searches which turn up additional versions of the scam spam:
 "[John Ryerson made you a beneficiary to his will](http://www.google.com/search?hl=en&amp;lr=&amp;ie=UTF-8&amp;oe=UTF-8&amp;c2coff=1&amp;q=%22John+Ryerson+made+you+a+beneficiary+to+his+will%22&amp;btnG=Google+Search)"
 "[Being a widely traveled man](http://www.google.com/search?hl=en&amp;lr=&amp;ie=UTF-8&amp;oe=UTF-8&amp;c2coff=1&amp;q=%22Being+a+widely+traveled+man%22&amp;btnG=Google+Search)"
 "[former managing director and pioneer staff of a giant construction company](http://www.google.com/search?hl=en&amp;lr=&amp;ie=UTF-8&amp;oe=UTF-8&amp;c2coff=1&amp;q=%22former+managing+director+and+pioneer+staff+of+a+giant+construction+company%22&amp;btnG=Google+Search)"
-"[died on the 9th day of February 2002](http://www.google.com/search?hl=en&amp;lr=&amp;ie=UTF-8&amp;oe=UTF-8&amp;c2coff=1&amp;q=%22died+on+the+9th+day+of+February+2002%22&amp;btnG=Google+Search)"<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>		<div class="Byline">			posted by Thomas at 			[08:41](http://www.tgharold.com/techblog/2004/03/bequest-scam-e-mail.shtml)								</div>	</rev_davidwink8></tgh></tgh></tgh></rev_davidwink8>
+"[died on the 9th day of February 2002](http://www.google.com/search?hl=en&amp;lr=&amp;ie=UTF-8&amp;oe=UTF-8&amp;c2coff=1&amp;q=%22died+on+the+9th+day+of+February+2002%22&amp;btnG=Google+Search)"

--- a/_posts/2004/2004-04-24-gentoo-partitioning-plans.md
+++ b/_posts/2004/2004-04-24-gentoo-partitioning-plans.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [ [gentoo-user] Help with new system](http://groups.google.com/groups?hl=en&amp;lr=&amp;ie=UTF-8&amp;oe=UTF-8&amp;c2coff=1&amp;selm=16ucP-pC-7%40gated-at.bofh.it) (discusses partition sizes)
 
 Possible partitions:
@@ -78,10 +78,4 @@ DISK 2:
 /tmp ext2 4GB
 /var/tmp ext2 8GB
 (root mirror) 2GB
-(backup partition)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[02:49](http://www.tgharold.com/techblog/2004/04/gentoo-partitioning-plans.shtml)
-
-		</div>
+(backup partition)

--- a/_posts/2004/2004-04-24-linix-distros-for-a-mini-itx-server.md
+++ b/_posts/2004/2004-04-24-linix-distros-for-a-mini-itx-server.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I'm going to build a mini-ITX file server using linux with part of my tax refund, so I'm busy trying to figure out which distro to use.  So far the list is RedHat 8/9, Suse Linux 9.something, Debian, Mandrake 9.1 or 10.0 (not out yet), or Gentoo.  
+I'm going to build a mini-ITX file server using linux with part of my tax refund, so I'm busy trying to figure out which distro to use.  So far the list is RedHat 8/9, Suse Linux 9.something, Debian, Mandrake 9.1 or 10.0 (not out yet), or Gentoo.  
 
 Yesterday, I was leaning towards Mandrake 9.1.  I have the 3 CDs downloaded, but looking around I'm not sure that Samba 3.x (for file serving) is included in the 9.1 distro that I have.  Plus, 9.1 is 6-10 months old (Aug 2003?), so support and updates would be drying up sooner then a newer release.  I'd consider 10.0, but the ISOs aren't released yet, and there's also some questions that I have about support.
 
@@ -20,10 +20,4 @@ So right now, I'm seriously considering going hardcore and using Gentoo.  I'm no
 
 Now I just need to plow through all of the [Gentoo articles on SlashDot](http://slashdot.org/search.pl?query=gentoo&amp;op=stories&amp;author=&amp;tid=&amp;section=&amp;sort=1).  (Usually, if you read at level 2 or 3 you can get a good overview of what techies think about a particular product.)
 
-The EPIA box is going to cost around $500.  I went with the ME6000 board (fanless), 512MB DDR266 of memory, and the Morex Venus 668 Black case (from logicsupply.com) for $340.  Add a black floppy and DVD drive and a 160GB 5400rpm drive for another $160.  Should be a dead-quiet little file server.  I'll probably add another 160GB drive in a few weeks once I get the system up and running.  Plus, it'll give me a linux box to install [PostgreSQL](http://www.postgresql.org/) on so I can evaluate moving away from MySQL.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[00:05](http://www.tgharold.com/techblog/2004/04/linix-distros-for-mini-itx-server.shtml)
-
-		</div>
+The EPIA box is going to cost around $500.  I went with the ME6000 board (fanless), 512MB DDR266 of memory, and the Morex Venus 668 Black case (from logicsupply.com) for $340.  Add a black floppy and DVD drive and a 160GB 5400rpm drive for another $160.  Should be a dead-quiet little file server.  I'll probably add another 160GB drive in a few weeks once I get the system up and running.  Plus, it'll give me a linux box to install [PostgreSQL](http://www.postgresql.org/) on so I can evaluate moving away from MySQL.

--- a/_posts/2004/2004-04-27-gentoo-epia-install-part-1.md
+++ b/_posts/2004/2004-04-27-gentoo-epia-install-part-1.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So... [time to install Gentoo](http://www.gentoo.org/doc/en/handbook/index.xml) (also see [epiawiki.org - Installing Gentoo on an EPIA system](http://www.alterself.com/~epia/wiki/tiki-index.php?page=EpiaInstallingGentoo)).  A good book to have handy during the install is "Linux in a Nutshell", especially for looking up option flags for the various commands.
+So... [time to install Gentoo](http://www.gentoo.org/doc/en/handbook/index.xml) (also see [epiawiki.org - Installing Gentoo on an EPIA system](http://www.alterself.com/~epia/wiki/tiki-index.php?page=EpiaInstallingGentoo)).  A good book to have handy during the install is "Linux in a Nutshell", especially for looking up option flags for the various commands.
 
 Popped the boot CD ([Universal CD](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=2) for 2004.0 Gentoo) in and let it boot up.  It reports my hardware as a "VIA Samuel 2 599MHz, 64KB cache".  It's now sitting at the '#' prompt (er, shell prompt).  When I was setting up the BIOS, I changed the shared memory for the video card from 128MB (default) to 32MB.  I also disabled things like the audio ports, serial ports, parallel port, leaving only ethernet, firewire and USB.
 
@@ -93,10 +93,4 @@ And the "proc" file system (last bit of chapter 4e in the handbook)
 mkdir /mnt/gentoo/proc
 mount -t proc none /mnt/gentoo/proc
 
-Taking a break for a bit. ([continued in next post](/techblog/2004/04/gentoo-epia-install-part-2.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[16:54](http://www.tgharold.com/techblog/2004/04/gentoo-epia-install-part-1.shtml)
-
-		</div>
+Taking a break for a bit. ([continued in next post](/techblog/2004/04/gentoo-epia-install-part-2.shtml))

--- a/_posts/2004/2004-04-27-gentoo-epia-install-part-2.md
+++ b/_posts/2004/2004-04-27-gentoo-epia-install-part-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Picking up at [chapter 5c of the Gentoo Handbook, Using a Stage from the LiveCD](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=5).  (Also see my [previous post](/techblog/2004/04/gentoo-epia-install-part-1.shtml) where I configured the disks.)  Here is where it gets fun...  I'm going to try starting with the x86 stage1 file:
+Picking up at [chapter 5c of the Gentoo Handbook, Using a Stage from the LiveCD](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=5).  (Also see my [previous post](/techblog/2004/04/gentoo-epia-install-part-1.shtml) where I configured the disks.)  Here is where it gets fun...  I'm going to try starting with the x86 stage1 file:
 
 cd /mnt/gentoo
 tar -xvjpf /mnt/cdrom/stages/stage1-x86-20040218.tar.bz2
@@ -36,11 +36,3 @@ USE=""
 CXXFLAGS="$(CFLAGS)"
 
 Onward to step 6, [Installing the Gentoo Base System](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=6).  The mirrorselect application chose "pair.com" as my mirror (which is fine, that's where I downloaded the ISOs from).  Alternate site is datapipe.net.  Not going to muck with the default USE flags at the moment, instead I'm going to step right into 6c (progressing from stage1 to stage2).  This will take a while (if it works!).
-
-([Next blog entry](/techblog/2004/04/gentoo-epia-install-part-3.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:31](http://www.tgharold.com/techblog/2004/04/gentoo-epia-install-part-2.shtml)
-
-		</div>

--- a/_posts/2004/2004-04-27-via-epia-gentoo-build.md
+++ b/_posts/2004/2004-04-27-via-epia-gentoo-build.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Got the VIA EPIA ME6000 system today.  Only gltich off the bat was that the first 7200rpm drive that I used draws slightly too much power which resulted in the system refusing to power-up.  (Hooking up an external 300W ATX power-supply proved that the components work fine.)  Fortunately, I had another 7200rpm laying around with lower power requirements.  (The problem drive was 500mA 3V 700mA 5V, the replacement drive is only 300mA 3V 500mA 5V.  Oddly, both drives are 80GB IBM DeskStars.)  A 5400rpm drive would've probably drawn even less power.  So my config at the moment (unless I change drives again):
+Got the VIA EPIA ME6000 system today.  Only gltich off the bat was that the first 7200rpm drive that I used draws slightly too much power which resulted in the system refusing to power-up.  (Hooking up an external 300W ATX power-supply proved that the components work fine.)  Fortunately, I had another 7200rpm laying around with lower power requirements.  (The problem drive was 500mA 3V 700mA 5V, the replacement drive is only 300mA 3V 500mA 5V.  Oddly, both drives are 80GB IBM DeskStars.)  A 5400rpm drive would've probably drawn even less power.  So my config at the moment (unless I change drives again):
 
 IDE0/PRI: 80GB IBM DeskStar 7200rpm
 IDE0/SEC: (nothing)
@@ -21,10 +21,4 @@ No PCI card installed, and a 3.5" floppy-drive up front.
 
 Now, the 120GB Western Digital has a nasty bearing whine at the moment, so I think I'll be swapping that out pretty quick for a better drive.  It's definitely the loudest thing in the case, and very annoying.  Haven't decided if I'll replace the 7200rpm drive with a 5400 as well (probably will, if only for power/heat reasons).  The new 160GB 5400rpm drive isn't slated to arrive until Thursday, which is why things are as they are for the moment.
 
-The Morex Venus 668 case isn't a bad little case, a bit larger then I expected.  Hold a pair of paperback books up, spine-to-spine and you'll get an idea of how big the front of it is.  Installing the components wasn't too bad, but it's best if you remove the power-supply during the initial installation and work from the bottom-up.  A short (4") phillips-head screwdriver might have been easier to use then the regular sized ratchet screwdriver that I use.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[16:53](http://www.tgharold.com/techblog/2004/04/via-epia-gentoo-build.shtml)
-
-		</div>
+The Morex Venus 668 case isn't a bad little case, a bit larger then I expected.  Hold a pair of paperback books up, spine-to-spine and you'll get an idea of how big the front of it is.  Installing the components wasn't too bad, but it's best if you remove the power-supply during the initial installation and work from the bottom-up.  A short (4") phillips-head screwdriver might have been easier to use then the regular sized ratchet screwdriver that I use.

--- a/_posts/2004/2004-04-27-via-epia-links.md
+++ b/_posts/2004/2004-04-27-via-epia-links.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [Identify Ezra-T/Nehemiah M10000](http://forums.viaarena.com/messageview.cfm?catid=32&amp;threadid=36416) (finding out if you have the Ezra or Nehemiah CPU core, I already know I have a Samuel 2 by doing a "cat /proc/cpuinfo")
 
 [linITX.org forums: Processor family](http://www.linitx.org/forum/viewtopic.php?t=1099) (discusses the -march=C3 flag for GCC)
@@ -19,10 +19,4 @@ tags:
 
 [Courville.org EPIA M Wiki](http://www.courville.org/phpwiki/EpiaM) (lots of links)
 
-[Building a mini MP3 server](http://www.ath0.com/meta/prose/mp3-server/part3.html) (using gentoo)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:12](http://www.tgharold.com/techblog/2004/04/via-epia-links.shtml)
-
-		</div>
+[Building a mini MP3 server](http://www.ath0.com/meta/prose/mp3-server/part3.html) (using gentoo)

--- a/_posts/2004/2004-04-28-gentoo-epia-install-part-3.md
+++ b/_posts/2004/2004-04-28-gentoo-epia-install-part-3.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([Previous blog entry](/techblog/2004/04/gentoo-epia-install-part-2.shtml))
+([Previous blog entry](/techblog/2004/04/gentoo-epia-install-part-2.shtml))
 
 While I'm not exactly sure when the first phase finished overnight, it was probably around 8-12 hours.  I don't see any errors on the screen, so I'm assuming that I'm good to go for the [next step](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=6) in the handbook (chapter 6d).
 
@@ -20,10 +20,4 @@ Anyway, not much to this step, and it's another one that takes a while to run:
 
 emerge system
 
-Back in a few... ([next entry](/techblog/2004/04/gentoo-epia-install-part-4.shtml)).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:55](http://www.tgharold.com/techblog/2004/04/gentoo-epia-install-part-3.shtml)
-
-		</div>
+Back in a few... ([next entry](/techblog/2004/04/gentoo-epia-install-part-4.shtml)).

--- a/_posts/2004/2004-04-28-gentoo-epia-install-part-4.md
+++ b/_posts/2004/2004-04-28-gentoo-epia-install-part-4.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([previous blog entry](/techblog/2004/04/gentoo-epia-install-part-3.shtml))
+([previous blog entry](/techblog/2004/04/gentoo-epia-install-part-3.shtml))
 
 Stage 2 compile is finished ([step 6d in the handbook](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=6)).  Not bad, emerge system took about 5.5 hours to run on my little VIA EPIA ME6000.  Now for [step 7, configuring the kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7)
 
@@ -55,10 +55,4 @@ Picking a kernel is tough... (make sure to read [gentoo kernel guide](http://www
 
 # emerge development-sources
 
-([next entry](/techblog/2004/04/gentoo-epia-install-part-3.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:38](http://www.tgharold.com/techblog/2004/04/gentoo-epia-install-part-4.shtml)
-
-		</div>
+([next entry](/techblog/2004/04/gentoo-epia-install-part-3.shtml))

--- a/_posts/2004/2004-04-28-gentoo-epia-install-part-5.md
+++ b/_posts/2004/2004-04-28-gentoo-epia-install-part-5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([previous entry](/techblog/2004/04/gentoo-epia-install-part-4.shtml))
+([previous entry](/techblog/2004/04/gentoo-epia-install-part-4.shtml))
 
 Well, that took somewhere around 2 hours to import and build the kernel from the development-sources package.    Now I need to [configure the kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7) (per chapter 7c of the handbook).  There are also notes over at [epiawiki.org](http://www.epiawiki.org/wiki/tiki-index.php?page=EpiaTheEpiaKernel) and [building a small MP3 server](http://www.ath0.com/meta/prose/mp3-server/part3.html) about configuring that I'll need to investigate (specifically looking at [their copy of the make config file](http://www.ath0.com/meta/prose/mp3-server/m10000-kernel-config-meta) which goes in "/usr/src/linux/.config").
 
@@ -57,10 +57,4 @@ Hit "Exit" when done and save your new kernel configuration.  Use "make &amp;&am
 # cp System.map /boot/System.map-2.6.3-gentoo
 # cp .config /boot/config-2.6.3-gentoo
 
-([next entry](/techblog/2004/04/gentoo-epia-install-part-6.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:20](http://www.tgharold.com/techblog/2004/04/gentoo-epia-install-part-5.shtml)
-
-		</div>
+([next entry](/techblog/2004/04/gentoo-epia-install-part-6.shtml))

--- a/_posts/2004/2004-04-28-gentoo-epia-install-part-6.md
+++ b/_posts/2004/2004-04-28-gentoo-epia-install-part-6.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([previous entry](/techblog/2004/04/gentoo-epia-install-part-5.shtml))
+([previous entry](/techblog/2004/04/gentoo-epia-install-part-5.shtml))
 
 Now to start with [chapter 7e, installing extra kernel modules](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  I didn't see any extra modules that needed to be emerge'd, so I skipped straight to the editing of the autoload file.  Actually I lie, I have to add in LVM2 module support.  So I need to follow the steps in [step 13 of the LVM install guide](http://www.gentoo.org/doc/en/lvm2.xml) and add LVM to the auto-load listing.
 
@@ -110,10 +110,4 @@ cd /
 umount ... (insert list of mounted file systems)
 reboot
 
-Reboot, go into the BIOS and change the boot order to bypass the CD-ROM (or simply remove the LiveCD), and refer to [chapter 12, where do I go from here](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=12) in the gentoo handbook.  I might jot down some additional notes in the future, but we'll have to see.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[22:28](http://www.tgharold.com/techblog/2004/04/gentoo-epia-install-part-6.shtml)
-
-		</div>
+Reboot, go into the BIOS and change the boot order to bypass the CD-ROM (or simply remove the LiveCD), and refer to [chapter 12, where do I go from here](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=12) in the gentoo handbook.  I might jot down some additional notes in the future, but we'll have to see.

--- a/_posts/2004/2004-04-29-gentoo-install-troubleshooting.md
+++ b/_posts/2004/2004-04-29-gentoo-install-troubleshooting.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Spoke too soon in my [last post](/techblog/2004/04/gentoo-epia-install-part-6.shtml).  Got a few errors on boot up.  First off, a complaint that the kernel was compiled without DEVFS support (not sure what that means off-hand), and none of my LVM2 stuff loaded.  Too tired to poke at it tonight, so I'm going to take a break and do some searching tomorrow.
+Spoke too soon in my [last post](/techblog/2004/04/gentoo-epia-install-part-6.shtml).  Got a few errors on boot up.  First off, a complaint that the kernel was compiled without DEVFS support (not sure what that means off-hand), and none of my LVM2 stuff loaded.  Too tired to poke at it tonight, so I'm going to take a break and do some searching tomorrow.
 
 I don't expect it to be difficult to resolve, might have to rebuild the kernel and reinstall the kernel.  During bootup, it tells me details about what needs to be done to fix the issue, but that's since scrolled off the screen.  Since my LVM2 volumes didn't mount, I can't look at /var/log/messages to see the boot messages.  Had to hard-reset since shutdown/reboot commands are hosed.
 
@@ -46,10 +46,4 @@ Then cross my fingers and reboot... and it boots!  Saw a few errors related to U
 
 Other things to do:
 
-- Look at /var/run/shutdown.pid, figure out where to stick the umount commands for all of my volumes when I use the shutdown command.  Also mentioned is /dev/initctl.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[00:24](http://www.tgharold.com/techblog/2004/04/gentoo-install-troubleshooting.shtml)
-
-		</div>
+- Look at /var/run/shutdown.pid, figure out where to stick the umount commands for all of my volumes when I use the shutdown command.  Also mentioned is /dev/initctl.

--- a/_posts/2004/2004-04-29-gentoo-next-steps-ssh.md
+++ b/_posts/2004/2004-04-29-gentoo-next-steps-ssh.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [Setting up SSHD on Gentoo](http://www.gentoo.org/proj/en/infrastructure/config-ssh.xml) (which just covers the basics, also see the [sshd manpage](http://www.cs.usyd.edu.au/cgi-bin/man.cgi?section=8&amp;topic=sshd) and [OpenSSH.org](http://www.openssh.com/)).
 
 I have a book called "Building Secure Servers with Linux", and it's extremely poor with regards to actually setting up the sshd system.  (Specifically, it completely ignores the topic of how to create the public/private DSA key for the sshd process.)  Googling around for [how to create the ssh_host_dsa_key](http://www.google.com/search?hl=en&amp;lr=&amp;ie=UTF-8&amp;oe=UTF-8&amp;c2coff=1&amp;q=%2Bsshd+%2Bkeygen+%2Bssh_host_dsa_key&amp;btnG=Search) netted me a few useful articles.
@@ -29,10 +29,4 @@ The NCSA link is probably the most useful, except that on my gentoo linux system
 To add sshd so it runs at startup (I think the following is correct):
 rc-update add sshd default 
 
-Now I can administer the box from the laptop (using SecureCRT software), getting it off of my desk and into the server rack where it belongs.  Things to do include getting PostgreSQL up and running, Samba, backing up the system, setting up recurring backups and checkout SubVersion as a replacement for Visual SourceSafe / SourceOffSite.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:56](http://www.tgharold.com/techblog/2004/04/gentoo-next-steps-ssh.shtml)
-
-		</div>
+Now I can administer the box from the laptop (using SecureCRT software), getting it off of my desk and into the server rack where it belongs.  Things to do include getting PostgreSQL up and running, Samba, backing up the system, setting up recurring backups and checkout SubVersion as a replacement for Visual SourceSafe / SourceOffSite.

--- a/_posts/2004/2004-04-30-gentoo-lvm2-stuff.md
+++ b/_posts/2004/2004-04-30-gentoo-lvm2-stuff.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>vgscan</b> - displays the list of volume groups allocated on the system (for my box, I have vgos, vguser, vgtmp and vgmedia)
 <b>lvscan</b> - displays the list of virtual partitions inside of the volume groups (for my box, I have 6)
 <b>vgdisplay</b> - displays a lot of data bout the volume groups, a good place to find out how much space is free within a particular volume group (vgos has 12GB free, vguser 19GB free, vgtmp 7GB free, vgmedia 92GB free).
@@ -23,10 +23,4 @@ mke2fs -j -c /dev/vgmedia/media
 mkdir /media
 mount /dev/vgmedia/media /media
 
-Now I'm ready to configure Samba.  See the [gentoo documentation about Samba](http://www.gentoo.org/doc/en/desktop.xml#doc_chap7).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/LVM.shtml">LVM</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:28](http://www.tgharold.com/techblog/2004/04/gentoo-lvm2-stuff.shtml)
-
-		</div>
+Now I'm ready to configure Samba.  See the [gentoo documentation about Samba](http://www.gentoo.org/doc/en/desktop.xml#doc_chap7).

--- a/_posts/2004/2004-05-01-gentoo-kernel-rebuild-samba-support.md
+++ b/_posts/2004/2004-05-01-gentoo-kernel-rebuild-samba-support.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Trying to compile a new kernel with samba support built in... I'll install this one as a different kernel image in the /boot folder.  (See the [Gentoo handbook](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7) for details on what is going on here.)
+Trying to compile a new kernel with samba support built in... I'll install this one as a different kernel image in the /boot folder.  (See the [Gentoo handbook](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7) for details on what is going on here.)
 
 # cd /usr/src/linux 
 # make menuconfig
@@ -38,10 +38,4 @@ title=Gentoo Linux 2.6.3
 root (hd0,0)
 kernel /kernel-2.6.3-gentoo root=/dev/hda2
 
-By leaving a 30 second timeout and leaving the old kernel information in the config file, I have a bit of a window to flip back to the previous kernel if needed.  (Not my idea, saw it somewhere else on the web.)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Samba.shtml">Samba</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[04:15](http://www.tgharold.com/techblog/2004/05/gentoo-kernel-rebuild-samba-support.shtml)
-
-		</div>
+By leaving a 30 second timeout and leaving the old kernel information in the config file, I have a bit of a window to flip back to the previous kernel if needed.  (Not my idea, saw it somewhere else on the web.)

--- a/_posts/2004/2004-05-01-gentoo-samba-round-2.md
+++ b/_posts/2004/2004-05-01-gentoo-samba-round-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([Gentoo samba page](http://www.gentoo.org/doc/en/desktop.xml#doc_chap7), [attempt #1](/techblog/2004/05/gentoo-samba-with-ads.shtml))
+([Gentoo samba page](http://www.gentoo.org/doc/en/desktop.xml#doc_chap7), [attempt #1](/techblog/2004/05/gentoo-samba-with-ads.shtml))
 
 Well, rebuilding the kernel didn't really do anything other then teach me how to rebuild the kernel...  I'm still getting the "net: command not found" error when trying to add the box the AD domain.  (And I'm not sure what I missed during the installation.)
 
@@ -26,10 +26,4 @@ Ah ha!  Now it indicates that it will install net-fs/samba-3.0.2a-r2, but first 
 Shows me that I have 2.0.50-r1 and the latest is 2.0.50.r6 and that the size of the download is 219KB.
 
 # emerge portage
-# emerge samba<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Samba.shtml">Samba</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[04:39](http://www.tgharold.com/techblog/2004/05/gentoo-samba-round-2.shtml)
-
-		</div>
+# emerge samba

--- a/_posts/2004/2004-05-01-gentoo-samba-with-ads.md
+++ b/_posts/2004/2004-05-01-gentoo-samba-with-ads.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Trying to setup my Samba box ("emerge samba") so that I can access the shares from Win2000 and WinXP machines in a Win2000 domain (Active Directory Services).  One of the links indicates that I need MIT Kerberos 1.3.1, which can be installed with "emerge mit-krb5" (AFAICT).  So I'll start with installing that...  I also have the <i>The Official Samba-3 HOWTO and Reference Guide</i> book handy, although it's a bit sparse on exactly how to setup Samba to be a file server in an ADS environment.
+Trying to setup my Samba box ("emerge samba") so that I can access the shares from Win2000 and WinXP machines in a Win2000 domain (Active Directory Services).  One of the links indicates that I need MIT Kerberos 1.3.1, which can be installed with "emerge mit-krb5" (AFAICT).  So I'll start with installing that...  I also have the <i>The Official Samba-3 HOWTO and Reference Guide</i> book handy, although it's a bit sparse on exactly how to setup Samba to be a file server in an ADS environment.
 
 (Note: you should emerge the mit-krb5 package prior to emerge the samba package... otherwise you'll have to recompile samba after the mit-krb5 package is installed if you want ADS support... per the official samba howto / reference guide book in the Bruce Peren's series, p 78, section 6.4.3.1.)
 
@@ -73,10 +73,4 @@ Well, samba has finished... yet testparm still complains about the "realm" and "
 
 Helpful links:
 [Authenticating to Samba share using "Active Directory Server"](http://linuxquestions.org/questions/history/161506)
-[[Samba] force user not working](http://www.mail-archive.com/samba@lists.samba.org/msg36617.html)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/ActiveDirectory.shtml">ActiveDirectory</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Samba.shtml">Samba</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[01:06](http://www.tgharold.com/techblog/2004/05/gentoo-samba-with-ads.shtml)
-
-		</div>
+[[Samba] force user not working](http://www.mail-archive.com/samba@lists.samba.org/msg36617.html)

--- a/_posts/2004/2004-05-07-hard-drive-power-requirements.md
+++ b/_posts/2004/2004-05-07-hard-drive-power-requirements.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Jottting down some of the V/A power-requirements for some hard-drives.  IBM is nice because they print it on the drive, the Maxtors (usually) aren't as helpful.  I'm also trying to make sure that the little 200W power-supplies in the light-weight servers like the VIA EPIA can handle the load. 
+Jottting down some of the V/A power-requirements for some hard-drives.  IBM is nice because they print it on the drive, the Maxtors (usually) aren't as helpful.  I'm also trying to make sure that the little 200W power-supplies in the light-weight servers like the VIA EPIA can handle the load. 
 
 [Hitachi Deskstar 180GXP](http://www.hitachigst.com/hdd/support/d180gxp/d180gxp.htm) (07N9685) 82.3GB
 7200rpm 8MB cache
@@ -63,10 +63,4 @@ I'm also looking to start cutting some power-usage as my power bill has crept up
 
 Of course, my 19" monitor eats up 140W... a comparable LCD would probably only eat 40W.  I pay 8.3 cents/KWH, so in a 30.4 day month (730 hours), 100W costs me $6.06.  Using 667 KWH in a month is roughly 914W per hour (to check my math).  A newer ViewSonic p90f 19" ($210) only uses 120W.
 
-So every 10W that I can shave off of power usage saves me $0.61/month ($7.27/yr).  Yeah, not a lot, but every little bit does add up.  At least LCD displays have fallen enough that they're worth buying just for the power-savings instead of a regular CRT.  LCD 17" displays are down to $360 (comparable to a 19" monitor), LCD 15" screens are $275.  Power savings is roughly 60-100W, which works out then to $43-$72/yr.  Cost difference pays for itself after about 2-3 years.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:29](http://www.tgharold.com/techblog/2004/05/hard-drive-power-requirements.shtml)
-
-		</div>
+So every 10W that I can shave off of power usage saves me $0.61/month ($7.27/yr).  Yeah, not a lot, but every little bit does add up.  At least LCD displays have fallen enough that they're worth buying just for the power-savings instead of a regular CRT.  LCD 17" displays are down to $360 (comparable to a 19" monitor), LCD 15" screens are $275.  Power savings is roughly 60-100W, which works out then to $43-$72/yr.  Cost difference pays for itself after about 2-3 years.

--- a/_posts/2004/2004-05-08-gentoo-samba-round-3.md
+++ b/_posts/2004/2004-05-08-gentoo-samba-round-3.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([previous post, samba round 2](/techblog/2004/05/gentoo-samba-round-2.shtml))
+([previous post, samba round 2](/techblog/2004/05/gentoo-samba-round-2.shtml))
 
 Well, after a busy week at work, I finally had time to log back into my little VIA EPIA server running Gentoo Linux.  In my previous post, I had re-emerged the latest version of samba (v3), but I never had time to go back and try things out again after the emerge finished.
 
@@ -158,10 +158,4 @@ A bit uglier... samba doesn't have kerberos support included.  And looking back 
 
 Okay, so I'm not sure what the next step is... I'll have to google again later when I'm not as frustrated.  Samba is still complaining that "ADS support is not compiled in".  The only "config.cache" file on the system is from July 2001 and is not in the samba folder.
 
-Update: The missing piece was that I hadn't configured both the kerberos and ldap USE flags in my make.conf file.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gnetoo.shtml">Gnetoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Samba.shtml">Samba</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:54](http://www.tgharold.com/techblog/2004/05/gentoo-samba-round-3.shtml)
-
-		</div>
+Update: The missing piece was that I hadn't configured both the kerberos and ldap USE flags in my make.conf file.

--- a/_posts/2004/2004-05-11-subversion-install-on-gentoo.md
+++ b/_posts/2004/2004-05-11-subversion-install-on-gentoo.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Working on setting up subversion on the box.  I've already emerged in the apache and subversion ebuilds, now I'm working on some other configuration information.  My plan is to store my respository in /svn, in it's own logical volume.  (Very similar to when I [created my "media" logical volume in the vgmedia volume group](/techblog/2004/04/gentoo-lvm2-stuff.shtml).)
+Working on setting up subversion on the box.  I've already emerged in the apache and subversion ebuilds, now I'm working on some other configuration information.  My plan is to store my respository in /svn, in it's own logical volume.  (Very similar to when I [created my "media" logical volume in the vgmedia volume group](/techblog/2004/04/gentoo-lvm2-stuff.shtml).)
 
 # lvcreate -L4G -nsvn vguser 
 # mke2fs -j -c /dev/vguser/svn
@@ -20,10 +20,4 @@ tags:
 
 [SubVersion book, chapter 6, section 4](http://svnbook.red-bean.com/svnbook/ch06s04.html) covers how to configure Apache2 for SVN.  One key thing that bit me is that if you already have apache2 installed, you need to <b>also set the apache2 USE flag</b> prior to emerging subversion.
 
-More later... I have to wait for apache/subversion to re-emerge.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:58](http://www.tgharold.com/techblog/2004/05/subversion-install-on-gentoo.shtml)
-
-		</div>
+More later... I have to wait for apache/subversion to re-emerge.

--- a/_posts/2004/2004-05-13-tyan-kt400-windows-2000-boot-failure.md
+++ b/_posts/2004/2004-05-13-tyan-kt400-windows-2000-boot-failure.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So after installing the 2nd round of patches (first round of patches was installing SP4 using WindowsUpdate), the system fails to start:
+So after installing the 2nd round of patches (first round of patches was installing SP4 using WindowsUpdate), the system fails to start:
 
 Windows 2000 could not start because the following file is missing or corrupt:
 (something)\System32\Ntoskrnl.exe
@@ -47,10 +47,4 @@ Unfortunately, no matter what combination of scsi(x) or multi(x) I tried at the 
 
 Hint: The boot diskette is great for testing out BOOT.INI changes, it boots up quickly compared to waiting for the system to boot.
 
-I'm going to try plan B, which is to reinstall... but during the Setup CD when I hit F6, I'm going to install both the HighPoint and the Silicon Image drivers.  That way, setup will see all of the disks in the system during the initial install and will hopefully write out a correct BOOT.INI file.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[21:43](http://www.tgharold.com/techblog/2004/05/tyan-kt400-windows-2000-boot-failure.shtml)
-
-		</div>
+I'm going to try plan B, which is to reinstall... but during the Setup CD when I hit F6, I'm going to install both the HighPoint and the Silicon Image drivers.  That way, setup will see all of the disks in the system during the initial install and will hopefully write out a correct BOOT.INI file.

--- a/_posts/2004/2004-05-13-tyan-trinity-kt400.md
+++ b/_posts/2004/2004-05-13-tyan-trinity-kt400.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So I'm finally ditching the very troublesome Asus A7V266-E motherboard in my one file server.  I went with the [Tyan Trinity KT400](ftp://ftp.tyan.com/datasheets/d_s2495_105.pdf) because it was relatively inexpensive and I was able to simply move my AthlonXP 1800+ CPU and my 512MB PC2100 memory modules over to the new motherboard.
+So I'm finally ditching the very troublesome Asus A7V266-E motherboard in my one file server.  I went with the [Tyan Trinity KT400](ftp://ftp.tyan.com/datasheets/d_s2495_105.pdf) because it was relatively inexpensive and I was able to simply move my AthlonXP 1800+ CPU and my 512MB PC2100 memory modules over to the new motherboard.
 
 The old A7V266-E is a VIA-based chipset that was notorious for problems with the PCI bus ([search around for KT266 and PCI latency](http://www.google.com/search?hl=en&amp;q=via+kt266+pci+bus+latency&amp;btnG=Google+Search), or check the [PCI Latency Patch](http://adsl.cutw.net/dlink-dsl200-via.html) page).  (And that's on top of the issue that the A7V266-E Promise FastTrak100 Lite only supports 127GB and smaller drives.)  For me, it manifested itself as an incompatibility with my add-in Adaptec USB card.  Anytime I had activity on the USB bus, the entire machine would halt for a few seconds at a time.  Extremely annoying and the only way that I got around it was to not install the Adaptec 3100 USB PCI card.
 
@@ -49,5 +49,4 @@ No supporting host adapter is found
 
 Okay... (drums fingers on desk), eh, forget it for now.  I have v2.345 already, which is reasonably up-to-date.  And this time, the Win2k install seems to have found the partition correctly (only basic difference between now and when it didn't work last night is the motherboard BIOS revision update from 1.02 to 1.05).
 
-Created my 16GB C: partition, and I'm off and installing.  Later, I get to test my recovery strategy (going to try to restore the system state through a non-authoritative restore).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>		<div class="Byline">			posted by Thomas at 			[02:51](http://www.tgharold.com/techblog/2004/05/tyan-trinity-kt400.shtml)								</div>
+Created my 16GB C: partition, and I'm off and installing.  Later, I get to test my recovery strategy (going to try to restore the system state through a non-authoritative restore).

--- a/_posts/2004/2004-05-15-more-trouble-with-the-tyan.md
+++ b/_posts/2004/2004-05-15-more-trouble-with-the-tyan.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So... this is definitely a taxing of my patience when installing hardware.
+So... this is definitely a taxing of my patience when installing hardware.
 
 The latest problem is that if I copy a file from the network to the HighPoint RAID 1 array... it gets corrupted.  (Using a MD5 tool to verify content.)  However, if I verify the file up on the network server, it's correct.  And copying it to the SATA scratch drive, it copies cleanly.
 
@@ -32,10 +32,4 @@ So right now, it looks like the data corruption bug is fixed.  (It only affected
 
 Update #2: The system is still corrupting files that as they are written to the HighPoint RAID array.  Especially when the system is under load, copying files to both the HighPoint and the SATA drives at the same time.  Copying from the network to the SATA drive works properly, but copying from the network or the SATA to the IDE RAID causes data corruption.
 
-I'm now going to remove the HPT from the BIOS, and put the drives back on the Promise FastTrak100 TX2 IDE RAID card.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[02:55](http://www.tgharold.com/techblog/2004/05/more-trouble-with-tyan.shtml)
-
-		</div>
+I'm now going to remove the HPT from the BIOS, and put the drives back on the Promise FastTrak100 TX2 IDE RAID card.

--- a/_posts/2004/2004-05-15-tyan-trinity-kt400-s2495-part-2.md
+++ b/_posts/2004/2004-05-15-tyan-trinity-kt400-s2495-part-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>More fun with the Tyan Trinity KT400 S2495 board.  While attempting to add the Promise FastTrak TX2 PCI RAID card, everything is happy until I go and connect drives to it and define an array.  After that, if the Adaptec 2930CU PCI SCSI card is <b>also</b> installed, the system will not boot.  I have the HighPoint HPT372N IDE RAID ports disabled in the BIOS and the Silicon Image Sil3112 SATA ports enabled.
+More fun with the Tyan Trinity KT400 S2495 board.  While attempting to add the Promise FastTrak TX2 PCI RAID card, everything is happy until I go and connect drives to it and define an array.  After that, if the Adaptec 2930CU PCI SCSI card is <b>also</b> installed, the system will not boot.  I have the HighPoint HPT372N IDE RAID ports disabled in the BIOS and the Silicon Image Sil3112 SATA ports enabled.
 
 Symptom of the boot issue is that the Sil3112 BIOS splash will not appear during the boot process.  System will then hang before or at the ESCD/DMI update point (right before it boots from a device).
 
@@ -35,10 +35,4 @@ Promise FastTrak TX2 PCI IDE card
 Silicon Image Sil3112 SATA ports (built-in)
 200GB SATA 7200rpm drive (scratch)
 IDE CD-RW
-IDE DVD-ROM/CD-RW<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[21:35](http://www.tgharold.com/techblog/2004/05/tyan-trinity-kt400-s2495-part-2.shtml)
-
-		</div>
+IDE DVD-ROM/CD-RW

--- a/_posts/2004/2004-05-19-tyan-trinity-kt400-s2495-performance.md
+++ b/_posts/2004/2004-05-19-tyan-trinity-kt400-s2495-performance.md
@@ -10,14 +10,8 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Now that the [new motherboard is finally bedded in](/techblog/2004/05/tyan-trinity-kt400-s2495-part-2.shtml), it's rather enjoyable compared to the old motherboard.  On the old box, the fastest that the Promise FastTrak100 TX2 RAID1 array would every transfer data was around 5-6 MB/s, if it was feeling perky.  Sometimes it would degrade down to only 2-3 MB/s.  (However, I blame a lot of that on the PCI Latency issue.)
+Now that the [new motherboard is finally bedded in](/techblog/2004/05/tyan-trinity-kt400-s2495-part-2.shtml), it's rather enjoyable compared to the old motherboard.  On the old box, the fastest that the Promise FastTrak100 TX2 RAID1 array would every transfer data was around 5-6 MB/s, if it was feeling perky.  Sometimes it would degrade down to only 2-3 MB/s.  (However, I blame a lot of that on the PCI Latency issue.)
 
 Same drives, same RAID card on the new motherboard easily handles data rates upwards of 20 MB/s, copying from point to point on the drive usually averages 10-15 MB/s.  And I've seen peak rates of 30 MB/s.  As a comparison, my video cap box with a 5400rpm ATA/100 drive and a 7200rpm SATA/150 drive can hit 32-36 MB/s when copying video files from one drive to the other.
 
-So, even with all of the nuisance of getting everything installed properly, it seems to be performing up to expectations and is turning out to have been worth it.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[00:59](http://www.tgharold.com/techblog/2004/05/tyan-trinity-kt400-s2495-performance.shtml)
-
-		</div>
+So, even with all of the nuisance of getting everything installed properly, it seems to be performing up to expectations and is turning out to have been worth it.

--- a/_posts/2004/2004-06-10-installing-cwrsync-on-windows-2000.md
+++ b/_posts/2004/2004-06-10-installing-cwrsync-on-windows-2000.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>The instructions over at [cwRSync's install page](http://www.itefix.no/cwrsync/) are a bit vague, so I'm going to jot down the steps that I use.  These steps are for installing rsync in a <b>server</b> configuration.  Since the install process needs to (optionally) create an user account and create a new service, you'll need administrative access to the machine that you are using.  (I'm not sure whether members of the Power Users group have enough privileges.)
+The instructions over at [cwRSync's install page](http://www.itefix.no/cwrsync/) are a bit vague, so I'm going to jot down the steps that I use.  These steps are for installing rsync in a <b>server</b> configuration.  Since the install process needs to (optionally) create an user account and create a new service, you'll need administrative access to the machine that you are using.  (I'm not sure whether members of the Power Users group have enough privileges.)
 <ol>
 <li>Download cwRSync, open up the ZIP file, then extract/run <b>cwRsync_x.x.x_Installer.exe</b>.
 
@@ -91,5 +91,4 @@ read only = false
 
 That allows <b>any client</b> who manages to authenticate with the rsync service to write the E:\Backup\Joe on the rsync server.  That is not exactly secure and you should take additional steps to lock it down through the use of "hosts allow", "auth users", "secrets file" and perhaps ssh.  Securing your box is a bit beyond the scope of this post.  It's also a bit beyond my experience level since I'm just getting started with rsync.
 
-(Update: See [Securing cwRSync](/techblog/2004/06/securing-cwrsync.shtml).)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>		<div class="Byline">			posted by Thomas at 			[10:29](http://www.tgharold.com/techblog/2004/06/installing-cwrsync-on-windows-2000.shtml)								</div>
+(Update: See [Securing cwRSync](/techblog/2004/06/securing-cwrsync.shtml).)

--- a/_posts/2004/2004-06-12-auditing-tools-for-windows.md
+++ b/_posts/2004/2004-06-12-auditing-tools-for-windows.md
@@ -10,15 +10,9 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [fsum by SlavaSoft](http://www.slavasoft.com/fsum/) - (free) Creates md5 signature files compatible with the md5sum command line tool (found on most unix/linux distros), but has the additional feature of directory recursion.  The tool also supports other checksum/hash functions.
 
 [DumpSec by SomarSoft](http://www.somarsoft.com/somarsoft_main.htm#DumpAcl) - (free) This tool used to be called DumpACL back in the days of Windows NT 4.0.  It has been re-released to report on the newer ACL information in an Active Directory Domain (Windows 2000), plus it has the option to dump out lists of users, groups, policies, shares, registry ACLs, and a few more goodies.  Output is either an interactive report viewer, a custom save file format, or various report file styles.
 
-[rsync](http://rsync.samba.org/) - (free) While not strictly an auditing tool, rsync is useful for pushing/pulling log files off of a server onto a better protected server for long-term storage.  The primary advantage is that rsync will only send the portions of a file that have changed, reducing transfer traffic.  It also supports compression of the transfer and you can route the information through ssh for security.  The version I use is [cwRSync](http://www.itefix.no/), which is a streamlined version of the Microsoft Windows port that doesn't require the full [Cygwin](http://www.cygwin.com/) application to be installed.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:46](http://www.tgharold.com/techblog/2004/06/auditing-tools-for-windows.shtml)
-
-		</div>
+[rsync](http://rsync.samba.org/) - (free) While not strictly an auditing tool, rsync is useful for pushing/pulling log files off of a server onto a better protected server for long-term storage.  The primary advantage is that rsync will only send the portions of a file that have changed, reducing transfer traffic.  It also supports compression of the transfer and you can route the information through ssh for security.  The version I use is [cwRSync](http://www.itefix.no/), which is a streamlined version of the Microsoft Windows port that doesn't require the full [Cygwin](http://www.cygwin.com/) application to be installed.

--- a/_posts/2004/2004-06-12-css-4-panel-layout-using-divs.md
+++ b/_posts/2004/2004-06-12-css-4-panel-layout-using-divs.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>You'd think it would be simple, right?  Oh, young grasshopper, you have much to learn!  Actually, it's not all <em>that</em> bad, just tedious to get a layout up and running.  Took me about 2 hours of trial-n-error, and looking at some of the sites over at the [CSS Zen Garden](http://www.mezzoblue.com/zengarden/).  Finally, [Michael Pick's blog entry about the CSS Zen Garden](http://www.mikepick.com/news/archives/000086.html) proved to be the most useful as I teased apart his DIVs and his CSS file.  Mike's page was already close to the layout that I wanted and his CSS file was pretty simple.
+You'd think it would be simple, right?  Oh, young grasshopper, you have much to learn!  Actually, it's not all <em>that</em> bad, just tedious to get a layout up and running.  Took me about 2 hours of trial-n-error, and looking at some of the sites over at the [CSS Zen Garden](http://www.mezzoblue.com/zengarden/).  Finally, [Michael Pick's blog entry about the CSS Zen Garden](http://www.mikepick.com/news/archives/000086.html) proved to be the most useful as I teased apart his DIVs and his CSS file.  Mike's page was already close to the layout that I wanted and his CSS file was pretty simple.
 
 My goal for this blog's design is a navigation bar across the top of the page, a footer at the bottom of the page, a side-bar containing links to the various archive pages, and a main body that is 80-85% of the page width.  This is somewhat similar to the diagram under [section 9.6.1 (Fixed positioning)](http://www.w3.org/TR/REC-CSS2/visuren.html#fixed-positioning) of the [W3C.org CSS2 Specification](), except that I don't want to use fixed positioning.
 
@@ -80,10 +80,3 @@ Bugs:<ol>
 
 </li>
 </ol>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[17:44](http://www.tgharold.com/techblog/2004/06/css-4-panel-layout-using-divs.shtml)
-
-		</div>

--- a/_posts/2004/2004-06-12-css-quick-links.md
+++ b/_posts/2004/2004-06-12-css-quick-links.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [W3C's Cascading Style Sheets, level 2 CSS2 Specification](http://www.w3.org/TR/REC-CSS2/cover.html#minitoc) - This is <b>the</b> source for what CSS is supposed to look like.  However, it generally avoids talking about what is supported in the real-world.
 
 [EchoEcho.com's CSS Tutorial](http://www.echoecho.com/cssintroduction.htm) - Covers the basics of CSS.

--- a/_posts/2004/2004-06-12-more-css-4-panel-layout-using-divs-attempt-2.md
+++ b/_posts/2004/2004-06-12-more-css-4-panel-layout-using-divs-attempt-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>1) Removed the "Main" DIV tag from the previous attempt.  (Go look at [BlueRobot.com's 2-panel layout](http://bluerobot.com/web/layouts/layout1.html).)
+1) Removed the "Main" DIV tag from the previous attempt.  (Go look at [BlueRobot.com's 2-panel layout](http://bluerobot.com/web/layouts/layout1.html).)
 
 2) Decided that I liked the look of [CSS Layout Techniques: for Fun and Profit](http://glish.com/css/) where the side-bar menu is on the right, which allows text to fill the width of the window once you scroll down past the end.  That looks more natural then a left side menu with a fixed left margin.  Internet Explorer 6 also seems to like that layout a bit better.  ([BlueRobot.com's 2-panel right menu layout](http://bluerobot.com/web/layouts/layout2.html))
 
@@ -63,10 +63,3 @@ Bugs:<ol>
 
 </li>
 </ol>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:38](http://www.tgharold.com/techblog/2004/06/more-css-4-panel-layout-using-divs.shtml)
-
-		</div>

--- a/_posts/2004/2004-06-14-monitor-calibration.md
+++ b/_posts/2004/2004-06-14-monitor-calibration.md
@@ -10,17 +10,11 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [The Monitor calibration and Gamma assessment page](http://www.photoscientia.co.uk/Gamma.htm) - While not the easiest to use, I did get the best results using it.  (I set my gamma to 1.8.)
 
 [Monitor Calibration and Gamma](http://www.normankoren.com/makingfineprints1A.html) - The explanation is extremely technical (which is good), but the explanation of how to do the adjustments is a bit vague.
 
 Now, on my Toshiba Tecra 9100, the S3 display utility has a gamma setting tool.  The values that I ended up with were Gamma 1.00, Brightness 1.07, Contrast 0.65.
 
-(Of course, this means I'll need to adjust my color scheme again.  It now looks too gray, when I wanted a hint of blue.  See my [color space](/color_space.shtml).)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[01:15](http://www.tgharold.com/techblog/2004/06/monitor-calibration.shtml)
-
-		</div>
+(Of course, this means I'll need to adjust my color scheme again.  It now looks too gray, when I wanted a hint of blue.  See my [color space](/color_space.shtml).)

--- a/_posts/2004/2004-06-14-xenus-link-sleuth.md
+++ b/_posts/2004/2004-06-14-xenus-link-sleuth.md
@@ -10,12 +10,6 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This is one of those indispensable tools for any web developer.  [Xenu's Link Sleuth](http://home.snafu.de/tilman/xenulink.html) is a nice, simple, easy-to-use, tool that will crawl any URL and report back on the status of every link.  When it's finished you have the option to generate a report, or just look at the results grid.
+This is one of those indispensable tools for any web developer.  [Xenu's Link Sleuth](http://home.snafu.de/tilman/xenulink.html) is a nice, simple, easy-to-use, tool that will crawl any URL and report back on the status of every link.  When it's finished you have the option to generate a report, or just look at the results grid.
 
-(I used this on my site over the weekend... fixed a few dozen errors.  So hopefully, nobody sees any broken internal links.  External links, OTOH, I have not checked recently.)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:00](http://www.tgharold.com/techblog/2004/06/xenus-link-sleuth.shtml)
-
-		</div>
+(I used this on my site over the weekend... fixed a few dozen errors.  So hopefully, nobody sees any broken internal links.  External links, OTOH, I have not checked recently.)

--- a/_posts/2004/2004-06-15-gentoo-install-1-via-epia-me6000.md
+++ b/_posts/2004/2004-06-15-gentoo-install-1-via-epia-me6000.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Going to rebuild my VIA EPIA Gentoo linux server.  While the [current setup](/techblog/2004/04/gentoo-epia-install-part-1.shtml) was fine, I've decided that I want to switch to use a pair of matched 5400rpm drives and [software RAID1](/techblog/2004/06/lvm-and-software-raid.shtml).  The configuration is identical to the [old drive configuration](/techblog/2004/04/via-epia-gentoo-build.shtml), except that I'm now using a pair of 300GB 5400rpm Maxtor drives.  The power draw seems to be well within the limits of the tiny power-supply in the Morex Venus 668 case.
+Going to rebuild my VIA EPIA Gentoo linux server.  While the [current setup](/techblog/2004/04/gentoo-epia-install-part-1.shtml) was fine, I've decided that I want to switch to use a pair of matched 5400rpm drives and [software RAID1](/techblog/2004/06/lvm-and-software-raid.shtml).  The configuration is identical to the [old drive configuration](/techblog/2004/04/via-epia-gentoo-build.shtml), except that I'm now using a pair of 300GB 5400rpm Maxtor drives.  The power draw seems to be well within the limits of the tiny power-supply in the Morex Venus 668 case.
 
 I'm going to skip some of the [initial information about my setup](/techblog/2004/04/gentoo-epia-install-part-1.shtml) as all of that really hasn't changed.  Shared video memory is still only 32MB instead of the default 128MB, and I've turned off all of the ports and devices that I'm not going to use (leaving only ethernet, firewire and USB ports active).  I'm still using the Gentoo 2004.0 Universal CD as my bootstrap system.
 
@@ -134,10 +134,4 @@ Create the raid set(s).
 
 If you get the error message: "raid_disks + spare_disks != nr_disks" when attempting to create any of your RAID sets, go back and verify your "/etc/raidtab" file as well as verifying your disk partitions.  The RAID sets will build in the background and you should periodically monitor their progress using "<b>cat /proc/mdstat</b>".  Another possibility is that you have set the "chunk-size" setting to be too small or too large (e.g. "chunk-size 4" did not work for me, but "chunk size 8" worked fine).  
 
-Since it's going to take 150 minutes to prep that last RAID volume, I'm going to [pick this up again later](/techblog/2004/06/gentoo-install-1-via-epia-me6000.shtml).  Data rate according to "<b>cat /proc/mdstat</b>" is around 30MB/sec, which is about what I'd expect for a 5400rpm PATA drive.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:39](http://www.tgharold.com/techblog/2004/06/gentoo-install-1-via-epia-me6000.shtml)
-
-		</div>
+Since it's going to take 150 minutes to prep that last RAID volume, I'm going to [pick this up again later](/techblog/2004/06/gentoo-install-1-via-epia-me6000.shtml).  Data rate according to "<b>cat /proc/mdstat</b>" is around 30MB/sec, which is about what I'd expect for a 5400rpm PATA drive.

--- a/_posts/2004/2004-06-15-gentoo-install-2-via-epia-me6000.md
+++ b/_posts/2004/2004-06-15-gentoo-install-2-via-epia-me6000.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([Previous post about fdisk and setting up the software RAID](/techblog/2004/06/gentoo-install-1-via-epia-me6000.shtml).)
+([Previous post about fdisk and setting up the software RAID](/techblog/2004/06/gentoo-install-1-via-epia-me6000.shtml).)
 
 At this point, we've partitioned the disk and setup the "/etc/raidtab" file.  It's a good idea to jot down everything in that file and put it in a safe place.  You should also "cat /proc/mdstat" and jot that information down too.
 
@@ -111,10 +111,4 @@ Next we're ready to install the base system, see [6. Installing the Gentoo Base 
 # source /etc/profile
 # emerge sync</pre>
 
-Synchronization of the portage tree will take a while (depending on the speed of your internet connection and how fast your system is).  My system downloaded 60MB or so worth of updates and took 30-60 minutes (at a guess).  Meanwhile, I'll continue this topic in [my next post](/techblog/2004/06/gentoo-install-3-bootstrapping.shtml).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:53](http://www.tgharold.com/techblog/2004/06/gentoo-install-2-via-epia-me6000.shtml)
-
-		</div>
+Synchronization of the portage tree will take a while (depending on the speed of your internet connection and how fast your system is).  My system downloaded 60MB or so worth of updates and took 30-60 minutes (at a guess).  Meanwhile, I'll continue this topic in [my next post](/techblog/2004/06/gentoo-install-3-bootstrapping.shtml).

--- a/_posts/2004/2004-06-15-gentoo-install-3-bootstrapping.md
+++ b/_posts/2004/2004-06-15-gentoo-install-3-bootstrapping.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([previous post](/techblog/2004/06/gentoo-install-2-via-epia-me6000.shtml))
+([previous post](/techblog/2004/06/gentoo-install-2-via-epia-me6000.shtml))
 
 Time to bootstrap the system (See [moving from stage 1 to stage 2](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=6)).  If you have multiple machines on the network, all with the same version of gcc, now is the when you'll want to [configure your distcc configuration](http://www.gentoo.org/doc/en/distcc.xml).
 <pre># cd /usr/portage
@@ -23,10 +23,4 @@ Once that finishes, run the following command.
 
 Which will also take a while to run (last time it took around 5.5 hours).  Update: Took around 4.5 hours this time.
 
-([next post](/techblog/2004/06/gentoo-install-4-installing-kernel.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:28](http://www.tgharold.com/techblog/2004/06/gentoo-install-3-bootstrapping.shtml)
-
-		</div>
+([next post](/techblog/2004/06/gentoo-install-4-installing-kernel.shtml))

--- a/_posts/2004/2004-06-15-imap-service-providers.md
+++ b/_posts/2004/2004-06-15-imap-service-providers.md
@@ -10,11 +10,5 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
-[ IMAP Service Providers: A Step in Dealing with Viruses, Spam, and Email Overload](http://www.ii.com/internet/messaging/imap/isps/) - A very in-depth listing of what companies provide IMAP mail service.  <div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[01:29](http://www.tgharold.com/techblog/2004/06/imap-service-providers.shtml)
 
-		</div>
+[ IMAP Service Providers: A Step in Dealing with Viruses, Spam, and Email Overload](http://www.ii.com/internet/messaging/imap/isps/) - A very in-depth listing of what companies provide IMAP mail service.

--- a/_posts/2004/2004-06-15-lvm-and-software-raid.md
+++ b/_posts/2004/2004-06-15-lvm-and-software-raid.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Links:
+Links:
 
 [Linux Logical Volume Manager (LVM) on Software RAID](http://www.aplawrence.com/Linux/lvm.html) - explains the benefits of using LVM, and also how to get LVM running on top of software RAID in RedHat 8.
 
@@ -34,10 +34,4 @@ There's a special set of command that need to be done in "grub" if you want to b
 
 Replacing a failed disk in a software RAID1 array requires partitioning the drive by hand prior to rebuilding the array.  This is also mentioned in the [gentoo forums thread about software RAID](http://forums.gentoo.org/viewtopic.php?t=8813&amp;postdays=0&amp;postorder=asc&amp;highlight=raid&amp;start=100), look for the post by "hover". 
 
-Searching around on my Gentoo 2004.0 Universal CD, I don't see the "mdadm" tools anywhere, but I do see "raidtools".<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/LVM.shtml">LVM</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:18](http://www.tgharold.com/techblog/2004/06/lvm-and-software-raid.shtml)
-
-		</div>
+Searching around on my Gentoo 2004.0 Universal CD, I don't see the "mdadm" tools anywhere, but I do see "raidtools".

--- a/_posts/2004/2004-06-16-gentoo-install-4-installing-the-kernel-sources.md
+++ b/_posts/2004/2004-06-16-gentoo-install-4-installing-the-kernel-sources.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([previous post](/techblog/2004/06/gentoo-install-3-bootstrapping.shtml))
+([previous post](/techblog/2004/06/gentoo-install-3-bootstrapping.shtml))
 
 Picking up with [7. Configuring the Kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  If your system crashes after this point, I do have a few notes jotted down on [how to get back to here without rebuilding everything](/techblog/2004/04/gentoo-epia-install-part-4.shtml).  (Since this is where I screwed up last time and put the machine into an unusable state.)
 
@@ -27,10 +27,4 @@ Next, [pick your kernel](http://www.gentoo.org/doc/en/gentoo-kernel.xml).  For m
 
 This will take a while to run.  Last time I think it took somewhere around 2 hours, this time it only took 30-40 minutes.  So my previous estimate was probably a bit off (or it took longer to download last time).
 
-([next step](/techblog/2004/06/gentoo-install-5-manual-kernel.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:00](http://www.tgharold.com/techblog/2004/06/gentoo-install-4-installing-kernel.shtml)
-
-		</div>
+([next step](/techblog/2004/06/gentoo-install-5-manual-kernel.shtml))

--- a/_posts/2004/2004-06-16-gentoo-install-5-manual-kernel-configuration.md
+++ b/_posts/2004/2004-06-16-gentoo-install-5-manual-kernel-configuration.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([previous post - building the kernel](/2004/06/gentoo-install-4-installing-kernel.shtml))
+([previous post - building the kernel](/2004/06/gentoo-install-4-installing-kernel.shtml))
 
 Note: This is for a VIA EPIA ME6000 motherboard being used as a headless server.  All of the multimedia and graphic options are disabled.  (See my [previous install](/techblog/2004/04/gentoo-epia-install-part-5.shtml).)  If this is your first install, you should probably use the "genkernel" method rather then manual configuration.  The [Gentoo docs explain configuring the kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7#doc_chap3).  They recommend being familiar with the "<b>cat /proc/pci</b>" and "<b>lsmod</b>" commands which is something I missed on my [previous install](/2004/04/gentoo-epia-install-part-5.shtml).
 <pre># cd /usr/src/linux
@@ -124,10 +124,4 @@ Change your hostname, domainname, and the default run level.
 Onward to [chapter 9, configuring the bootloader](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=9).  Here's where I ran into trouble; ["emerge grub" or "emerge lilo" failed with "cannot automatically mount your /boot partition"](/techblog/2004/06/gentoo-install-emerge-grub-or-emerge.shtml).
 <pre># emerge grub</pre>
 
-([continued in my next post](/techblog/2004/06/gentoo-install-6-grub-system-tools.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:37](http://www.tgharold.com/techblog/2004/06/gentoo-install-5-manual-kernel.shtml)
-
-		</div>
+([continued in my next post](/techblog/2004/06/gentoo-install-6-grub-system-tools.shtml))

--- a/_posts/2004/2004-06-16-gentoo-install-6-grub-system-tools-finalizing-the-install.md
+++ b/_posts/2004/2004-06-16-gentoo-install-6-grub-system-tools-finalizing-the-install.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([previous post about configuring the kernel and setting up the filesystem](/techblog/2004/06/gentoo-install-5-manual-kernel.shtml))
+([previous post about configuring the kernel and setting up the filesystem](/techblog/2004/06/gentoo-install-5-manual-kernel.shtml))
 
 Picking up with [9.b. Default: Using GRUB](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=9#doc_chap2) in the handbook.  (Also see my [older post about configuring grub](/techblog/2004/04/gentoo-epia-install-part-6.shtml).)  Also take a look at the end of the thread [](http://forums.gentoo.org/viewtopic.php?t=8813&amp;postdays=0&amp;postorder=asc&amp;highlight=raid&amp;start=100) on the gentoo forums (look for user "havoc") where it discusses how to setup grub on both the primary and secondary drives ([see the original article](http://lists.us.dell.com/pipermail/linux-poweredge/2003-July/014331.html)).  Now is also a good time to pull up the [official Software RAID HOWTO](http://unthought.net/Software-RAID.HOWTO/) and review that as well (especially section 7.3).
 <pre># grub --no-floppy
@@ -62,10 +62,4 @@ livecd / # reboot</pre>
 
 If all goes well, the system should shutdown and then restart from the software RAID.  
 
-My system locked up during shutdown on or after "Stopping USB and PCI hotplugging".  Which probably means there was a boot option that I should've entered way back when I booted off the LiveCD (actually it means I didn't properly specify the "nohotplug" option at the "boot:" prompt on the LiveCD).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:25](http://www.tgharold.com/techblog/2004/06/gentoo-install-6-grub-system-tools.shtml)
-
-		</div>
+My system locked up during shutdown on or after "Stopping USB and PCI hotplugging".  Which probably means there was a boot option that I should've entered way back when I booted off the LiveCD (actually it means I didn't properly specify the "nohotplug" option at the "boot:" prompt on the LiveCD).

--- a/_posts/2004/2004-06-16-gentoo-install-emerge-grub-or-emerge-lilo-fails-to-mount-boot.md
+++ b/_posts/2004/2004-06-16-gentoo-install-emerge-grub-or-emerge-lilo-fails-to-mount-boot.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Sometimes "emerge grub" or "emerge lilo" fails with the following error and you are attempting to mount "/boot" on a software RAID1 partition:
+Sometimes "emerge grub" or "emerge lilo" fails with the following error and you are attempting to mount "/boot" on a software RAID1 partition:
 <pre>*
 * Cannot automatically mount your /boot partition.
 * Your boot partition has to be mounted rw before the installation
@@ -48,10 +48,4 @@ The root-cause was that back when I did the first part of the install, not only 
 
 Links:
 
-[www.gentoo.pl](http://www.gentoo.pl/?id=forum&amp;id_watek=1669&amp;posty=1) - This page might've had the answer, but unfortunately it was written in polish.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/GRUB.shtml">GRUB</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:26](http://www.tgharold.com/techblog/2004/06/gentoo-install-emerge-grub-or-emerge.shtml)
-
-		</div>
+[www.gentoo.pl](http://www.gentoo.pl/?id=forum&amp;id_watek=1669&amp;posty=1) - This page might've had the answer, but unfortunately it was written in polish.

--- a/_posts/2004/2004-06-17-troubleshooting-software-raid-boot-problems.md
+++ b/_posts/2004/2004-06-17-troubleshooting-software-raid-boot-problems.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>First problem is that the system boots straight into "grub".  Probably due to a missing "grub.conf" file, which I'm pretty sure I had written to the proper location earlier in the install. So I'll load the kernel by hand and fix the config file once I get the box to boot properly.
+First problem is that the system boots straight into "grub".  Probably due to a missing "grub.conf" file, which I'm pretty sure I had written to the proper location earlier in the install. So I'll load the kernel by hand and fix the config file once I get the box to boot properly.
 <pre>grub&gt;
 grub&gt; cat /boot/grub/grub.conf
 (no file found)
@@ -111,10 +111,4 @@ livecd / # emerge sync
 livecd / # cd /usr/portage
 livecd / # scripts/bootstrap.sh</pre>
 
-If bootstrap runs correctly (and it should now that I re-formatted the /opt, /usr, /var, /home, /tmp, and /var/tmp volumes), I can pick back up with the [rest of my original install process](/techblog/2004/06/gentoo-install-3-bootstrapping.shtml)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[01:08](http://www.tgharold.com/techblog/2004/06/troubleshooting-software-raid-boot.shtml)
-
-		</div>
+If bootstrap runs correctly (and it should now that I re-formatted the /opt, /usr, /var, /home, /tmp, and /var/tmp volumes), I can pick back up with the [rest of my original install process](/techblog/2004/06/gentoo-install-3-bootstrapping.shtml)

--- a/_posts/2004/2004-06-18-securing-cwrsync.md
+++ b/_posts/2004/2004-06-18-securing-cwrsync.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>At the office we're working on setting up [cwRSync](http://www.itefix.no/) on the web server array to push the daily web/ftp/smtp log files back to a central point for archiving.  Right now, since all of the web servers are on the same LAN segment at the hosting facility, we're just sending the plain text data across the wire to the rsync port (tcp/873).  Since the previous solution was to use FTP to move the log files around, it's no worse then the old solution from a security standpoint.  (It is, however, much faster and more efficient.)  Security is handled solely thorugh the rsyncd.conf "hosts allow" setting (only the internal IP addresses are allowed to be used to transfer the data) with no passwords or shared keys.
+At the office we're working on setting up [cwRSync](http://www.itefix.no/) on the web server array to push the daily web/ftp/smtp log files back to a central point for archiving.  Right now, since all of the web servers are on the same LAN segment at the hosting facility, we're just sending the plain text data across the wire to the rsync port (tcp/873).  Since the previous solution was to use FTP to move the log files around, it's no worse then the old solution from a security standpoint.  (It is, however, much faster and more efficient.)  Security is handled solely thorugh the rsyncd.conf "hosts allow" setting (only the internal IP addresses are allowed to be used to transfer the data) with no passwords or shared keys.
 
 However, since the next step is that we want to setup pulling those log files automatically back to the main office, we need to look into locking it down further and putting encryption in place (e.g. routing rsync traffic over an ssh tunnel). 
 
@@ -24,10 +24,4 @@ That being said, I'm going to explore some other packages.  All of which will ei
 
 Links:
 
-[Rsync wrapper for Win32](http://footboot.net/rsync-win/) - Uses the cygwin DLLs, but doesn't require a full cygwin install, includes SSH.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:18](http://www.tgharold.com/techblog/2004/06/securing-cwrsync.shtml)
-
-		</div>
+[Rsync wrapper for Win32](http://footboot.net/rsync-win/) - Uses the cygwin DLLs, but doesn't require a full cygwin install, includes SSH.

--- a/_posts/2004/2004-06-19-gentoo-failed-to-load-mii.md
+++ b/_posts/2004/2004-06-19-gentoo-failed-to-load-mii.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>More self-inflicted pain (guarantee that I'm doing this to myself, not due to the Gentoo install guide...)
+More self-inflicted pain (guarantee that I'm doing this to myself, not due to the Gentoo install guide...)
 
 During boot-up after installing the 2.6.6 kernel, the following (2) modules fail to load:
 <pre>Loading module mii...
@@ -21,10 +21,4 @@ Failed to load via-rhine</pre>
 
 The second error is because I had [configured the kernel](/techblog/2004/06/gentoo-install-5-manual-kernel.shtml) to load "via-rhine" as <b>built-in</b> and not as a <b>module</b>.  You can do one or the other, but not both.
 
-Not sure about the "mii" error, I'll merely comment it out in the autoload config file for now and see what happens.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:25](http://www.tgharold.com/techblog/2004/06/gentoo-failed-to-load-mii.shtml)
-
-		</div>
+Not sure about the "mii" error, I'll merely comment it out in the autoload config file for now and see what happens.

--- a/_posts/2004/2004-06-19-gentoo-segmentation-fault-in-vgscan-during-boot.md
+++ b/_posts/2004/2004-06-19-gentoo-segmentation-fault-in-vgscan-during-boot.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Now for the other error that I got during the initial bootup.
+Now for the other error that I got during the initial bootup.
 <pre>* Using /etc/modules.autoload.d/kernel-2.6 as config:
 * Loading module dm-mod...                                                 [ ok ]
 * Autoloaded 1 module(s)
@@ -62,10 +62,4 @@ Links:
 
 [Example of lvm.conf file](https://www.redhat.com/archives/linux-lvm/2003-December/msg00009.html) - shows a more complex lvm.conf file, complete with multiple filters.
 
-[A more complete example lvm.conf file](http://gondor.com/lvm/lvm.conf)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/LVM.shtml">LVM</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:31](http://www.tgharold.com/techblog/2004/06/gentoo-segmentation-fault-in-vgscan.shtml)
-
-		</div>
+[A more complete example lvm.conf file](http://gondor.com/lvm/lvm.conf)

--- a/_posts/2004/2004-06-20-linux-bare-metal-backup-and-recovery-planning.md
+++ b/_posts/2004/2004-06-20-linux-bare-metal-backup-and-recovery-planning.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>The whole concept behind bare-metal restore is that it's the shortest point from pulling a replacement set of server hardware out of a box to having a working system to replace the one that's down.  Ideally, without having to go through re-installing the operating system (which, in the case of Gentoo, can take a few hours).  It also (generally) only works when you have exactly the same hardware in the replacement box as the box that's kaput.  So if you're using any exotic hardware (e.g. a fancy RAID card), you'd best buy (3).  That way when the first one dies, you can put in one of the (2) spare cards and still get at your data.
+The whole concept behind bare-metal restore is that it's the shortest point from pulling a replacement set of server hardware out of a box to having a working system to replace the one that's down.  Ideally, without having to go through re-installing the operating system (which, in the case of Gentoo, can take a few hours).  It also (generally) only works when you have exactly the same hardware in the replacement box as the box that's kaput.  So if you're using any exotic hardware (e.g. a fancy RAID card), you'd best buy (3).  That way when the first one dies, you can put in one of the (2) spare cards and still get at your data.
 
 Some backup software makes the process as simple as dropping a boot CD in the drive and inserting the most recent bare-metal backup (sometimes called a "gold" tape?) tape.  It can also be a multi-step process, where the first step restores the operating system to a known state and the second step handles restoring the data and applications.
 
@@ -24,10 +24,4 @@ Since I'm not ready to tackle writing a guide, I'll settle for a few links:
 
 [Unix SysAdm Resources: Backup &amp; Archival Software for Unix](http://www.stokely.com/unix.sysadm.resources/backup.html) (Stokely Consulting) - Listing of backup software for unix.
 
-[Linux Backups Mini-FAQ](http://kmself.home.netcom.com/Linux/FAQs/backups.html) (Karsten M. Self) - Good article on simply using "tar".<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/DisasterRecovery.shtml">DisasterRecovery</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Linux.shtml">Linux</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[01:06](http://www.tgharold.com/techblog/2004/06/linux-bare-metal-backup-and-recovery.shtml)
-
-		</div>
+[Linux Backups Mini-FAQ](http://kmself.home.netcom.com/Linux/FAQs/backups.html) (Karsten M. Self) - Good article on simply using "tar".

--- a/_posts/2004/2004-06-25-spf-records.md
+++ b/_posts/2004/2004-06-25-spf-records.md
@@ -10,10 +10,4 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Published [SPF records](http://spf.pobox.com/) for my domain this week.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SPF.shtml">SPF</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:55](http://www.tgharold.com/techblog/2004/06/spf-records.shtml)
-
-		</div>
+Published [SPF records](http://spf.pobox.com/) for my domain this week.

--- a/_posts/2004/2004-07-02-removable-patasata-drive-bays.md
+++ b/_posts/2004/2004-07-02-removable-patasata-drive-bays.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Shopping around for some removable drive bays (either PATA or SATA).  I definitely don't want anything plastic, which cuts the field a bit.  [StarTech](http://www.startech.com/) seem to make some nice drawers with multiple fans.  
+Shopping around for some removable drive bays (either PATA or SATA).  I definitely don't want anything plastic, which cuts the field a bit.  [StarTech](http://www.startech.com/) seem to make some nice drawers with multiple fans.  
 
 It's a pity that their multi-bay SATA systems aren't ready yet, because that looks interesting.  (Holds 3 SATA drives in removable shells, takes up 2 5.25" drive bays, has a single large fan on the back.)
 
@@ -23,10 +23,4 @@ Extra bays are $20-$30, extra caddies are $50-$60.
 
 Since we'll be using these for backups, we'll probably go with PATA and 5400rpm drives (which run a lot cooler then 7200rpm SATA drives).  I have to allow for ambient temperatures up to 85F at the office and I'm afraid that 7200rpm drives would cook themselves.
 
-Update: I now own a set of the DRW115ATA drawers.  The construction is quite sturdy, but the fit and finish is not always the best.  They can be moderately difficult to slide in and out of the drive bays.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:13](http://www.tgharold.com/techblog/2004/07/removable-patasata-drive-bays.shtml)
-
-		</div>
+Update: I now own a set of the DRW115ATA drawers.  The construction is quite sturdy, but the fit and finish is not always the best.  They can be moderately difficult to slide in and out of the drive bays.

--- a/_posts/2004/2004-07-08-misc-mozilla-bits.md
+++ b/_posts/2004/2004-07-08-misc-mozilla-bits.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Just a few misc Mozilla 1.7 settings that I've found useful.  All of these need to be added/changed in your <b>prefs.js</b> file in your profile directory.  Make sure that you've exited out of all Mozilla windows, including the QuickLaunch icon in the system tray before making your edits.  Otherwise, when Mozilla exits again later, it will overwrite your changes.
+Just a few misc Mozilla 1.7 settings that I've found useful.  All of these need to be added/changed in your <b>prefs.js</b> file in your profile directory.  Make sure that you've exited out of all Mozilla windows, including the QuickLaunch icon in the system tray before making your edits.  Otherwise, when Mozilla exits again later, it will overwrite your changes.
 
 It's also a good idea to make a backup file of your prefs.js file prior to making changes.
 
@@ -28,11 +28,3 @@ user_pref("mail.identity.id5.fcc_folder_picker_mode", "1");
 2) Displaying an error page instead of just a blank page when a webpage times out.  One of the most annoying features in base Mozilla/Firebird is the way that they handle timeout errors.  Instead of getting an error message on the screen, you get a blank page and the location bar will have been cleared.  Which, if you were trying to load the page in the background for later viewing, means you have to try and remember or figure out what link you were trying to look at.  Adding the following line to your prefs.js file will at least give you an error display that lets you retry the URL:
 
 user_pref("browser.xul.error_pages.enabled", true);
-
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:49](http://www.tgharold.com/techblog/2004/07/misc-mozilla-bits.shtml)
-
-		</div>

--- a/_posts/2004/2004-07-09-gentoo-setting-up-postgresql.md
+++ b/_posts/2004/2004-07-09-gentoo-setting-up-postgresql.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Getting PostgreSQL installed really isn't that difficult on Gentoo Linux.
+Getting PostgreSQL installed really isn't that difficult on Gentoo Linux.
 <pre># emerge -s postgresql
 # emerge postgresql
 (install takes a while, didn't time it)
@@ -46,10 +46,4 @@ The default Gentoo install seems to already include a "postgres" user in /etc/pa
 
 Now you can continue with [section 16](http://www.postgresql.org/docs/7.4/interactive/creating-cluster.html).  Skip the page about creating the database cluster, it's already been created in "<b>/var/lib/postgresql/data</b>" back when you ran the "ebuild config" command.  You can verify this by looking at the config file ("<b>cat /etc/conf.d/postgresql</b>"), where the <b>PGDATA=</b> line indicates the location of the database.  
 
-In fact, skip straight to [chapter 16.4 - Run-time Configuration](http://www.postgresql.org/docs/7.4/interactive/runtime-config.html), because the server is already running.  To verify that the server is running, "<b>cat /var/lib/postgresql/data/postmaster.pid</b>".  Make a note of the PID on the first line (second line is the database location), then "<b>cat /proc/nnnn/status</b>" (replacing "nnnn" with the PID).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PostgreSQL.shtml">PostgreSQL</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[00:12](http://www.tgharold.com/techblog/2004/07/gentoo-setting-up-postgresql.shtml)
-
-		</div>
+In fact, skip straight to [chapter 16.4 - Run-time Configuration](http://www.postgresql.org/docs/7.4/interactive/runtime-config.html), because the server is already running.  To verify that the server is running, "<b>cat /var/lib/postgresql/data/postmaster.pid</b>".  Make a note of the PID on the first line (second line is the database location), then "<b>cat /proc/nnnn/status</b>" (replacing "nnnn" with the PID).

--- a/_posts/2004/2004-07-20-linux-on-laptops.md
+++ b/_posts/2004/2004-07-20-linux-on-laptops.md
@@ -10,13 +10,6 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Today's useful link is: [Linux on Laptops](http://www.linux-on-laptops.com/).
+Today's useful link is: [Linux on Laptops](http://www.linux-on-laptops.com/).
 
  They have a short-n-sweet index where people submit links to their HOWTO pages regarding how to get a specific distro to work on a particular make/model of laptop.
- <div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[22:33](http://www.tgharold.com/techblog/2004/07/linux-on-laptops.shtml)
-
-		</div>

--- a/_posts/2004/2004-07-21-hacking-together-a-minimal-rsync-for-windows-installation.md
+++ b/_posts/2004/2004-07-21-hacking-together-a-minimal-rsync-for-windows-installation.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Based on what I've read elsewhere (links in my [previous posting](/techblog/2004/06/rsync-and-windows.shtml)), I think I can pull the relevant pieces out of the [Cygwin package](http://cygwin.com/mirrors.html).  I'll try to keep good notes as to what worked and what didn't, but let me know if you find any errors.  [Rsync wrapper for Win32](http://footboot.net/rsync-win/) seems to be a good starting point for which DLLs and files I'll need to pull out of the standard Cygwin release.
+Based on what I've read elsewhere (links in my [previous posting](/techblog/2004/06/rsync-and-windows.shtml)), I think I can pull the relevant pieces out of the [Cygwin package](http://cygwin.com/mirrors.html).  I'll try to keep good notes as to what worked and what didn't, but let me know if you find any errors.  [Rsync wrapper for Win32](http://footboot.net/rsync-win/) seems to be a good starting point for which DLLs and files I'll need to pull out of the standard Cygwin release.
 
 You can download the files off of any of the [Cygwin public mirrors](http://cygwin.com/mirrors.html).  Grab the following  archives and extract them to a temporary directory on your machine.  
 
@@ -41,10 +41,4 @@ If you have a log file, there should now be an entry indicating that rsync has s
 To do:
 - create the user account to use for the rsync service
 - setup rsync to run as a service (need the SRVANY.EXE file, I think)
-- figure out how to get rsync talking through an SSHD server<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:53](http://www.tgharold.com/techblog/2004/07/hacking-together-minimal-rsync-for.shtml)
-
-		</div>
+- figure out how to get rsync talking through an SSHD server

--- a/_posts/2004/2004-07-21-minimal-cygwin-install-for-rsync-and-ssh.md
+++ b/_posts/2004/2004-07-21-minimal-cygwin-install-for-rsync-and-ssh.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Source links:
+Source links:
 
 [How to setup the secure shell daemon on a Windows 2000 machine?](http://ist.uwaterloo.ca/~kscully/cygwin/CygwinSSHd_win2k.html)
 [Windows Rsync Server Setup](http://www.gaztronics.net/rsync.php)
@@ -37,10 +37,4 @@ tags:
 a) Setup your rsync.conf file (in the "etc" folder)
 b) create a service account for use by the rsync service
 c) create a Windows service using the "cygrunsvc" tool
-d) setup OpenSSH and then re-configure rsync to use it<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[19:19](http://www.tgharold.com/techblog/2004/07/minimal-cygwin-install-for-rsync-and.shtml)
-
-		</div>
+d) setup OpenSSH and then re-configure rsync to use it

--- a/_posts/2004/2004-07-21-rsync-and-windows.md
+++ b/_posts/2004/2004-07-21-rsync-and-windows.md
@@ -10,15 +10,8 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This is a follow-up to my previous post about [Securing cwRSync](/techblog/2004/06/securing-cwrsync.shtml).  We were using the "[cwRSync package](http://www.itefix.no/)", but when running in server mode it doesn't know how to talk to clients over an SSH-encrypted connection. Which isn't a big deal if you're only talking to other servers on the local network, but is problematic in cases where you have to be wary of eavesdropping (across WiFi links or untrusted networks like the internet). So I've been looking off-and-on over the past month at figuring out how to get an rsync service running using SSH on a Windows server.
+This is a follow-up to my previous post about [Securing cwRSync](/techblog/2004/06/securing-cwrsync.shtml).  We were using the "[cwRSync package](http://www.itefix.no/)", but when running in server mode it doesn't know how to talk to clients over an SSH-encrypted connection. Which isn't a big deal if you're only talking to other servers on the local network, but is problematic in cases where you have to be wary of eavesdropping (across WiFi links or untrusted networks like the internet). So I've been looking off-and-on over the past month at figuring out how to get an rsync service running using SSH on a Windows server.
 
  One option is to install the full [Cygwin](http://cygwin.com/) package.  Which is a bit much for a server (or rather, I'm not comfortable installing Cygwin on a server... yet).
 
  Another option seems to be the [OpenSSH for Windows](http://sshwindows.sourceforge.net/) project at SourceForge.  That doesn't include rsync though, just scp.  So I might look at "[Installing ssh and rsync on a Windows machine: minimalist approach](http://optics.ph.unimelb.edu.au/help/rsync/rsync_pc1.html)" which requires an absolute bare minimum of files to be installed. However, the files at that location are from Jan 2002, which is a bit old and the [latest version as of July 2004 for the Cygwin DLL is cygwin-1.5.10-2](http://cygwin.com/ml/cygwin-announce/2004-05/).
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[17:59](http://www.tgharold.com/techblog/2004/07/rsync-and-windows.shtml)
-
-		</div>

--- a/_posts/2004/2004-07-21-rsyncconf-file-for-cygwin-environments.md
+++ b/_posts/2004/2004-07-21-rsyncconf-file-for-cygwin-environments.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>You should definitely refer to the [official rsync website](http://rsync.samba.org/) for the real documentation on [configuring the rsyncd.conf file](http://rsync.samba.org/ftp/rsync/rsyncd.conf.html).  
+You should definitely refer to the [official rsync website](http://rsync.samba.org/) for the real documentation on [configuring the rsyncd.conf file](http://rsync.samba.org/ftp/rsync/rsyncd.conf.html).  
 
 Locate your /etc folder under where you installed Cygwin.  Since I installed Cygwin to C:\bin\cygwin, my /etc folder is C:\bin\cygwin\etc.  For a fresh install, you'll need to create the "rsyncd.conf" file in that folder (C:\bin\cygwin\etc\rsyncd.conf).
 
@@ -23,10 +23,3 @@ log file = rsyncd.log
 path = /cygdrive/d/rsync/test
 read only = false
 transfer logging = yes</pre>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:00](http://www.tgharold.com/techblog/2004/07/rsyncconf-file-for-cygwin-environments.shtml)
-
-		</div>

--- a/_posts/2004/2004-07-26-openssh-for-windows.md
+++ b/_posts/2004/2004-07-26-openssh-for-windows.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I've pretty much given up on trying to extract the key bits from Cygwin in order to setup a SSHD server.  The [OpenSSH for Windows](http://sshwindows.sourceforge.net/) project at SourceForge seems to have what I'm looking for, they just don't have the RSync application included.
+I've pretty much given up on trying to extract the key bits from Cygwin in order to setup a SSHD server.  The [OpenSSH for Windows](http://sshwindows.sourceforge.net/) project at SourceForge seems to have what I'm looking for, they just don't have the RSync application included.
 
 For an excellent introduction to SSH, check out [OpenSSH for the impatient](http://www.ypsolog.com/docs/openssh.html).
 
@@ -30,10 +30,4 @@ b) RSAAuthentication - setting this to no will disable the ability to login with
 
 c) PasswordAuthentication - you may want to change this to "no" and force users to setup a public/private key pair in order to login to the server.
 
-(note: this post was never completed... so use with a grain of salt)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[17:01](http://www.tgharold.com/techblog/2004/07/openssh-for-windows.shtml)
-
-		</div>
+(note: this post was never completed... so use with a grain of salt)

--- a/_posts/2004/2004-08-17-flac-audio.md
+++ b/_posts/2004/2004-08-17-flac-audio.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Re-ripping my CDs to a lossless format for permanent archival (I had ripped them all as 128kbps a few years ago, then reripped at 160kbps, now I'm going lossless).  Here's two links that I found useful.
+Re-ripping my CDs to a lossless format for permanent archival (I had ripped them all as 128kbps a few years ago, then reripped at 160kbps, now I'm going lossless).  Here's two links that I found useful.
 
 [Comparison of lossless audio codecs](http://members.home.nl/w.speek/comparison.htm) - Compares most of the popular lossless codecs such as FLAC
 
@@ -18,10 +18,4 @@ tags:
 
 Right now, I'm probably going to rip at compression level = 5 using Easy CD-DA Extractor's Audio CD Ripper.  My M.I.B. CD weighed in at  436MB with FLAC(5) compared to about 485MB with compression level zero.  That means I'll be able to archive about (8) albums on a DVD-R (compared to 20-30 using 160kbps MP3).  If I had ripped it to 320kbps CBR MP3, it would've ended up as 151MB.
 
-[AliveAudio - Getting to know FLAC](https://www.aliveaudio.net/flac.html) - Lists information about players and ripping utilities.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:59](http://www.tgharold.com/techblog/2004/08/flac-audio.shtml)
-
-		</div>
+[AliveAudio - Getting to know FLAC](https://www.aliveaudio.net/flac.html) - Lists information about players and ripping utilities.

--- a/_posts/2004/2004-09-19-tyan-tiger-k8w-s2875.md
+++ b/_posts/2004/2004-09-19-tyan-tiger-k8w-s2875.md
@@ -10,13 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [2CPU.com Tyan Tiger K8W (S2875)](http://forums.2cpu.com/showthread.php?s=eacb655947e462adbd7eb8ce03697801&amp;threadid=45804) - Thread with users of the Tyan Tiger K8W.
 
-I have one of these boards with a pair of Opteron 246s.  Great for video work, but I never managed to get Aquamark3 running on it to determine performance.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:52](http://www.tgharold.com/techblog/2004/09/tyan-tiger-k8w-s2875.shtml)
-
-		</div>
+I have one of these boards with a pair of Opteron 246s.  Great for video work, but I never managed to get Aquamark3 running on it to determine performance.

--- a/_posts/2004/2004-10-26-installing-ssh-and-rsync-on-a-windows-machine-minimalist-approach.md
+++ b/_posts/2004/2004-10-26-installing-ssh-and-rsync-on-a-windows-machine-minimalist-approach.md
@@ -10,13 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [Installing ssh and rsync on a Windows machine: minimalist approach](http://optics.ph.unimelb.edu.au/help/rsync/rsync_pc1.html)
 
-Found this on Slashdot recently... haven't had time to go read it.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:21](http://www.tgharold.com/techblog/2004/10/installing-ssh-and-rsync-on-windows.shtml)
-
-		</div>
+Found this on Slashdot recently... haven't had time to go read it.

--- a/_posts/2004/2004-11-08-win2003-scheduled-tasks-0x80070005-error.md
+++ b/_posts/2004/2004-11-08-win2003-scheduled-tasks-0x80070005-error.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Trying to setup a backup job (kicked off by a .cmd file) on Windows 2003.  I have a special, limited rights, user account created (rather then running the backup job under the administrator account).  Everything seems fine until I go to test my scheduled task.
+Trying to setup a backup job (kicked off by a .cmd file) on Windows 2003.  I have a special, limited rights, user account created (rather then running the backup job under the administrator account).  Everything seems fine until I go to test my scheduled task.
 
 Looking at the log (Scheduled Tasks - Advanced - View Log) will show: 
 
@@ -20,10 +20,4 @@ The specific error is:
 
 ["Access is denied" error message when you run a batch job on a Windows Server 2003-based computer](http://support.microsoft.com/?kbid=867466)
 
-As expected, this is a permissions error.  Specifically, you need to grant permissions for batch processes to use "cmd.exe".<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:49](http://www.tgharold.com/techblog/2004/11/win2003-scheduled-tasks-0x80070005.shtml)
-
-		</div>
+As expected, this is a permissions error.  Specifically, you need to grant permissions for batch processes to use "cmd.exe".

--- a/_posts/2004/2004-12-05-inaccessible_boot_device.md
+++ b/_posts/2004/2004-12-05-inaccessible_boot_device.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Came home from my weekend trip to find that one of my Windows 2000 servers had crashed with the INACCESSIBLE_BOOT_DEVICE 0x0000007B error message.  Apparently, the power went out sometime this weekend because the 2nd server had turned itself off, and when the primary server booted back up it was BSOD'd with the 7B error.
+Came home from my weekend trip to find that one of my Windows 2000 servers had crashed with the INACCESSIBLE_BOOT_DEVICE 0x0000007B error message.  Apparently, the power went out sometime this weekend because the 2nd server had turned itself off, and when the primary server booted back up it was BSOD'd with the 7B error.
 
 The boot disks are mounted on a Promise FastTrak100 TX2 RAID card (which showed both disks as working).  So I wasn't too worried (I also have fairly fresh backups of everything on the RAID array.
 
@@ -24,10 +24,4 @@ Next, I booted up the Win2000 install CDs, loaded the RAID driver from floppy an
 
 Once it had finished checking the boot drive (C:), I rebooted the box and it came up fine.  It ran CHKDSK on all of the other drives during boot (finding some minor errors in the 2nd partition that is part of the Promise RAID).
 
-My guess at this point is that when the UPS ran out of juice and the box crashed, it caused some issues with the NTFS file system.  One of these days I'll put each of my personal servers on their own UPSs and hookup the "shutdown on low battery" cable.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2004.shtml">2004</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:08](http://www.tgharold.com/techblog/2004/12/inaccessiblebootdevice.shtml)
-
-		</div>
+My guess at this point is that when the UPS ran out of juice and the box crashed, it caused some issues with the NTFS file system.  One of these days I'll put each of my personal servers on their own UPSs and hookup the "shutdown on low battery" cable.

--- a/_posts/2005/2005-01-19-printer-banner-on-windows-servers.md
+++ b/_posts/2005/2005-01-19-printer-banner-on-windows-servers.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [How do I configure a Print Separator Page? ](http://www.windowsitpro.com/Article/ArticleID/14517/14517.html) (March 1999)
 - Explains very briefly how to do it.
 
@@ -18,10 +18,4 @@ tags:
 - A much more useful article.
 
 [Shared printer separator page for Windows 2000 and Windows XP](http://www.windowsnetworking.com/kbase/WindowsTips/WindowsXP/AdminTips/Network/SharedprinterseparatorpageforWindows2000andWindowsXP.html)
-- Another source.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[17:06](http://www.tgharold.com/techblog/2005/01/printer-banner-on-windows-servers.shtml)
-
-		</div>
+- Another source.

--- a/_posts/2005/2005-02-11-subversion-links.md
+++ b/_posts/2005/2005-02-11-subversion-links.md
@@ -10,15 +10,9 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [Experiences with SubVersion](http://www.chiark.greenend.org.uk/~sgtatham/svn.html) (first-hand user account of using SubVersion compared to CVS)
 
 [Version Control System Comparison](http://better-scm.berlios.de/comparison/comparison.html)
 
-[Why Bitkeeper Isn't Right For Free Software](http://web.mit.edu/ghudson/thoughts/bitkeeper.whynot)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:03](http://www.tgharold.com/techblog/2005/02/subversion-links.shtml)
-
-		</div>
+[Why Bitkeeper Isn't Right For Free Software](http://web.mit.edu/ghudson/thoughts/bitkeeper.whynot)

--- a/_posts/2005/2005-03-29-gentoo-epia-install-part-1.md
+++ b/_posts/2005/2005-03-29-gentoo-epia-install-part-1.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
 
 So, I'm back to re-building my VIA EPIA linux box (it was scavanged for another project for a few months).  Once again, I'm digging out my Gentoo CDs and I'm going to simply build a box where I can house my music MP3s and do some Apache / PostGreSQL work.  Since this is an EPIA box, the [EPIAWiki.org](http://www.epiawiki.org/wiki/tiki-index.php) site comes in handy.  I'll also be referring back to my [April 2004 notes](2004_04_01_archive.shtml) to speed up my setup process.
@@ -88,10 +88,4 @@ First up is BIOS settings:
 - (information only)
 
 <b>Frequency/Voltage Control</b>
-- (left alone)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:55](http://www.tgharold.com/techblog/2005/03/gentoo-epia-install-part-1.shtml)
-
-		</div>
+- (left alone)

--- a/_posts/2005/2005-03-29-gentoo-epia-install-part-2.md
+++ b/_posts/2005/2005-03-29-gentoo-epia-install-part-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
 
 First up, still using the 2004.0 Gentoo Boot CD and referring to my [old notes from last year](/techblog/2004/04/gentoo-epia-install-part-1.shtml).  Also note that I rebuilt it in [June 2004](http://www.tgharold.com/techblog/2004_06_01_archive.shtml), so it may be better to look at those notes.  Especially the "gentoo nohotplug" command during the boot process.
@@ -25,10 +25,4 @@ Key commands (that don't do anything other then report status):
 
 Now to fire up fdisk and wipe any existing partitions.  Then I'm going to create the same partitions I did last year.  (Helps to refer to the Gentoo handbook for this step.)
 
-Currently making my raid volumes, no changes from the June 2004 instructions.  Verifying progress using "<b>cat /proc/mdstat</b>".<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:16](http://www.tgharold.com/techblog/2005/03/gentoo-epia-install-part-2.shtml)
-
-		</div>
+Currently making my raid volumes, no changes from the June 2004 instructions.  Verifying progress using "<b>cat /proc/mdstat</b>".

--- a/_posts/2005/2005-03-29-gentoo-epia-install-part-3.md
+++ b/_posts/2005/2005-03-29-gentoo-epia-install-part-3.md
@@ -10,14 +10,8 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>The RAID array has finally finished synchronizing.  Continuing on, referecing my [June 2004 notes about setting up LVM](/techblog/2004/06/gentoo-install-2-via-epia-me6000.shtml).
+The RAID array has finally finished synchronizing.  Continuing on, referecing my [June 2004 notes about setting up LVM](/techblog/2004/06/gentoo-install-2-via-epia-me6000.shtml).
 
 Things went well up until I started extracting the portage tree.  Then I started to get random errors, which means I need to stop and verify that the hardware is behaving properly.
 
-(Time to dig out my memory test programs...)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[16:09](http://www.tgharold.com/techblog/2005/03/gentoo-epia-install-part-3.shtml)
-
-		</div>
+(Time to dig out my memory test programs...)

--- a/_posts/2005/2005-03-31-gentoo-20050-on-gigabyte-ga-6va7-part-1.md
+++ b/_posts/2005/2005-03-31-gentoo-20050-on-gigabyte-ga-6va7-part-1.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
 
 While I swap around some memory modules in the old EPIA box, I'm also going to take a swipe at using the new 2005.0 Gentoo image and build a 2nd box.
@@ -24,10 +24,4 @@ Sec S: CD-ROM - /dev/hdd
 
 I also have a 3rd hard drive (80GB, /dev/hde) hooked up to an old Promise FastTrak66 PCI RAID card.  It uses the PDC20262 chip and I'm really just using it as an IDE card rather then making use of its RAID functionality.
 
-I plan on mirroring using the two 72GB master drives and using the 80GB as a backup/scratch disk.  Similar setup and goals as the EPIA box from [last June's install](/techblog/2004_06_01_archive.shtml).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:32](http://www.tgharold.com/techblog/2005/03/gentoo-20050-on-gigabyte-ga-6va7-part.shtml)
-
-		</div>
+I plan on mirroring using the two 72GB master drives and using the 80GB as a backup/scratch disk.  Similar setup and goals as the EPIA box from [last June's install](/techblog/2004_06_01_archive.shtml).

--- a/_posts/2005/2005-03-31-gentoo-20050-on-gigabyte-ga-6va7-part-2.md
+++ b/_posts/2005/2005-03-31-gentoo-20050-on-gigabyte-ga-6va7-part-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
 
 Okay, tossed the new 2005.0 boot CD in, and I'm booting it up.  Just trying a standard default boot for the moment (not trying to use the "nohotplug" option yet).
@@ -136,10 +136,4 @@ If you get the error message: "raid_disks + spare_disks != nr_disks" when attemp
 
 Building the raid sets may take a while, so once again, I'll come back to this point in a few hours.
 
-Update:  <b>mkraid is tossing errors</b> (see my next post)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:43](http://www.tgharold.com/techblog/2005/03/gentoo-20050-on-gigabyte-ga-6va7-part_31.shtml)
-
-		</div>
+Update:  <b>mkraid is tossing errors</b> (see my next post)

--- a/_posts/2005/2005-03-31-gentoo-mkraid-errors.md
+++ b/_posts/2005/2005-03-31-gentoo-mkraid-errors.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
 
 So, I've created my /etc/raidtab file.  I've done the "<b>modprobe md</b>" and "<b>modprobe dm-mod</b>" commands.  I'm able to "<b>cat /proc/mdstat</b>" which shows that I have no personalities and no unused devices.  But, when I try to use the "<b>mkraid</b>" command, I get the following error:
@@ -32,10 +32,4 @@ Other possible gotches:
 
 1) (not confirmed) After you fdisk, you may want to reboot so make sure that the disks are no longer in use.  Otherwise you may get "bd_claim" errors when trying to setup the RAID array.
 
-(still fighting with this a few hours later... going to start a new post)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:08](http://www.tgharold.com/techblog/2005/03/gentoo-mkraid-errors.shtml)
-
-		</div>
+(still fighting with this a few hours later... going to start a new post)

--- a/_posts/2005/2005-03-31-installing-gentoo-on-software-raid.md
+++ b/_posts/2005/2005-03-31-installing-gentoo-on-software-raid.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I'm currently fighting with this again.  Apparently, there have been some changes between the 2004.0 CD and the 2005.0 CD (mostly related to the 2.6 kernal and the DevFS vs UDev systems).
+I'm currently fighting with this again.  Apparently, there have been some changes between the 2004.0 CD and the 2005.0 CD (mostly related to the 2.6 kernal and the DevFS vs UDev systems).
 
 First off, some tips-n-tricks:
 
@@ -90,10 +90,4 @@ Units = cylinders of 1008 * 512 = 516096 bytes
 /dev/hdc4            8188      148945    70942032   fd  Linux raid autodetect
 livecd root # </code>
 
-All of which looks right and proper.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:48](http://www.tgharold.com/techblog/2005/03/installing-gentoo-on-software-raid.shtml)
-
-		</div>
+All of which looks right and proper.

--- a/_posts/2005/2005-04-19-gentoo-20043-on-gigabyte-ga-6va7-part-1.md
+++ b/_posts/2005/2005-04-19-gentoo-20043-on-gigabyte-ga-6va7-part-1.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
 
 This is a continuation of [Gentoo and Software RAID (2004.3)](/techblog/2005/04/gentoo-and-software-raid-20043.shtml), where I configured the disks and setup the RAID array.  I'm now picking up at the point where the RAID array has been configured and we're ready to start installing file systems.
@@ -198,10 +198,4 @@ Change into the new system (note that we already mounted the proc filesystem ear
 
 This should update your portage tree to the latest version (and make take a while to run).
 
-([See the next step](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[16:21](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part.shtml)
-
-		</div>
+([See the next step](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part.shtml))

--- a/_posts/2005/2005-04-19-gentoo-20043-on-gigabyte-ga-6va7-part-2.md
+++ b/_posts/2005/2005-04-19-gentoo-20043-on-gigabyte-ga-6va7-part-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>([Continuation of part 1](/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part.shtml))
+([Continuation of part 1](/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part.shtml))
 
 <code># ls -l /etc/make.profile</code>
 
@@ -25,10 +25,4 @@ This will take a while to run (I estimate a few hours, maybe even overnight).  O
 
 Which will also take a few hours.
 
-([next step](/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part_20.shtml))<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:58](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part_19.shtml)
-
-		</div>
+([next step](/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part_20.shtml))

--- a/_posts/2005/2005-04-19-gentoo-and-software-raid-20043.md
+++ b/_posts/2005/2005-04-19-gentoo-and-software-raid-20043.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Going back to the 2004.3 Gentoo Universal boot CD.  Trying to get past my previous issue [bd_claim issues when setting up a software RAID](/techblog/2005/03/installing-gentoo-on-software-raid.shtml).  This is on my Gigabyte GA-6VA7+ motherboard ([notes on the Gigabyte GA-6VA7+ motherboard and other hardware](/techblog/2005/03/gentoo-20050-on-gigabyte-ga-6va7-part.shtml)).
+Going back to the 2004.3 Gentoo Universal boot CD.  Trying to get past my previous issue [bd_claim issues when setting up a software RAID](/techblog/2005/03/installing-gentoo-on-software-raid.shtml).  This is on my Gigabyte GA-6VA7+ motherboard ([notes on the Gigabyte GA-6VA7+ motherboard and other hardware](/techblog/2005/03/gentoo-20050-on-gigabyte-ga-6va7-part.shtml)).
 
 Starting with the usual tricks:
 
@@ -98,10 +98,4 @@ Seems to be working fine.  Once each RAID set finishes initialization, I'll crea
 <code># mdadm --create /dev/md2 --level=1 --raid-devices=2 /dev/hda3  /dev/hdc3
 # mdadm --create /dev/md3 --level=1 --raid-devices=2 /dev/hda4 /dev/hdc4</code>
 
-The last RAID set will take a while to initialize (2 hours?), so I'm going to go work on other things while it runs.  I also need to go back and review the documentation to see what else I need to do when doing software RAID.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:04](http://www.tgharold.com/techblog/2005/04/gentoo-and-software-raid-20043.shtml)
-
-		</div>
+The last RAID set will take a while to initialize (2 hours?), so I'm going to go work on other things while it runs.  I also need to go back and review the documentation to see what else I need to do when doing software RAID.

--- a/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-3.md
+++ b/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-3.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
 
 ([previous step](/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part_19.shtml))
@@ -32,10 +32,4 @@ Last year, I went with development-sources for the kernel in order to get 2.6.  
 
 This takes a while to run (maybe an hour or two).
 
-(next step)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[19:42](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-ga-6va7-part_20.shtml)
-
-		</div>
+(next step)

--- a/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-4.md
+++ b/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-4.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
 
 (previous step)
@@ -140,10 +140,4 @@ Now, some misc stuff:
 
 (add a user called 'john' and set a password)</code>
 
-(next step)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:43](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-g_111404509792475776.shtml)
-
-		</div>
+(next step)

--- a/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-5.md
+++ b/_posts/2005/2005-04-20-gentoo-20043-on-gigabyte-ga-6va7-part-5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all until I find out why I'm ending up with non-bootable systems (looks like a bug in the 2.6 kernel).</b>
 
 (previous step)
@@ -70,10 +70,4 @@ livecd / # reboot</code>
 
 Pull the CD-ROM at this point, otherwise the LiveCD will probably boot.
 
-(next step)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gigabyte-GA-6VA7%2B.shtml">Gigabyte-GA-6VA7+</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:39](http://www.tgharold.com/techblog/2005/04/gentoo-20043-on-gigabyte-g_111405560831835556.shtml)
-
-		</div>
+(next step)

--- a/_posts/2005/2005-04-20-gentoo-upgrading-your-profile.md
+++ b/_posts/2005/2005-04-20-gentoo-upgrading-your-profile.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>At some point, I need to upgrade my Gentoo profile from 2004.3 to 2005.0.  Here's the error message that you see on screen when you need to do this.
+At some point, I need to upgrade my Gentoo profile from 2004.3 to 2005.0.  Here's the error message that you see on screen when you need to do this.
 
 <code>livecd linux # emerge (something)
 
@@ -33,10 +33,4 @@ To upgrade do the following steps:
 
 # More information can be found at the following URLs:
 # http://www.gentoo.org/doc/en/gentoo-upgrading.xml
-# http://www.gentoo.org/doc/en/migration-to-2.6.xml</code><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:59](http://www.tgharold.com/techblog/2005/04/gentoo-upgrading-your-profile.shtml)
-
-		</div>
+# http://www.gentoo.org/doc/en/migration-to-2.6.xml</code>

--- a/_posts/2005/2005-04-24-gentoo-cant-create-lock-file.md
+++ b/_posts/2005/2005-04-24-gentoo-cant-create-lock-file.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Well, first glitch. Looking at my boot screen with [Shift-PgUp] / [Shift-PgDn] to find the error. I see that the Software RAID is working fine (it built md0..md3 automatically).
+Well, first glitch. Looking at my boot screen with [Shift-PgUp] / [Shift-PgDn] to find the error. I see that the Software RAID is working fine (it built md0..md3 automatically).
 
 <code>* Mounting proc at /proc [ ok ]
 * Mounting sysfs at /sys [ !! ]
@@ -33,10 +33,4 @@ Give root password for maintenance
 
 So, according to a quick google, this indicates an issue with /etc/fstab.
 
-I'll be digging into this in a few days when I get a chance.  (See [Troubleshooting 1](http://www.blogger.com/techblog/2005/04/gentoo-troubleshooting-1.shtml).)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[00:10](http://www.tgharold.com/techblog/2005/04/gentoo-cant-create-lock-file.shtml)
-
-		</div>
+I'll be digging into this in a few days when I get a chance.  (See [Troubleshooting 1](http://www.blogger.com/techblog/2005/04/gentoo-troubleshooting-1.shtml).)

--- a/_posts/2005/2005-04-29-gentoo-troubleshooting-1.md
+++ b/_posts/2005/2005-04-29-gentoo-troubleshooting-1.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So, I've got a system that isn't booting yet.  The boot error is:
+So, I've got a system that isn't booting yet.  The boot error is:
 
 <code>* Mounting proc at /proc [ ok ]
 * Mounting sysfs at /sys [ !! ]
@@ -100,10 +100,4 @@ Nope.
 
 Attempt #5 - using [this thread over at the gentoo forums](http://forums.gentoo.org/viewtopic-t-318344-highlight-mtab.html), I added some more information to my kernel line in the grub.conf file.
 
-Nope.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:44](http://www.tgharold.com/techblog/2005/04/gentoo-troubleshooting-1.shtml)
-
-		</div>
+Nope.

--- a/_posts/2005/2005-05-03-cwrsync-and-copssh.md
+++ b/_posts/2005/2005-05-03-cwrsync-and-copssh.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <i>Note: These directions are works-in-progress... in fact, they might not even work at all.  I got side-tracked before I could finish this and will re-visit it at some point in the future.</i>
 
 The folks who created cwRSync ([www.itefix.no](http://www.itefix.no/)) have now released a package called copSSH which is basically SSH for windows and works with cwRSync.  I'll be refering back to my old post about [installing cwRSync](http://www.tgharold.com/techblog/2004/06/installing-cwrsync-on-windows-2000.shtml).  The latest version I have is from late April 2005 and includes bug fixes for Windows Server 2003.
@@ -79,10 +79,3 @@ Now we need to install copSSH.
 
 </li>
 </ol>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:29](http://www.tgharold.com/techblog/2005/05/cwrsync-and-copssh.shtml)
-
-		</div>

--- a/_posts/2005/2005-06-27-gentoo-no-news.md
+++ b/_posts/2005/2005-06-27-gentoo-no-news.md
@@ -10,10 +10,4 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Been fighting with the Gentoo install for a few weeks now, but am currently working on another project.  It will be a few weeks before I get back around to working on the Gentoo issues again.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:33](http://www.tgharold.com/techblog/2005/06/gentoo-no-news.shtml)
-
-		</div>
+Been fighting with the Gentoo install for a few weeks now, but am currently working on another project.  It will be a few weeks before I get back around to working on the Gentoo issues again.

--- a/_posts/2005/2005-07-13-gentoo-20050-software-raid-part-1.md
+++ b/_posts/2005/2005-07-13-gentoo-20050-software-raid-part-1.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <i>Note: As always, these are works-in-progress.  They might work, or they might not and are mostly here so that I can keep track of what I did or didn't do during an install.</i>
 
 Gentoo 2005.0 Software RAID (part 1) - Going to try again with Gentoo 2005.0 in a software RAID with LVM configuration.  There's a [post](http://forums.gentoo.org/viewtopic-t-358713.html) on the Gentoo forums that indicates it may now be possible to get it up and running (seems to indicate there was a bug with kernels prior to 2.6.12).
@@ -72,10 +72,4 @@ Command: w</code>
 
 This gives me a 128MB boot area, a 2GB swap area, a 2GB root area, with the rest of the disk set aside for my LVM partitions. Repeat the above commands to configure the 2nd disk in the same fashion. Note that I'm using a different partition type then that shown in chapter 4.c. The 'fd' partition type is what I need to use since all 4 partitions on hda/hdc are going to be put into a software RAID1 set.
 
-<i>(Eventually ran out of time to get this working due to other projects, now waiting on 2005.1 release.)</i><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:37](http://www.tgharold.com/techblog/2005/07/gentoo-20050-software-raid-part-1.shtml)
-
-		</div>
+<i>(Eventually ran out of time to get this working due to other projects, now waiting on 2005.1 release.)</i>

--- a/_posts/2005/2005-08-09-more-rsync-links-for-using-rsync-as-a-backup-tool.md
+++ b/_posts/2005/2005-08-09-more-rsync-links-for-using-rsync-as-a-backup-tool.md
@@ -10,13 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [Easy Automated Snapshot-Style Backups with Linux and Rsync](http://www.mikerubel.org/computers/rsync_snapshots/)
 
-I'll need to come back and revisit this link, from a glance, it looks very well laid out and will be exactly what I want to pattern my backup systems after.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:58](http://www.tgharold.com/techblog/2005/08/more-rsync-links-for-using-rsync-as.shtml)
-
-		</div>
+I'll need to come back and revisit this link, from a glance, it looks very well laid out and will be exactly what I want to pattern my backup systems after.

--- a/_posts/2005/2005-08-30-visual-basic-rnd-function-tricks-and-traps.md
+++ b/_posts/2005/2005-08-30-visual-basic-rnd-function-tricks-and-traps.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Found this while examining some code results this week.  
+Found this while examining some code results this week.  
 
 One of our bits of code attempts to generate a negative 32bit integer to be used for a random ID.  The code is pretty standard for Visual Basic, and is used just about everywhere:
 
@@ -21,10 +21,4 @@ The problem with this code is that the end result is <i>always</i> divisible by 
 
 But, if you do some digging, it becomes pretty apparent why this happens.  The Rnd() function returns a value of type "single", which is a 32-bit IEEE floating point value.  (One bit is used for the sign, 8 bits for the exponent, and 23 bits for the mantissa.) The value returned is always &gt;=0 and &lt;1, which is only about 30bits worth of randomness.
 
-So, when you try to eek out a full 31 or 32 bits worth of randomness, you simply don't have the bits to do it.  There are ways to combine two calls to the Rnd() function to get more bits, but I need to do some research rather then posting a broken method of doing this.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:12](http://www.tgharold.com/techblog/2005/08/visual-basic-rnd-function-tricks-and.shtml)
-
-		</div>
+So, when you try to eek out a full 31 or 32 bits worth of randomness, you simply don't have the bits to do it.  There are ways to combine two calls to the Rnd() function to get more bits, but I need to do some research rather then posting a broken method of doing this.

--- a/_posts/2005/2005-09-07-gentoo-20051-software-raid-part-1.md
+++ b/_posts/2005/2005-09-07-gentoo-20051-software-raid-part-1.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: These directions are works-in-progress... in fact, they might not even work at all.  The big change that I'm trying this time around is using the 2005.1 release.  I'm also going to skip LVM2 on the initial installation.  I'm now in the process of updating this to include instructions for both with and without LVM2.</b>
 
 Now that the 2005.1 release is out, I'm going to take yet another swing at getting a software RAID configuration up and running on a pair of ATA disks. I'm working on two different systems.
@@ -326,10 +326,4 @@ Pick your kernel using the [kernel guide](http://www.gentoo.org/doc/en/gentoo-ke
 <code># emerge gentoo-sources
 # ls -l /usr/src</code>
 
-Next up is configuring the kernel, which I'll cover in another post.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:03](http://www.tgharold.com/techblog/2005/09/gentoo-20051-software-raid-part-1.shtml)
-
-		</div>
+Next up is configuring the kernel, which I'll cover in another post.

--- a/_posts/2005/2005-09-18-gentoo-emerge-sync-errors-during-installation.md
+++ b/_posts/2005/2005-09-18-gentoo-emerge-sync-errors-during-installation.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So, I'm trying to install Gentoo 2005.1 on Software RAID and LVM2.  Everything seems to work up until I do my initial "emerge --sync".
+So, I'm trying to install Gentoo 2005.1 on Software RAID and LVM2.  Everything seems to work up until I do my initial "emerge --sync".
 
 <code>livecd / # emerge --sync
 ...
@@ -59,10 +59,4 @@ Use smaller disks.  I did some more digging and the Gigabyte motherboard almost 
 
 I have (3) 120GB disks on order and will be dropping them into this system when they arrive.  That will take care of the issue and still allow me to put this older hardware into use.
 
-Update #1: DBaN is reporting errors on the (2) 160GB disks attached to the Promise FastTrak66 card, but not for the drive connected directly to the motherboard.  (Method: PRNG Stream, Verify: All Passes)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:50](http://www.tgharold.com/techblog/2005/09/gentoo-emerge-sync-errors-during.shtml)
-
-		</div>
+Update #1: DBaN is reporting errors on the (2) 160GB disks attached to the Promise FastTrak66 card, but not for the drive connected directly to the motherboard.  (Method: PRNG Stream, Verify: All Passes)

--- a/_posts/2005/2005-09-21-gentoo-20051-software-raid-part-2-via-epia-me6000.md
+++ b/_posts/2005/2005-09-21-gentoo-20051-software-raid-part-2-via-epia-me6000.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Time to [configure the Gentoo kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  I'm configuring this for my VIA EPIA ME6000 motherboard.  (Notice that I'm now including the LVM2 components as part of my base installation.)
+Time to [configure the Gentoo kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  I'm configuring this for my VIA EPIA ME6000 motherboard.  (Notice that I'm now including the LVM2 components as part of my base installation.)
 
 <code># emerge mdadm
 # emerge lvm2
@@ -65,10 +65,4 @@ Linux Kernel v2.6.11 Configuration
 
 Exit and save your configuration. Then build the kernel (the following command is for 2.6 kernels). Expect the compile to take about an hour.
 
-<code># make &amp;&amp; make modules_install</code><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:44](http://www.tgharold.com/techblog/2005/09/gentoo-20051-software-raid-part-2-via.shtml)
-
-		</div>
+<code># make &amp;&amp; make modules_install</code>

--- a/_posts/2005/2005-09-22-gentoo-20051-software-raid-part-2-celeron-cpu.md
+++ b/_posts/2005/2005-09-22-gentoo-20051-software-raid-part-2-celeron-cpu.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Time to [configure the Gentoo kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  I'm configuring this for my Celeron motherboard.
+Time to [configure the Gentoo kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  I'm configuring this for my Celeron motherboard.
 
 Note the use of "emerge lvm2" since I'm using LVM2 on this system during the initial installation.
 
@@ -67,10 +67,4 @@ Linux Kernel v2.6.11 Configuration
 
 Exit and save your configuration. Then build the kernel (the following command is for 2.6 kernels). Expect the compile to take about an hour.
 
-<code># make &amp;&amp; make modules_install</code><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:31](http://www.tgharold.com/techblog/2005/09/gentoo-20051-software-raid-part-2.shtml)
-
-		</div>
+<code># make &amp;&amp; make modules_install</code>

--- a/_posts/2005/2005-09-22-gentoo-emerge-grub-error---cat-procmounts-no-such-file-or-directory.md
+++ b/_posts/2005/2005-09-22-gentoo-emerge-grub-error---cat-procmounts-no-such-file-or-directory.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>During my initial Gentoo installation, I ran into the following issue after trying to "emerge grub".
+During my initial Gentoo installation, I ran into the following issue after trying to "emerge grub".
 
 <code>...
 &gt;&gt;&gt; Completed installing grub-0.96-r2 into /var/tmp/portage/grub-0.96-r2/image/
@@ -56,10 +56,4 @@ livecd gentoo # chroot /mnt/gentoo /bin/bash
 livecd / # env-update
 &gt;&gt;&gt; Regenerating /etc/ld.so.cache...
 livecd / # source /etc/profile
-livecd / # emerge grub</code><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:49](http://www.tgharold.com/techblog/2005/09/gentoo-emerge-grub-error-cat.shtml)
-
-		</div>
+livecd / # emerge grub</code>

--- a/_posts/2005/2005-09-23-gentoo-20051-software-raid-part-3.md
+++ b/_posts/2005/2005-09-23-gentoo-20051-software-raid-part-3.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Picking up with part 7c after [compiling the kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  Now you need to install your kernel into the boot partition. Change the "2.6.12-Sep2005" portion of the filenames to whatever you want.
+Picking up with part 7c after [compiling the kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  Now you need to install your kernel into the boot partition. Change the "2.6.12-Sep2005" portion of the filenames to whatever you want.
 
 <code># cp arch/i386/boot/bzImage /boot/kernel-2.6.12-Sep2005
 # cp System.map /boot/System.map-2.6.12-Sep2005
@@ -137,10 +137,4 @@ livecd / # umount /mnt/gentoo/proc
 livecd / # umount /mnt/gentoo
 livecd / # reboot</code>
 
-Pull the CD-ROM at this point, otherwise the LiveCD will probably boot.  Then cross your fingers and watch the console for errors.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[16:18](http://www.tgharold.com/techblog/2005/09/gentoo-20051-software-raid-part-3.shtml)
-
-		</div>
+Pull the CD-ROM at this point, otherwise the LiveCD will probably boot.  Then cross your fingers and watch the console for errors.

--- a/_posts/2005/2005-10-05-ntbackup-to-a-disk-file.md
+++ b/_posts/2005/2005-10-05-ntbackup-to-a-disk-file.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <i>Note: This post may be incomplete...</i>
 
 Sometimes you have to start simple.  For us, after fighting with tape drives and tape drive software, we've switched back to using NTBACKUP that comes with Windows 2000 Server and Windows 2003 Server.  We've also given up on tape drives for the moment since our backup needs have drastically outstripped what the old tape drive is capable of.
@@ -53,10 +53,4 @@ Microsoft reference links:
 [Windows 2003 Server - NTBackup Command](http://www.microsoft.com/technet/prodtechnol/windowsserver2003/library/ServerHelp/2b8c47c9-a769-46d2-9e26-f4d16f0261f8.mspx)
 [Windows XP - NTBackup Command](http://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/ntbackup_command.mspx)
 
-That takes care of the weekly snapshots (a full backup that also resets the archive bit).  For our daily updates, we need to set NTBackup to append to those files and only backup files that have changed since the snapshot was taken.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[19:36](http://www.tgharold.com/techblog/2005/10/ntbackup-to-disk-file.shtml)
-
-		</div>
+That takes care of the weekly snapshots (a full backup that also resets the archive bit).  For our daily updates, we need to set NTBackup to append to those files and only backup files that have changed since the snapshot was taken.

--- a/_posts/2005/2005-10-17-imaging-a-tecra-8200-windows-2000-install-using-knoppix-ntfsclone-and-samba.md
+++ b/_posts/2005/2005-10-17-imaging-a-tecra-8200-windows-2000-install-using-knoppix-ntfsclone-and-samba.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One of the more annoying things that our users do is to get their Windows workstations into an unworkable state after 9 months or so.  We've tried user education, we use things like spyware removers, eliminating the use of Internet Explorer, etc, but there are a lot of times where it's less time and trouble for us to reset the machine back to a known point.  Now, there are a few ways to do this such as paying for programs like Norton Ghost or Acronis True Image.  Both of those work but they cost $50/seat roughly.  But I'd like to do it for less.  Or at least take a shot at doing it for less.
+One of the more annoying things that our users do is to get their Windows workstations into an unworkable state after 9 months or so.  We've tried user education, we use things like spyware removers, eliminating the use of Internet Explorer, etc, but there are a lot of times where it's less time and trouble for us to reset the machine back to a known point.  Now, there are a few ways to do this such as paying for programs like Norton Ghost or Acronis True Image.  Both of those work but they cost $50/seat roughly.  But I'd like to do it for less.  Or at least take a shot at doing it for less.
 
 (I do use Acronis True Image on a few of my systems.  It's good for making more frequent snapshots without having to reboot to a seperate operating system.  It also has an incremental mode that can be used to keep a single image up to date.  For user simplicity, it's hands-down the winner over Ghost.)
 
@@ -109,10 +109,4 @@ Notes:
 - You'll probably want to use the underscore ("_") on the end of the image filename so that split adds the 2-letter suffix (aa, ab, ac, etc) in a way that is not confusing.
 - Note, I also hit the 2GB limit (even though I was writing to a share on an NTFS volume).  So I went ahead and backed off to 1GB splits.
 
-(FIXME) (to be continued)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[19:07](http://www.tgharold.com/techblog/2005/10/imaging-tecra-8200-windows-2000.shtml)
-
-		</div>
+(FIXME) (to be continued)

--- a/_posts/2005/2005-10-20-gentoo-eth0-does-not-exist.md
+++ b/_posts/2005/2005-10-20-gentoo-eth0-does-not-exist.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So, oops.  When I built my Celeron box, I didn't include the driver for my Netgear FA310TX Rev-D1 in the kernel build.  The Universal CD automatically detects the network card properly, now I just need to get it configured into my kernel build (using "make menuconfig").  The Universal CD (2005.1) detected and configured it using the Tulip driver (Lite-On 82c168).
+So, oops.  When I built my Celeron box, I didn't include the driver for my Netgear FA310TX Rev-D1 in the kernel build.  The Universal CD automatically detects the network card properly, now I just need to get it configured into my kernel build (using "make menuconfig").  The Universal CD (2005.1) detected and configured it using the Tulip driver (Lite-On 82c168).
 
 So I know it works, I just don't have it right and proper.  My original build for this kernel is:
 
@@ -55,10 +55,4 @@ title=Gentoo Linux 2.6.12 (Sep 22 2005)
 root (hd0,0)
 kernel /kernel-2.6.12-Sep2005 root=/dev/md2</code>
 
-Not technically difficult, if you can find out what device driver to  use.  Which, is why I try to document as much of this stuff as possible.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:17](http://www.tgharold.com/techblog/2005/10/gentoo-eth0-does-not-exist.shtml)
-
-		</div>
+Not technically difficult, if you can find out what device driver to  use.  Which, is why I try to document as much of this stuff as possible.

--- a/_posts/2005/2005-10-22-unixlunix-filesystem-hierarchy-standard.md
+++ b/_posts/2005/2005-10-22-unixlunix-filesystem-hierarchy-standard.md
@@ -10,12 +10,6 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>The [Filesystem Hierarchy Standard](http://www.pathname.com/fhs/) is a set of guidelines designed to get various distrobutions of Linux/Unix all on the same page with regards to what goes where in the file system.
+The [Filesystem Hierarchy Standard](http://www.pathname.com/fhs/) is a set of guidelines designed to get various distrobutions of Linux/Unix all on the same page with regards to what goes where in the file system.
 
-For us laymen, it's a decent guide to what is where in the filesystem (why is there a /sbin and a /usr/local/sbin?).  It helps answer questions like, "If I have a backup script, where should I put the file?".<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:09](http://www.tgharold.com/techblog/2005/10/unixlunix-filesystem-hierarchy.shtml)
-
-		</div>
+For us laymen, it's a decent guide to what is where in the filesystem (why is there a /sbin and a /usr/local/sbin?).  It helps answer questions like, "If I have a backup script, where should I put the file?".

--- a/_posts/2005/2005-10-24-gentoo-emerge-samba-fails-while-compiling-rpctorturec.md
+++ b/_posts/2005/2005-10-24-gentoo-emerge-samba-fails-while-compiling-rpctorturec.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Got the following error while trying to emerge samba into my Gentoo box.
+Got the following error while trying to emerge samba into my Gentoo box.
 
 <code>Compiling torture/rpctorture.c
 make: *** Waiting for unfinished jobs....
@@ -173,10 +173,4 @@ Portage overlays:
 
 samba # emerge samba</code>
 
-(crosses fingers)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Samba.shtml">Samba</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:59](http://www.tgharold.com/techblog/2005/10/gentoo-emerge-samba-fails-while.shtml)
-
-		</div>
+(crosses fingers)

--- a/_posts/2005/2005-10-26-misc-ssh-as-a-vpn-links.md
+++ b/_posts/2005/2005-10-26-misc-ssh-as-a-vpn-links.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Just collecting some links that look interesting.  My plan is to use SSH as a VPN server and I'll need to figure out how Mac and Windows clients can connect in.
+Just collecting some links that look interesting.  My plan is to use SSH as a VPN server and I'll need to figure out how Mac and Windows clients can connect in.
 
 [Using a Linux L2TP/IPsec VPN server](http://www.jacco2.dds.nl/networking/freeswan-l2tp.html)
 
@@ -18,10 +18,4 @@ tags:
 
 [about.com - VPN Setup](http://compnetworking.about.com/cs/vpnsetup/)
 
-[Q&amp;A on using the VPN service (www.doc.ic.ac.uk/csg/faqs/)](http://www.doc.ic.ac.uk/csg/faqs/vpn.html)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VPN.shtml">VPN</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[21:21](http://www.tgharold.com/techblog/2005/10/misc-ssh-as-vpn-links.shtml)
-
-		</div>
+[Q&amp;A on using the VPN service (www.doc.ic.ac.uk/csg/faqs/)](http://www.doc.ic.ac.uk/csg/faqs/vpn.html)

--- a/_posts/2005/2005-11-01-random-gentoo-tools.md
+++ b/_posts/2005/2005-11-01-random-gentoo-tools.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Things that might be useful to a system administrator and which don't come pre-installed on Gentoo.
+Things that might be useful to a system administrator and which don't come pre-installed on Gentoo.
 
 curl
 denyhosts
@@ -20,10 +20,4 @@ lynx
 nload
 screen
 
-In order to install "denyhosts", you'll probably have to muck with application specific keywords.  See [USE flags (gentoo.org)](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=2&amp;chap=2) or [FAQ USE Flags (Gentoo Linux Wiki)](http://gentoo-wiki.com/FAQ_USE_Flags).  Look for information on editing the "/etc/portage/package.keywords" file.  The current version of denyhosts is tagged with "~x86" (indicating that it compiles, but has not been verified?).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[21:05](http://www.tgharold.com/techblog/2005/11/random-gentoo-tools.shtml)
-
-		</div>
+In order to install "denyhosts", you'll probably have to muck with application specific keywords.  See [USE flags (gentoo.org)](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=2&amp;chap=2) or [FAQ USE Flags (Gentoo Linux Wiki)](http://gentoo-wiki.com/FAQ_USE_Flags).  Look for information on editing the "/etc/portage/package.keywords" file.  The current version of denyhosts is tagged with "~x86" (indicating that it compiles, but has not been verified?).

--- a/_posts/2005/2005-11-04-gentoo-20051-on-athlon64-3200-and-asus-a8v-deluxe.md
+++ b/_posts/2005/2005-11-04-gentoo-20051-on-athlon64-3200-and-asus-a8v-deluxe.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So, I was going to rebuild my 1Ghz Athlon machine with 640MB, but in the process of transplating hard drives and installing a new (quieter) CPU fan, I seem to have put it down for the count.  Moderate annoyance only as it's an older motherboard and was nearing the end of its lifespan.  (I may try and troubleshoot it next week.)
+So, I was going to rebuild my 1Ghz Athlon machine with 640MB, but in the process of transplating hard drives and installing a new (quieter) CPU fan, I seem to have put it down for the count.  Moderate annoyance only as it's an older motherboard and was nearing the end of its lifespan.  (I may try and troubleshoot it next week.)
 
 Instead, I replaced with an Asus A8V Deluxe (VIA chipset, BIOS version 08.00.09 05/19/05) motherboard with an Athlon64 3200+ and 2GB of RAM.  In addition, I have (8) 300GB hard drives hooked up to this unit.  The (2) RAID1 boot drives are 7200rpm (hooked to the primary IDE port and the 2nd one on the Promise FastTrak RAID port).  The other (6) drives are 5400rpm drives hooked up to a Promise SX6000 card.
 
@@ -83,10 +83,4 @@ livecd ~ #</code>
 
 Basically, hda &amp; sda are my (2) 7200rpm 300GB drives that I'm going to use as my primary RAID1.  The sdb drive is my 200GB 7200rpm SATA which I plan on using for a scratch drive.  The rest of the drives (all ending in "160" blocks) are 5400rpm 300GB IDEs hooked to the Highpoint / Promise PCI cards.
 
-Now I can go ahead and build my system.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:24](http://www.tgharold.com/techblog/2005/11/gentoo-20051-on-athlon64-3200-and-asus.shtml)
-
-		</div>
+Now I can go ahead and build my system.

--- a/_posts/2005/2005-11-08-gentoo-20051-software-raid-part-2-amd64-on-asus-a8v.md
+++ b/_posts/2005/2005-11-08-gentoo-20051-software-raid-part-2-amd64-on-asus-a8v.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This is a record of the kernel flags that I'm going to use for my AMD64 system.  It's an Asus A8V (K8T800Pro and VT8237) with an Athlon64 3200+ chip along with 2GB of RAM.  Hard drives are hooked up to the onboard Promise controller (PDC20378), the onboard SATA controller and the onboard IDE controller.  Plus the motherboard has an onboard gigabit ethernet NIC (Marvell 88E8001).
+This is a record of the kernel flags that I'm going to use for my AMD64 system.  It's an Asus A8V (K8T800Pro and VT8237) with an Athlon64 3200+ chip along with 2GB of RAM.  Hard drives are hooked up to the onboard Promise controller (PDC20378), the onboard SATA controller and the onboard IDE controller.  Plus the motherboard has an onboard gigabit ethernet NIC (Marvell 88E8001).
 
 In addition, I have even more hard drives hooked up to a Promise Ultra133 TX2 PCI card (PDC20269) and some HighPoint Rocket133SB PCI cards (HPT302).
 
@@ -146,10 +146,4 @@ One key line that look interesting:
 
 Sharing PCI IDE interrupts support (CONFIG_IDEPCI_SHARE_IRQ)
 
-Turned that on, but still haven't fixed the sluggishness or the lost ticks issue.  I'm very tempted to give up on the PDC20378 chip, except that I know it worked on the LiveCD.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[17:06](http://www.tgharold.com/techblog/2005/11/gentoo-20051-software-raid-part-2.shtml)
-
-		</div>
+Turned that on, but still haven't fixed the sluggishness or the lost ticks issue.  I'm very tempted to give up on the PDC20378 chip, except that I know it worked on the LiveCD.

--- a/_posts/2005/2005-11-09-sluggish-linux-box-losing-some-ticks.md
+++ b/_posts/2005/2005-11-09-sluggish-linux-box-losing-some-ticks.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Messages seen in my "# dmesg" output.
+Messages seen in my "# dmesg" output.
 
 <code>Losing some ticks... checking if CPU frequency changed.
 kjournald starting.  Commit interval 5 seconds
@@ -47,10 +47,4 @@ wa = iowait (time spent waiting for IO to complete)
 hi = hardware interrupts (time spent within hardware interrupt handlers)
 si = softirq (time spent within other critical sections within the kernel)
 
-You can see the 40% "sy" (system) and 52% "si" (softirq) utilizations on the problem box, with only 6% idle.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:33](http://www.tgharold.com/techblog/2005/11/sluggish-linux-box-losing-some-ticks.shtml)
-
-		</div>
+You can see the 40% "sy" (system) and 52% "si" (softirq) utilizations on the problem box, with only 6% idle.

--- a/_posts/2005/2005-11-12-sluggish-linux-box-troubleshooting-steps.md
+++ b/_posts/2005/2005-11-12-sluggish-linux-box-troubleshooting-steps.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Time to sit down and jot some things down so I can figure out which device/driver in my Gentoo AMD64 box is causing issues.  This gets a little complex because I have (5) 5400rpm 300GB PATA drives, (2) 7200rpm 300GB PATA drives and (1) 7200rpm 200GB SATA drive installed.
+Time to sit down and jot some things down so I can figure out which device/driver in my Gentoo AMD64 box is causing issues.  This gets a little complex because I have (5) 5400rpm 300GB PATA drives, (2) 7200rpm 300GB PATA drives and (1) 7200rpm 200GB SATA drive installed.
 
 Back when I finally booted into the AMD64 LiveCD, I got the following information from /proc/partitions:
 
@@ -128,10 +128,4 @@ usb_storage 55616 0 - Live 0xffffffff88026000
 usbhid 27680 0 - Live 0xffffffff8801e000
 ehci_hcd 25864 0 - Live 0xffffffff88016000
 usbcore 86008 7 sl811_hcd,ohci_hcd,uhci_hcd,usb_storage,usbhid,ehci_hcd, Live 0xffffffff88000000
-livecd linux #</code><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:06](http://www.tgharold.com/techblog/2005/11/sluggish-linux-box-troubleshooting.shtml)
-
-		</div>
+livecd linux #</code>

--- a/_posts/2005/2005-11-13-amd64-broken-kernel-config-file.md
+++ b/_posts/2005/2005-11-13-amd64-broken-kernel-config-file.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Current broken configuration.  Here is the diff between my current configuration and what was on the LiveCD.  Left side is the LiveCD config file, right side is my kernel's config file.
+Current broken configuration.  Here is the diff between my current configuration and what was on the LiveCD.  Left side is the LiveCD config file, right side is my kernel's config file.
 
 [AMD64 2005.1 Gentoo LiveCD Kernel Config](/techblog/Gentoo/AMD64/2005_1-LiveCDConfig.txt)
 
@@ -1513,10 +1513,4 @@ I'm still trying to puzzle out what is different on the LiveCD (which works, and
 1661c1181
 &lt; CONFIG_LIBCRC32C=m
 ---
-&gt; CONFIG_LIBCRC32C=y<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:25](http://www.tgharold.com/techblog/2005/11/amd64-broken-kernel-config-file.shtml)
-
-		</div>
+&gt; CONFIG_LIBCRC32C=y

--- a/_posts/2005/2005-11-14-more-troubleshooting-steps.md
+++ b/_posts/2005/2005-11-14-more-troubleshooting-steps.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>A) [AMD64 / Athlon X2 Opinions](http://forums.gentoo.org/viewtopic-t-385651-highlight-lost+ticks.html) - Recommends adding "clock=pmtmr notsc" to the kernel parameters in the grub.conf file.  It probably won't help with the sluggishness and lost ticks since those arguments are not being passed on the LiveCD boot.
+A) [AMD64 / Athlon X2 Opinions](http://forums.gentoo.org/viewtopic-t-385651-highlight-lost+ticks.html) - Recommends adding "clock=pmtmr notsc" to the kernel parameters in the grub.conf file.  It probably won't help with the sluggishness and lost ticks since those arguments are not being passed on the LiveCD boot.
 
 The LiveCD boots with:
 
@@ -38,10 +38,4 @@ warning: many lost ticks.
 Your time source seems to be instable or some driver is hogging interupts
 rip scsi_dispatch_cmd+0x1f3/0x250
 
-I had not seen "rip scsi_dispatch_cmd+0x1f3/0x250" yet.  The old message was "rip __do_softirq+0x48/0xb0".  Wow, no google hit for the scsi_dispatch_cmd line.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:28](http://www.tgharold.com/techblog/2005/11/more-troubleshooting-steps.shtml)
-
-		</div>
+I had not seen "rip scsi_dispatch_cmd+0x1f3/0x250" yet.  The old message was "rip __do_softirq+0x48/0xb0".  Wow, no google hit for the scsi_dispatch_cmd line.

--- a/_posts/2005/2005-11-21-success-at-fixing-sluggishness.md
+++ b/_posts/2005/2005-11-21-success-at-fixing-sluggishness.md
@@ -10,16 +10,10 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Hah, I finally flipped the right bit on my AMD64 Gentoo server to eliminate the issue with sluggishness while mdadm is rebuilding a RAID array.  So, without further ado, here is my current .config file for a 2.6.13 kernel along with the diff between the last unsuccessful kernel and the kernel that worked.
+Hah, I finally flipped the right bit on my AMD64 Gentoo server to eliminate the issue with sluggishness while mdadm is rebuilding a RAID array.  So, without further ado, here is my current .config file for a 2.6.13 kernel along with the diff between the last unsuccessful kernel and the kernel that worked.
 
 [KernelConfig-1122-0030.txt](/techblog/Gentoo/AMD64/KernelConfig-1122-0030.txt)
 
 [KernelConfig-1122-0030-diff.txt](/techblog/Gentoo/AMD64/KernelConfig-1122-0030-diff.txt)
 
-I changed close to a dozen flags when I built the last kernel.  One (or more) of them was key in getting rid of the sluggishness.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:54](http://www.tgharold.com/techblog/2005/11/success-at-fixing-sluggishness.shtml)
-
-		</div>
+I changed close to a dozen flags when I built the last kernel.  One (or more) of them was key in getting rid of the sluggishness.

--- a/_posts/2005/2005-11-21-troubleshooting-comparison-of-kernel-configs.md
+++ b/_posts/2005/2005-11-21-troubleshooting-comparison-of-kernel-configs.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I now have a few sample kernel configs from kind folks in alt.os.linux.gentoo.  There are two that I've focused in on (mostly because they posted first and they gave background on the config files).
+I now have a few sample kernel configs from kind folks in alt.os.linux.gentoo.  There are two that I've focused in on (mostly because they posted first and they gave background on the config files).
 
 [2005_1-LiveCDConfig.txt](/techblog/Gentoo/AMD64/2005_1-LiveCDConfig.txt) - This is the .config file from the AMD64 2005.1 LiveCD.  Since I know this kernel works, it's a prime starting point for researching why I'm having the issues that I'm having.
 
@@ -92,10 +92,4 @@ Probably not an issue.  The Anton config sets this to "Y"/"M" instead of "Y"/"Y"
 
 Updates:
 
-None of the above settings seem to have made any difference.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[22:05](http://www.tgharold.com/techblog/2005/11/troubleshooting-comparison-of-kernel.shtml)
-
-		</div>
+None of the above settings seem to have made any difference.

--- a/_posts/2005/2005-11-23-ntp-daemons-for-gentoo.md
+++ b/_posts/2005/2005-11-23-ntp-daemons-for-gentoo.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Looks like there are two basic choices (according to "emerge -s ntp"), [ntp](http://www.ntp.org/) and [openntpd](http://openntpd.org/).
+Looks like there are two basic choices (according to "emerge -s ntp"), [ntp](http://www.ntp.org/) and [openntpd](http://openntpd.org/).
 
 <pre>*  net-misc/ntp
       Latest version available: 4.2.0.20040617-r3
@@ -59,10 +59,4 @@ What this actually means is that your clock is currently off by approximately 12
 
 If you want your server to synchronize at a faster rate, you should manually set the time using the 'date' command to as close to proper time as you can.  Otherwise, it may take a few days for OpenNTPD to finish synchronizing your machine's local clock.
 
-You should also look up the "hwclock" command, especially the --hctosys and --systohc options.  Also look at "nano -w /etc/conf.d/clock", you should probably set the CLOCK_SYSTOHC flag to "yes" so that your system time gets written to the hardware clock during shutdown.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NTP.shtml">NTP</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:18](http://www.tgharold.com/techblog/2005/11/ntp-daemons-for-gentoo.shtml)
-
-		</div>
+You should also look up the "hwclock" command, especially the --hctosys and --systohc options.  Also look at "nano -w /etc/conf.d/clock", you should probably set the CLOCK_SYSTOHC flag to "yes" so that your system time gets written to the hardware clock during shutdown.

--- a/_posts/2005/2005-11-25-visual-basic-rnd-issues-take-2.md
+++ b/_posts/2005/2005-11-25-visual-basic-rnd-issues-take-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I talked about this a few months ago in [Visual Basic Rnd() function tricks and traps](/techblog/2005/08/visual-basic-rnd-function-tricks-and.shtml), where I discovered that I wasn't getting a full 32bits of randomness out of VB's Rnd() function in my VBScript/Visual Basic pages.  At the time, I thought it was simply due to Rnd() returning a 32bit IEEE floating point value which really only has 30bits of data.
+I talked about this a few months ago in [Visual Basic Rnd() function tricks and traps](/techblog/2005/08/visual-basic-rnd-function-tricks-and.shtml), where I discovered that I wasn't getting a full 32bits of randomness out of VB's Rnd() function in my VBScript/Visual Basic pages.  At the time, I thought it was simply due to Rnd() returning a 32bit IEEE floating point value which really only has 30bits of data.
 
 In reality, the situation is even worse:
 
@@ -21,10 +21,4 @@ In reality, the situation is even worse:
 
 VB's Rnd() function only provides 24bits of randomness.  After the 2^24th sample, it starts repeating.  (See [INFO: How Visual Basic Generates Pseudo-Random Numbers for the RND Function](http://support.microsoft.com/support/kb/articles/Q231/8/47.asp).)
 
-Randomize() just contributes to the problem.  See [An Examination of Visual Basic's Random Number Generation By Mark Hutchinson](http://www.15seconds.com/issue/051110.htm) and notice that calling Randomize() is based on the time of the day and only provides around 2^16 different starting points within the 2^24 stream.  So if you're calling Randomize() before every Rnd(), you're only getting 16bits of randomness.  (It's actually worse, because you'll get identical starting points at the same time of day.)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:39](http://www.tgharold.com/techblog/2005/11/visual-basic-rnd-issues-take-2.shtml)
-
-		</div>
+Randomize() just contributes to the problem.  See [An Examination of Visual Basic's Random Number Generation By Mark Hutchinson](http://www.15seconds.com/issue/051110.htm) and notice that calling Randomize() is based on the time of the day and only provides around 2^16 different starting points within the 2^24 stream.  So if you're calling Randomize() before every Rnd(), you're only getting 16bits of randomness.  (It's actually worse, because you'll get identical starting points at the same time of day.)

--- a/_posts/2005/2005-11-28-lm_sensors-and-gigabyte-ga-6va7.md
+++ b/_posts/2005/2005-11-28-lm_sensors-and-gigabyte-ga-6va7.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Working on setting up lm_sensors on my Gigabyte GA-6VA7+ (Intel Celeron Coppermine 566Mhz CPU) system.  [First step](http://secure.netroedge.com/~lm78/kernel26.html) is to turn on I2C support in the 2.6 kernel configuration.
+Working on setting up lm_sensors on my Gigabyte GA-6VA7+ (Intel Celeron Coppermine 566Mhz CPU) system.  [First step](http://secure.netroedge.com/~lm78/kernel26.html) is to turn on I2C support in the 2.6 kernel configuration.
 
 <code># cd /usr/src/linux
 # make menuconfig</code>
@@ -309,10 +309,4 @@ Module                  Size  Used by
 eeprom                  5528  - 
 i2c_sensor              2984  - 
 i2c_viapro              7640  - 
-dm_mod                 45340  - </code><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:47](http://www.tgharold.com/techblog/2005/11/lmsensors-and-gigabyte-ga-6va7.shtml)
-
-		</div>
+dm_mod                 45340  - </code>

--- a/_posts/2005/2005-12-12-resizing-an-ext3-partition-in-an-lvm2-volume.md
+++ b/_posts/2005/2005-12-12-resizing-an-ext3-partition-in-an-lvm2-volume.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [Extending a Logical Volume](http://www.netadmintools.com/art366.html)
 
 The basic (3) commands are:
@@ -30,10 +30,4 @@ For example, I have /home that is currently a 4GB partition mounted in my vgmirr
 # resize2fs /dev/vgmirror/home
 # mount /home</code>
 
-Now, for /home, odds are high that you will have to boot a LiveCD due to the volume being in use.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/ext3.shtml">ext3</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:31](http://www.tgharold.com/techblog/2005/12/resizing-ext3-partition-in-lvm2-volume.shtml)
-
-		</div>
+Now, for /home, odds are high that you will have to boot a LiveCD due to the volume being in use.

--- a/_posts/2005/2005-12-19-windows-domain-time-server-w32time.md
+++ b/_posts/2005/2005-12-19-windows-domain-time-server-w32time.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I'm not going to get into the full details of configuring a time server for your Windows 2000 or Windows 2003 domains, but the basic idea is that your PDC (Primary Domain Controller) at the root of your Active Directory forest should be synchronized with an external time source.  Microsoft includes a service to do this called "Windows Time" (a.k.a. W32Time).  It's not as nice as the official NTPD service that you can get from ntp.org, but it generally works.
+I'm not going to get into the full details of configuring a time server for your Windows 2000 or Windows 2003 domains, but the basic idea is that your PDC (Primary Domain Controller) at the root of your Active Directory forest should be synchronized with an external time source.  Microsoft includes a service to do this called "Windows Time" (a.k.a. W32Time).  It's not as nice as the official NTPD service that you can get from ntp.org, but it generally works.
 
 By default, Windows client computers that are members of a domain should get their time from the domain controllers within the domain.  So once you get the domain controllers keeping time properly you won't have to deal with bad time on the desktops.
 
@@ -97,10 +97,4 @@ The key line in the above output is "Error -45702ms" which shows us how much the
 
 In my opinion, W32Time is "good enough" for most purposes.  At least for small offices or home networks.  If you're going to be dealing with more then a dozen servers or 50 workstations, then you should definitely look into setting up a real "ntpd" server.  (In reality, you should have at least 4 ntpd servers in your infrastructure so that they can keep an eye on each other and alert you to ntpd servers that are not keeping time properly.)
 
-Here's my previous posting dealing with time issues: [NTP daemons for Gentoo](http://www.tgharold.com/techblog/2005/11/ntp-daemons-for-gentoo.shtml)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NTP.shtml">NTP</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[21:21](http://www.tgharold.com/techblog/2005/12/windows-domain-time-server-w32time.shtml)
-
-		</div>
+Here's my previous posting dealing with time issues: [NTP daemons for Gentoo](http://www.tgharold.com/techblog/2005/11/ntp-daemons-for-gentoo.shtml)

--- a/_posts/2005/2005-12-20-more-handy-linux-console-tools.md
+++ b/_posts/2005/2005-12-20-more-handy-linux-console-tools.md
@@ -10,14 +10,8 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>A few more tools that I've found useful for console-only Linux server administration.  All of these have Gentoo ebuilds so they can simply be emerge'd into your system.
+A few more tools that I've found useful for console-only Linux server administration.  All of these have Gentoo ebuilds so they can simply be emerge'd into your system.
 
 [atop](http://www.atcomputing.nl/Tools/atop) - Similar to the built-in "top" command in Linux/Unix, except that it gives additional details about what is going on with the system.  Of particular use is that it will show you individual disk utilization statistics so that you can locate spindles that are in heavy use.  (Which is much needed when tuning a database server.)
 
-[tree](http://mama.indstate.edu/users/ice/tree/) - Allows you to output a hierachial display of all files and directories on your system in a "tree" view.  Which is useful for documenting the directory layout of your system.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2005.shtml">2005</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Linux.shtml">Linux</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[19:48](http://www.tgharold.com/techblog/2005/12/more-handy-linux-console-tools.shtml)
-
-		</div>
+[tree](http://mama.indstate.edu/users/ice/tree/) - Allows you to output a hierachial display of all files and directories on your system in a "tree" view.  Which is useful for documenting the directory layout of your system.

--- a/_posts/2006/2006-01-12-dual-core-dual-opteron-system-pricing.md
+++ b/_posts/2006/2006-01-12-dual-core-dual-opteron-system-pricing.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I've been using a dual-Opteron (twin 246s) system as my main workhorse machine for a while now.  It still works well, but the [Tyan Tiger K8W](ftp://ftp.tyan.com/datasheets/d_s2875_120.pdf) pipes all memory accesses from the one CPU through the other CPU, which makes it slower then it could be.  Plus the K8W doesn't support the newer dual-core Opterons (at least not according to [Tyan's CPU chart](http://www.tyan.com/support/html/cpu_athlon_duron_opteron.html)).
+I've been using a dual-Opteron (twin 246s) system as my main workhorse machine for a while now.  It still works well, but the [Tyan Tiger K8W](ftp://ftp.tyan.com/datasheets/d_s2875_120.pdf) pipes all memory accesses from the one CPU through the other CPU, which makes it slower then it could be.  Plus the K8W doesn't support the newer dual-core Opterons (at least not according to [Tyan's CPU chart](http://www.tyan.com/support/html/cpu_athlon_duron_opteron.html)).
 
 The newer [Tiger K8WE (S2877ANRF)](ftp://ftp.tyan.com/datasheets/d_s2877_100.pdf) has a different memory configuration along with an NVIDIA chipset (instead of the AMD chipset).  It's also a PCIe motherboard, so there would be some upgrade potential.  Looks like it's available for around $275 to $375.
 
@@ -18,10 +18,4 @@ However, the Opteron 265 (dual-core, 1.8Ghz, 2x1MB L2 cache) is around $720 each
 
 Memory chips are $120 each (Corsair CM72SD1024RLP, PC3200).
 
-Eh, I think I'll wait until the Opteron 270s drop below $500 each.  The chips are still too far up the price curve for my tastes.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:24](http://www.tgharold.com/techblog/2006/01/dual-core-dual-opteron-system-pricing.shtml)
-
-		</div>
+Eh, I think I'll wait until the Opteron 270s drop below $500 each.  The chips are still too far up the price curve for my tastes.

--- a/_posts/2006/2006-01-13-postgresql---dumping-a-single-table.md
+++ b/_posts/2006/2006-01-13-postgresql---dumping-a-single-table.md
@@ -10,14 +10,8 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>$ pg_dump -Fp -U postgres --table=TABLENAME DATABASENAME &gt; TABLENAME.sql
+$ pg_dump -Fp -U postgres --table=TABLENAME DATABASENAME &gt; TABLENAME.sql
 
 $ pg_dump -Fp -U postgres --table=TABLENAME DATABASENAME | gzip -c &gt; TABLENAME.sql.gz
 
-Useful for dumping out individual tables from a particular database in plain-text (SQL) format.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PostgreSQL.shtml">PostgreSQL</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:46](http://www.tgharold.com/techblog/2006/01/postgresql-dumping-single-table.shtml)
-
-		</div>
+Useful for dumping out individual tables from a particular database in plain-text (SQL) format.

--- a/_posts/2006/2006-01-27-gentoo---dcfldd.md
+++ b/_posts/2006/2006-01-27-gentoo---dcfldd.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [dcfldd](http://dcfldd.sourceforge.net/)
 
 A fancier version of the basic "dd" command.  The big advantage that I wanted was:
@@ -25,10 +25,4 @@ If you're in more of a hurry, try:
 
 <code># dcfldd if=/dev/zero of=/dev/sda conv=notrunc bs=128k</code>
 
-Some slower CPUs can't generate PRNG numbers (/dev/urandom) fast enough to keep up with the disk wipe process.  If you're using "atop" you'll notice that the system is spending 100% of the time in the "sys" (and dcfldd is using up 100% CPU).  In addition, the hard drive lights will not be constantly lit.  Plus the "DSK" line for the drive being wiped will not be busy 100% of the time in "atop".<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:40](http://www.tgharold.com/techblog/2006/01/gentoo-dcfldd.shtml)
-
-		</div>
+Some slower CPUs can't generate PRNG numbers (/dev/urandom) fast enough to keep up with the disk wipe process.  If you're using "atop" you'll notice that the system is spending 100% of the time in the "sys" (and dcfldd is using up 100% CPU).  In addition, the hard drive lights will not be constantly lit.  Plus the "DSK" line for the drive being wiped will not be busy 100% of the time in "atop".

--- a/_posts/2006/2006-02-20-cryptography-security-and-privacy.md
+++ b/_posts/2006/2006-02-20-cryptography-security-and-privacy.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [infoAnarchy Wiki](http://www.infoanarchy.org/wiki/index.php/Main_Page)
 
 [Eraser - File Wipe Tool](http://www.heidi.ie/eraser/) (Note: I would recommend not using the new 5.8 beta until all the bugs are worked out.)
@@ -35,10 +35,4 @@ Practical uses:
 
 A) Encrypted USB backup drive.  I have a USB hard drive hooked up to my laptop.  This drive contains a single TrueCrypt volume that I mount at login and use as a backup target every few hours.  So if the laptop dies, I just install TrueCrypt on the new laptop/hard drive, mount the backup drive, and I can restore my data.  But I don't have to worry about anyone else getting at the data and restoring it.
 
-B) Encrypted volume on my laptop's hard drive.  I have financial data stored on my laptop (since it's my primary machine).  Needless to say, if someone were to steal my laptop, I worry greatly about their access to that information.  So I have a TrueCrypt volume file in the root of my C: (C:\Personal.tc) that I mount to a drive letter whenever I need to access my financial records.  In order to keep this data safe, I periodically copy the TC file to another drive or to CD-R.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Encryption.shtml">Encryption</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/GnuPG.shtml">GnuPG</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/TrueCrypt.shtml">TrueCrypt</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/WindowsEFS.shtml">WindowsEFS</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:24](http://www.tgharold.com/techblog/2006/02/cryptography-security-and-privacy.shtml)
-
-		</div>
+B) Encrypted volume on my laptop's hard drive.  I have financial data stored on my laptop (since it's my primary machine).  Needless to say, if someone were to steal my laptop, I worry greatly about their access to that information.  So I have a TrueCrypt volume file in the root of my C: (C:\Personal.tc) that I mount to a drive letter whenever I need to access my financial records.  In order to keep this data safe, I periodically copy the TC file to another drive or to CD-R.

--- a/_posts/2006/2006-03-05-truecrypt.md
+++ b/_posts/2006/2006-03-05-truecrypt.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I've been looking for a good disk encryption system for a while.  In the past few years, I've been using PGP's PGPDisk tool with good success, but there have been a few annoyances.
+I've been looking for a good disk encryption system for a while.  In the past few years, I've been using PGP's PGPDisk tool with good success, but there have been a few annoyances.
 
 - Difficulty interacting with WindowsXP, drives have to be mounted at bootup or they won't show up after being mounted.  This made it difficult to keep PGP volumes on DVD-R for ad-hoc mounting to refer to information contained within the encrypted disk.
 
@@ -32,10 +32,4 @@ So why should someone use disk encryption?
 
 The easiest scenario to sell is with someone who uses Quicken or MS Money to manage their finances.  This is the primary reason that I started using disk encryption back in 2000.  Since I keep my Quicken program on my laptop, I want to protect my financial data in case the laptop gets stolen.  By storing my Quicken files inside of an encrypted volume that is rarely mounted, a thief who steals the laptop will not have access to those files.
 
-In addition, if the hard drive fails, I don't have to worry about getting it back up and running to wipe the data before getting a replacement.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Encryption.shtml">Encryption</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/TrueCrypt.shtml">TrueCrypt</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:17](http://www.tgharold.com/techblog/2006/03/truecrypt.shtml)
-
-		</div>
+In addition, if the hard drive fails, I don't have to worry about getting it back up and running to wipe the data before getting a replacement.

--- a/_posts/2006/2006-03-09-truecrypt---basic-thoughts.md
+++ b/_posts/2006/2006-03-09-truecrypt---basic-thoughts.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Probably the easiest way to get started with on-the-fly encryption is to create a TrueCrypt volume file and mount that as a Windows drive letter.  The volume file (i.e. "mydrive.tc") can be stored on any hard drive and can be easily backed up as long as the volume is not mounted.  Controlling who can mount a volume can be limited by using either a passphrase and/or a set of "keyfiles".
+Probably the easiest way to get started with on-the-fly encryption is to create a TrueCrypt volume file and mount that as a Windows drive letter.  The volume file (i.e. "mydrive.tc") can be stored on any hard drive and can be easily backed up as long as the volume is not mounted.  Controlling who can mount a volume can be limited by using either a passphrase and/or a set of "keyfiles".
 
 Once you have created the volume, you can store files inside it (using the mounted volume's drive letter) just like you would store files on any regular hard drive, USB/Firewire drive, or network share.  It's completely invisible to the application.  This makes it ideal for storing application data such as e-mail, financial programs, or other sensitive data.
 
@@ -58,10 +58,3 @@ Now you are ready to mount your new volume:
 <li>You may now start copying data to your new encrypted volume.</li>
 
 </ol>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Encryption.shtml">Encryption</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/TrueCrypt.shtml">TrueCrypt</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[02:02](http://www.tgharold.com/techblog/2006/03/truecrypt-basic-thoughts.shtml)
-
-		</div>

--- a/_posts/2006/2006-04-22-windows-2003-domain-servers-in-a-windows-2000-domain.md
+++ b/_posts/2006/2006-04-22-windows-2003-domain-servers-in-a-windows-2000-domain.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So, I'm working on installing our first Windows 2003 server as a domain controller in an existing Windows 2000 Active Directory domain.  Now, if I remember correctly, when I first tried this last fall, it errored out due to the AD domain not having all of the schema details needed for a Windows 2003 domain controller.
+So, I'm working on installing our first Windows 2003 server as a domain controller in an existing Windows 2000 Active Directory domain.  Now, if I remember correctly, when I first tried this last fall, it errored out due to the AD domain not having all of the schema details needed for a Windows 2003 domain controller.
 
 Ah, here we go... got the error message:
 
@@ -32,10 +32,4 @@ So... off we go to research this.  The server already exists as a member server 
 
 The second link is the most helpful of the bunch for this particular case (an existing Windows 2000 domain where I'm trying to add new domain controllers that are running Windows 2003).
 
-However, since there are potential issues with Mac clients when upgrading to Windows 2003 domain servers, I'm going to hold off on the upgrade until my next trip to the main office.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:01](http://www.tgharold.com/techblog/2006/04/windows-2003-domain-servers-in-windows.shtml)
-
-		</div>
+However, since there are potential issues with Mac clients when upgrading to Windows 2003 domain servers, I'm going to hold off on the upgrade until my next trip to the main office.

--- a/_posts/2006/2006-05-14-microsoft-outlook-backup-method.md
+++ b/_posts/2006/2006-05-14-microsoft-outlook-backup-method.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This is how I backup my PST files whenever I login to my laptop.  Because I always have MSOutlook open, I find it difficult to get a good backup of the PST files.
+This is how I backup my PST files whenever I login to my laptop.  Because I always have MSOutlook open, I find it difficult to get a good backup of the PST files.
 
 1) You will want a copy of [Info-Zip's ZIP and UNZIP executables](http://www.info-zip.org/).
 
@@ -56,10 +56,4 @@ e) If you find that ZIP is too slow, you may wish to change the "-u9" to "-u1" i
 
 f) I'm pretty sure the above script is foolproof and correct, but as always you should have a good backup before you attempt things like this.
 
-4) Create a shortcut link to "backupemail.cmd" and place it in your Programs -&gt; Startup folder.  That way it will run as soon as you login.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Backups.shtml">Backups</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:17](http://www.tgharold.com/techblog/2006/05/microsoft-outlook-backup-method.shtml)
-
-		</div>
+4) Create a shortcut link to "backupemail.cmd" and place it in your Programs -&gt; Startup folder.  That way it will run as soon as you login.

--- a/_posts/2006/2006-05-31-microsoft-outlook-error-0x800ccc92.md
+++ b/_posts/2006/2006-05-31-microsoft-outlook-error-0x800ccc92.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I get the following error when trying to retrieve e-mail from our POP3 Postfix mail server (on Solaris 5.8).  We're also using Sendmail to interact with the PreciseMail spam filtering system:
+I get the following error when trying to retrieve e-mail from our POP3 Postfix mail server (on Solaris 5.8).  We're also using Sendmail to interact with the PreciseMail spam filtering system:
 
 Task 'mail.example.com - Sending and Receiving' reported error (0x800CCC92): 'Your e-mail server rejected your login.  Verify your user name and password in your account properties.  Under Tools, click E-mail accounts.  The server responded: ??RR /usr/mail/.thomas.pop lock busy! Is another session active? (11)'
 
@@ -20,10 +20,4 @@ Links:
 [Telnet - POP Commands (retrieving mail using telnet)](http://www.yuki-onna.co.uk/email/pop.html)
 [POP lock busy](http://www.exit109.com/emailproblems.html#poplock)
 
-Looking at the contents of /usr/mail ("ls -la /usr/mail") you will see that there are at least one (and possibly multiple) .pop files in the directory (".username.pop").<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:46](http://www.tgharold.com/techblog/2006/05/microsoft-outlook-error-0x800ccc92.shtml)
-
-		</div>
+Looking at the contents of /usr/mail ("ls -la /usr/mail") you will see that there are at least one (and possibly multiple) .pop files in the directory (".username.pop").

--- a/_posts/2006/2006-06-05-toshiba-introduces-200gb-25-drive.md
+++ b/_posts/2006/2006-06-05-toshiba-introduces-200gb-25-drive.md
@@ -10,15 +10,9 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [Toshiba has now released a hard drive based on the perpendicular recording technology](http://tech.moneycontrol.com/news/toshiba-introduces-200-gb-25-inch-hdd/1377/india/).  It's 200GB, 2.5" form factor (useful for notebooks / laptops).  Areal density is 178.8 gigabits (per square inch).
 
 In comparison, [Hitachi has demonstrated 230 gigabits per square inch](http://www.hitachigst.com/hdd/research/recording_head/pr/index.html) (see also [PCWorld](http://www.pcworld.com/news/article/0,aid,120279,00.asp) where current drives top out at 120-130 gigabits/sq inch while perpendicular should allow areal density of 230 gigabits/sq inch).  Back in 2004, [Toshiba demonstrated a density of 133 gigabits per square inch](http://www.toshiba.co.jp/about/press/2004_12/pr1401.htm), which was done using the older recording technology.  Back in 2002, [Seagate announced drives that had areal densities of 100 gigabits/sq in](http://www.internetnews.com/storage/article.php/1499221).  [Seagate expects areal densities to hit 500 gigabits/sq in](http://www.silentpcreview.com/article298-page1.html) over the next few years, compared with today's current density of ~110 gigabits/sq in.
 
-So it looks like perpendicular recording will definitely allow hard drive sizes to double and possibly quadruple over the next few years.  That means we can reasonably expect 1TB drives in the short-term with the possibility of 2TB drives down the road.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:03](http://www.tgharold.com/techblog/2006/06/toshiba-introduces-200gb-25-drive.shtml)
-
-		</div>
+So it looks like perpendicular recording will definitely allow hard drive sizes to double and possibly quadruple over the next few years.  That means we can reasonably expect 1TB drives in the short-term with the possibility of 2TB drives down the road.

--- a/_posts/2006/2006-06-10-lm_sensors-and-gigabyte-ga-6va7-take-2.md
+++ b/_posts/2006/2006-06-10-lm_sensors-and-gigabyte-ga-6va7-take-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>A while back I had tried to [configure lm_sensors on an old Gigabyte GA-6VA7+ motherboard](/techblog/2005/11/lmsensors-and-gigabyte-ga-6va7.shtml).  That didn't work out so well, so I'm going to give it another shot.  Which is important because I had a drive overheat this week due to a failed fan.
+A while back I had tried to [configure lm_sensors on an old Gigabyte GA-6VA7+ motherboard](/techblog/2005/11/lmsensors-and-gigabyte-ga-6va7.shtml).  That didn't work out so well, so I'm going to give it another shot.  Which is important because I had a drive overheat this week due to a failed fan.
 
 There's a new version of lm_sensors out (2.10) while I'm still running the old 2.09.  Most of the steps are the same, I'm simply emerging the new version and then following the instructions.  On my slow little 566Mhz Celeron box, this takes a while.  Especially since I'm also rebuilding a failed raid element (thank goodness for Software RAID).
 
@@ -201,10 +201,4 @@ Winbond 83977 (I/O chipset)
 VIA VT82C596B
 VIA VT82C693A
 
-Hmm... those VIA chips are [supposedly supported](http://secure.netroedge.com/~lm78/supported.html) via the [i2c-viapro](http://www2.lm-sensors.nu/~lm78/cvs/lm_sensors2/doc/busses/i2c-viapro) module.  I'll need to reboot at some point and check out my BIOS settings to make sure the proper things are turned on.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[21:11](http://www.tgharold.com/techblog/2006/06/lmsensors-and-gigabyte-ga-6va7-take-2.shtml)
-
-		</div>
+Hmm... those VIA chips are [supposedly supported](http://secure.netroedge.com/~lm78/supported.html) via the [i2c-viapro](http://www2.lm-sensors.nu/~lm78/cvs/lm_sensors2/doc/busses/i2c-viapro) module.  I'll need to reboot at some point and check out my BIOS settings to make sure the proper things are turned on.

--- a/_posts/2006/2006-06-11-failing-hard-drive-in-a-software-raid.md
+++ b/_posts/2006/2006-06-11-failing-hard-drive-in-a-software-raid.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So today's fun is that I have a drive that is failing in my 566Mhz Celeron server.  This is a small server with (3) 120GB hard drives.
+So today's fun is that I have a drive that is failing in my 566Mhz Celeron server.  This is a small server with (3) 120GB hard drives.
 
 hda - 120GB (primary drive, 4 partitions)
 hdc - CD-ROM
@@ -815,10 +815,4 @@ md0 : active raid1 hde1[0] hda1[1]
       125376 blocks [2/2] [UU]
 
 unused devices: <none>
-coppermine thomas #</none></none></code><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:02](http://www.tgharold.com/techblog/2006/06/failing-hard-drive-in-software-raid.shtml)
-
-		</div>
+coppermine thomas #</none></none></code>

--- a/_posts/2006/2006-06-12-getting-started-with-gpg4win.md
+++ b/_posts/2006/2006-06-12-getting-started-with-gpg4win.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [EMail-Security using GnuPG for Windows](http://www.gpg4win.org/) - GPG4Win offers better integration of GnuPG into Windows them past products (such as using WinPT with the command-line version of GnuPG).  That means that the user experience is a lot nicer and it doesn't seem as clunky.
 
 You can [download GPG4Win here](http://www.gpg4win.org/download.html).  The current version is: 1.0.2
@@ -249,10 +249,3 @@ Backing up your secret key and passphrase on paper
 
 </li>
 </ol>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Encryption.shtml">Encryption</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/GnuPG.shtml">GnuPG</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:47](http://www.tgharold.com/techblog/2006/06/getting-started-with-gpg4win.shtml)
-
-		</div>

--- a/_posts/2006/2006-06-14-subversion-for-linux-administrators.md
+++ b/_posts/2006/2006-06-14-subversion-for-linux-administrators.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Updated: 26 Aug 2006
+Updated: 26 Aug 2006
 
 I *think* I have this figured out.  After banging my head against the wall for a few months, I finally figured out how to put my /etc configuration folder (and config files) into SubVersion so that I have version control over them.
 
@@ -332,10 +332,4 @@ nogitsune sbin #</code>
 
 Note: Each of the "svnadmin dump" lines should be all on one line and not split across two lines.
 
-As far as I know, svndump is adequate to the task of backing up SubVersion repositories.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[21:23](http://www.tgharold.com/techblog/2006/06/subversion-for-linux-administrators.shtml)
-
-		</div>
+As far as I know, svndump is adequate to the task of backing up SubVersion repositories.

--- a/_posts/2006/2006-06-15-truecrypt---encrypted-usb-drive.md
+++ b/_posts/2006/2006-06-15-truecrypt---encrypted-usb-drive.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>TrueCrypt comes in handy for securing external USB or Firewire drives.  Especially when those drives are used for backups of sensitive files or if you are going to ship the drives from point A to point B.  Or even if you are worried about someone swiping the drive and mounting it on another workstation to access files that you have stored there.
+TrueCrypt comes in handy for securing external USB or Firewire drives.  Especially when those drives are used for backups of sensitive files or if you are going to ship the drives from point A to point B.  Or even if you are worried about someone swiping the drive and mounting it on another workstation to access files that you have stored there.
 
 Plus, as long as you know the passphrase and/or have the keyfiles used to decrypt the volume, you can move the USB device from workstation to workstation without losing access to the content.
 
@@ -80,10 +80,4 @@ C. Create the TrueCrypt drive on the partition
 </li>
 </ol>
 
-Once the partition has been formatted with TrueCrypt you can then return to the TrueCrypt window and mount the drive to a drive letter.  If this drive is always connected to the system you may wish to mount it upon login by making it a "favorite" volume in TrueCrypt.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Encryption.shtml">Encryption</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/TrueCrypt.shtml">TrueCrypt</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:36](http://www.tgharold.com/techblog/2006/06/truecrypt-encrypted-usb-drive.shtml)
-
-		</div>
+Once the partition has been formatted with TrueCrypt you can then return to the TrueCrypt window and mount the drive to a drive letter.  If this drive is always connected to the system you may wish to mount it upon login by making it a "favorite" volume in TrueCrypt.

--- a/_posts/2006/2006-06-17-editing-user-ids-associated-with-a-gpg-key.md
+++ b/_posts/2006/2006-06-17-editing-user-ids-associated-with-a-gpg-key.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Back when one of my users created their GPG keys, they put some bogus text in the Comment field because they didn't realize the public nature of the field.  So their name looks like:
+Back when one of my users created their GPG keys, they put some bogus text in the Comment field because they didn't realize the public nature of the field.  So their name looks like:
 
 Joe Smith (bogus text) jsmith@example.com
 
@@ -57,10 +57,4 @@ For information on backing up a key, see [my previous post on GPG4Win](/techblog
 
 Note #1: If you have multiple UIDs associated with a key, you can use the "PRIMARY" command to flag one of the UIDs as the default UID to display in the key list.  Simply select "PRIMARY" from the Command list, highlight the UID you want as the primary and click "OK".  However, this only works in WinPT... in most other implementations, the default UID is the last one added to the key.
 
-Note #2: Prior to exporting the key or giving it to anyone else, you can use the DELUID to remove UIDs from the key. But once you have published a UID for a particular key, only the REVUID command will do what you want.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Encryption.shtml">Encryption</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/GnuPG.shtml">GnuPG</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:29](http://www.tgharold.com/techblog/2006/06/editing-user-ids-associated-with-gpg.shtml)
-
-		</div>
+Note #2: Prior to exporting the key or giving it to anyone else, you can use the DELUID to remove UIDs from the key. But once you have published a UID for a particular key, only the REVUID command will do what you want.

--- a/_posts/2006/2006-06-20-hde-dma_intr-bad-dma-status-dma_stat35.md
+++ b/_posts/2006/2006-06-20-hde-dma_intr-bad-dma-status-dma_stat35.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Getting the following messages in my system log:
+Getting the following messages in my system log:
 
 <code>nogitsune etc # grep 'Jun 16 07' /var/log/messages
 Jun 16 07:38:51 nogitsune ntpd[6095]: peer 205.166.121.66 now invalid
@@ -61,10 +61,4 @@ nogitsune etc #</code>
 
 Basically, they happen anytime that I put a sustained load onto the 2 drives attached to that PCI card.  At the moment, I'm not sure (might be in the archives) which IDE host adapter I'm using for hde and hdg.
 
-From my limited digging, it appears that it may have something to do with lost interrupts, except that I'm not seeing any other messages in the logs regarding that.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[02:14](http://www.tgharold.com/techblog/2006/06/hde-dmaintr-bad-dma-status-dmastat35.shtml)
-
-		</div>
+From my limited digging, it appears that it may have something to do with lost interrupts, except that I'm not seeing any other messages in the logs regarding that.

--- a/_posts/2006/2006-06-20-via-epia-gentoo-migration.md
+++ b/_posts/2006/2006-06-20-via-epia-gentoo-migration.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Currently, I was using a VIA EPIA system as my music server, but now I'm thinking about turning it into a smart router for the home office.  This will entail adding a ethernet card to the unit in addition to migrating my hard drives from a pair of 300GB drives to a pair of notebook drives (for less power).  Since I'm using Software RAID, moving from one set of disks to another should be nearly seamless.
+Currently, I was using a VIA EPIA system as my music server, but now I'm thinking about turning it into a smart router for the home office.  This will entail adding a ethernet card to the unit in addition to migrating my hard drives from a pair of 300GB drives to a pair of notebook drives (for less power).  Since I'm using Software RAID, moving from one set of disks to another should be nearly seamless.
 
 The hardware has changed a little bit since my [previous attempt at building the system back in March 2005](/techblog/2005/03/gentoo-epia-install-part-1.shtml), but the BIOS settings are identical.  The current hardware consists of:
 
@@ -49,10 +49,4 @@ I'm going to replace the two 300GB 3.5" drives with less power-hungry 60GB lapto
 </li>
 </ol>
 
-Note: I forgot to install grub on the new disk this last time.  So I need to boot from the LiveCD, chroot into the O/S and re-install grub on the new disks.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VIAEPIA.shtml">VIAEPIA</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:35](http://www.tgharold.com/techblog/2006/06/via-epia-gentoo-migration.shtml)
-
-		</div>
+Note: I forgot to install grub on the new disk this last time.  So I need to boot from the LiveCD, chroot into the O/S and re-install grub on the new disks.

--- a/_posts/2006/2006-06-26-spf-gaining-traction.md
+++ b/_posts/2006/2006-06-26-spf-gaining-traction.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>As I was signing up for a few mailing lists, I was glancing through the confirmation / welcome messages and I see that there are now some SPF headers showing up in those checks.  The <b>ezmlm</b> list manager program includes the full body of the subscribe/confirmation message in its responses:
+As I was signing up for a few mailing lists, I was glancing through the confirmation / welcome messages and I see that there are now some SPF headers showing up in those checks.  The <b>ezmlm</b> list manager program includes the full body of the subscribe/confirmation message in its responses:
 
 <code>Received-SPF: pass (asf.osuosl.org: domain of tgh@tgharold.com designates 69.36.9.168 as permitted sender)
 Received: from [69.36.9.168] (HELO omega.jtlnet.com) (69.36.9.168)
@@ -18,10 +18,4 @@ Received: from [69.36.9.168] (HELO omega.jtlnet.com) (69.36.9.168)
 
 A quick glance through my other mailing list confirmation messages didn't turn up any more.  Other mailing list software doesn't reflect back the sign-up mail message so it's not possible to see if SPF checks are being used or not.
 
-I run a very strict SPF record for this domain.  I wish companies would check the SPF record before bouncing messages back to me (due to joe-jobs by spammers).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SPF.shtml">SPF</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:03](http://www.tgharold.com/techblog/2006/06/spf-gaining-traction.shtml)
-
-		</div>
+I run a very strict SPF record for this domain.  I wish companies would check the SPF record before bouncing messages back to me (due to joe-jobs by spammers).

--- a/_posts/2006/2006-06-27-dhcp-and-dynamic-dns-updates-with-bind.md
+++ b/_posts/2006/2006-06-27-dhcp-and-dynamic-dns-updates-with-bind.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>After a few hours last night (and a lot of help from <i>DNS &amp; BIND Cookbook</i>) I finally got my DHCP server on the Gentoo box to automatically add records to my local LAN's DNS zone.  It's not terribly difficult to do, just a little tricky until you get all the ducks in a row and put everything in the right place.
+After a few hours last night (and a lot of help from <i>DNS &amp; BIND Cookbook</i>) I finally got my DHCP server on the Gentoo box to automatically add records to my local LAN's DNS zone.  It's not terribly difficult to do, just a little tricky until you get all the ducks in a row and put everything in the right place.
 
 First off, I can't recommend enough making use of SubVersion to keep track of configuration / zone file changes.  It greatly simplifies things in case you have to revert to a previous version.  It's also a good way to get comfortable with SVN command-line usage because you're not doing anything complex (mostly 'svn add' and 'svn ci' commands).
 
@@ -254,10 +254,4 @@ reverse #</code>
 
 H. That should be it
 
-That should be everything that is needed.  If not, leave me a note in a comment and I'll re-examine my notes.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/BIND9.shtml">BIND9</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:46](http://www.tgharold.com/techblog/2006/06/dhcp-and-dynamic-dns-updates-with-bind.shtml)
-
-		</div>
+That should be everything that is needed.  If not, leave me a note in a comment and I'll re-examine my notes.

--- a/_posts/2006/2006-07-15-motherboard-bundles.md
+++ b/_posts/2006/2006-07-15-motherboard-bundles.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>We've been digging through the junkyard at work (and in my home office) and we're trying to use up some old ATX towers and other misc parts to build new systems this fall.  In some cases, this just means buying a MB/CPU/RAM combo along with a copy of WinXP Pro and Office 2003.  In other cases, the older ATX power-supply can't do the job and we have to purchase a new PSU.
+We've been digging through the junkyard at work (and in my home office) and we're trying to use up some old ATX towers and other misc parts to build new systems this fall.  In some cases, this just means buying a MB/CPU/RAM combo along with a copy of WinXP Pro and Office 2003.  In other cases, the older ATX power-supply can't do the job and we have to purchase a new PSU.
 
 The unit that I'm currently working on is an Athlon64 3000+ system.  The MB/CPU/RAM bundle cost me approximately $265 from MWave for an Athlon64 (BA21443), Kingston 2x512MB (BA19405) and an Asus A8N-VM CSM motherboard (BA22045).  Because the PSU that I'm using is a slightly older ATX+12V PSU (20 pin + 4 pin connectors), I had to also purchase the 20-24 pin PSU adapter (BA20019) for $9.
 
@@ -69,10 +69,4 @@ BA20959 2GB Mwave PC3200 2x1GB RAM
 
 ---
 
-I'm still waiting on Core Duo and Core 2 Duo systems to be sold as motherboard bundles.  The pricing on the chips is still a bit high.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:24](http://www.tgharold.com/techblog/2006/07/motherboard-bundles.shtml)
-
-		</div>
+I'm still waiting on Core Duo and Core 2 Duo systems to be sold as motherboard bundles.  The pricing on the chips is still a bit high.

--- a/_posts/2006/2006-07-16-3dmark06-scores.md
+++ b/_posts/2006/2006-07-16-3dmark06-scores.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [FutureMark's 3DMark06](http://www.futuremark.com/products/)
 
 Note that 3DMark06 is heavily weighted towards 3D card power rather then CPU power.
@@ -59,10 +59,4 @@ Asus SK8N motherboard
 NVIDIA GeForce 7800GS (256MB AGP)
 NVIDIA 91.47
 
-(The 7800GS is a nice upgrade over my older 6800.)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:23](http://www.tgharold.com/techblog/2006/07/3dmark06-scores.shtml)
-
-		</div>
+(The 7800GS is a nice upgrade over my older 6800.)

--- a/_posts/2006/2006-07-16-aquamark3-scores.md
+++ b/_posts/2006/2006-07-16-aquamark3-scores.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One benchmark that I used to use is AquaMark3 (a DirectX 9 based benchmark).  Unfortunately, the company behind AquaMark3 is no longer in business.  Which is a shame, because they allowed you to submit your scores to a central database which had some decent search parameters.  (For instance, you could search for equivalent systems that were not overclocked to get an idea of what performance a particular upgrade would give you.)
+One benchmark that I used to use is AquaMark3 (a DirectX 9 based benchmark).  Unfortunately, the company behind AquaMark3 is no longer in business.  Which is a shame, because they allowed you to submit your scores to a central database which had some decent search parameters.  (For instance, you could search for equivalent systems that were not overclocked to get an idea of what performance a particular upgrade would give you.)
 
 Still, since I have it around, I threw it at the new Athlon64 3000+ system that I just built.  I expect that the video scores will be pretty poor since it's using an integrated NVIDIA GeForce 6150 video card that uses 64MB of system RAM.
 
@@ -69,10 +69,4 @@ AMD Opteron 148
 PC3200 2GB (2x1GB) ECC DDR RAM
 Asus SK8N motherboard
 NVIDIA GeForce 7800GS AGP 256MB
-NVIDIA 91.47<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:34](http://www.tgharold.com/techblog/2006/07/aquamark3-scores.shtml)
-
-		</div>
+NVIDIA 91.47

--- a/_posts/2006/2006-07-16-lcd-panel-prices.md
+++ b/_posts/2006/2006-07-16-lcd-panel-prices.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>The other half of the upgrade equation is the displays.  Most users at the main office are already using 17" CRTs (mostly running at 1024x768).  I'd like to start converting them to using 17" or 19" LCDs running at least 1280x1024 if not 1600x1200 (20" LCDs).
+The other half of the upgrade equation is the displays.  Most users at the main office are already using 17" CRTs (mostly running at 1024x768).  I'd like to start converting them to using 17" or 19" LCDs running at least 1280x1024 if not 1600x1200 (20" LCDs).
 
 Some key terms to know when searching at BizRate:
 
@@ -27,10 +27,4 @@ Given the prices for the UXGA displays ($375+) there's a good argument for givin
 WSXGA - 1680x1050 (20" $400-$500)
 WUXGA - 1920x1200 (24" $750-$1000)
 
-I'm surprised at the pricing on the WSXGA displays, although there are only 2 on the market.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[00:08](http://www.tgharold.com/techblog/2006/07/lcd-panel-prices.shtml)
-
-		</div>
+I'm surprised at the pricing on the WSXGA displays, although there are only 2 on the market.

--- a/_posts/2006/2006-07-16-pcmark05-basic-scores.md
+++ b/_posts/2006/2006-07-16-pcmark05-basic-scores.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [FutureMark's PCMark05](http://www.futuremark.com/products/)
 
 More of a general office benchmark (even though it won't run on my Tecra 9100).  The integrated video on the Asus A8N-VM CSM motherboard really doesn't slow the system down much.
@@ -40,10 +40,4 @@ DDR 533 (2x1GB) RAM
 Asus M2NPV-VM CSM motherboard
 NVIDIA GeForce 6150 integrated graphics (32MB)
 
-(All systems are stock settings (no overclocking), usually with 7200rpm hard drives.  If I get a chance this week, I'll run some tests on some older Dell systems at the main office.)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:54](http://www.tgharold.com/techblog/2006/07/pcmark05-basic-scores.shtml)
-
-		</div>
+(All systems are stock settings (no overclocking), usually with 7200rpm hard drives.  If I get a chance this week, I'll run some tests on some older Dell systems at the main office.)

--- a/_posts/2006/2006-07-17-gentoo-20060-livecd-and-ntfsclone.md
+++ b/_posts/2006/2006-07-17-gentoo-20060-livecd-and-ntfsclone.md
@@ -10,14 +10,8 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>In the past, I've been using the [Knoppix LiveCD and NTFSClone](/techblog/2005/10/imaging-tecra-8200-windows-2000.shtml) to make snapshot images of Windows workstations.  However, since Knoppix 4.0.2 doesn't auto-detect the ethernet port on the Asus A8N-VM CSM motherboard, I tried out the Gentoo AMD64 2006.0 LiveCD instead.
+In the past, I've been using the [Knoppix LiveCD and NTFSClone](/techblog/2005/10/imaging-tecra-8200-windows-2000.shtml) to make snapshot images of Windows workstations.  However, since Knoppix 4.0.2 doesn't auto-detect the ethernet port on the Asus A8N-VM CSM motherboard, I tried out the Gentoo AMD64 2006.0 LiveCD instead.
 
 The big trick with the newer LiveCDs is keeping them from booting into X.  At the <b>boot:</b> prompt you need to enter "<b>gentoo nox</b>" in order to prevent that from happening.  That gives you the normal command line that has root level access to the LiveCD and you can switch between sessions using [Alt-F1] and [Alt-F2].
 
-After that, it's pretty easy to mount a drive and write the image file out to wherever you need it to go.  I typically create a hidden Linux partition at the end of the primary drive using ext3 and write a pair of images to it when I finish the initial build.  I'll also burn one of the images to DVD-R for use in cases where the user manages to wipe out the hidden partition (or the drive dies entirely).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NTFSClone.shtml">NTFSClone</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:35](http://www.tgharold.com/techblog/2006/07/gentoo-20060-livecd-and-ntfsclone.shtml)
-
-		</div>
+After that, it's pretty easy to mount a drive and write the image file out to wherever you need it to go.  I typically create a hidden Linux partition at the end of the primary drive using ext3 and write a pair of images to it when I finish the initial build.  I'll also burn one of the images to DVD-R for use in cases where the user manages to wipe out the hidden partition (or the drive dies entirely).

--- a/_posts/2006/2006-07-26-system-burnin-testing.md
+++ b/_posts/2006/2006-07-26-system-burnin-testing.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One of the key things I try to do when setting up a new system is to really hammer it for a few days prior to delivering it to the main office and installing it.  That means exercising the disks, keeping an eye on temps, making the CPU run at 100% utilization and running data to/from the memory.  To do this, there are (4) programs that I use under Windows:
+One of the key things I try to do when setting up a new system is to really hammer it for a few days prior to delivering it to the main office and installing it.  That means exercising the disks, keeping an eye on temps, making the CPU run at 100% utilization and running data to/from the memory.  To do this, there are (4) programs that I use under Windows:
 
 1) [SpeedFan](http://www.almico.com/speedfan.php) - Which does an excellent job at allowing you to see what your CPU and hard drive temperatures are.  You can also display graphs of historical temperatures so that you can see the rise/fall as the component is put under a load.  Configuration is fairly easy, the hard part is identifying which temperature sensor is which.
 
@@ -38,10 +38,4 @@ For example:  The WD Raptor 10k SATA that I installed today shows a minimum temp
 
 5) Check the other temperature sensors inside the case.  Different CPUs run at different temperatures, so it is hard to make ballpark recommendations.  The Athlon64 X2 4200+ in a system that I'm burning in right now runs at 60-61C under full load.
 
-6) Watch the Prime95 windows and look for error indicators.  An error in Prime95 indicates that there is a problem with either your RAM or your CPU.  It could be as simple as incorrect timings or maybe the "fast" RAM that you bought isn't as fast as it says it is (and backing off on memory timings will make the system stable).  In general, Prime95 is extremely sensitive to marginal hardware, where MemTest86 might give it a "pass" Prime95 will throw a warning.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[22:24](http://www.tgharold.com/techblog/2006/07/system-burnin-testing.shtml)
-
-		</div>
+6) Watch the Prime95 windows and look for error indicators.  An error in Prime95 indicates that there is a problem with either your RAM or your CPU.  It could be as simple as incorrect timings or maybe the "fast" RAM that you bought isn't as fast as it says it is (and backing off on memory timings will make the system stable).  In general, Prime95 is extremely sensitive to marginal hardware, where MemTest86 might give it a "pass" Prime95 will throw a warning.

--- a/_posts/2006/2006-07-27-iacimedll---identified-as-a-virus.md
+++ b/_posts/2006/2006-07-27-iacimedll---identified-as-a-virus.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>According to HijackThis (v1.98.2) it's a BHO without a name {2afba397-d964-4056-a9df-060a93ffa503} that was installed in C:\Windows\System32\iacime.dll.
+According to HijackThis (v1.98.2) it's a BHO without a name {2afba397-d964-4056-a9df-060a93ffa503} that was installed in C:\Windows\System32\iacime.dll.
 
 Symantec Anti-Virus identifies it as:
 
@@ -22,10 +22,4 @@ Location:  C:\WINDOWS\system32
 Computer:  JOE-LAPTOP
 User:  Joe
 Action taken:  Clean failed : Quarantine failed : Access denied
-Date found: Thu Jul 27 08:54:43 2006<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:51](http://www.tgharold.com/techblog/2006/07/iacimedll-identified-as-virus.shtml)
-
-		</div>
+Date found: Thu Jul 27 08:54:43 2006

--- a/_posts/2006/2006-07-28-result-code-0x57-when-scheduling-a-backup.md
+++ b/_posts/2006/2006-07-28-result-code-0x57-when-scheduling-a-backup.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This was a slightly odd one that did not show up on Google at all.  We had a bunch of backup jobs on our main Windows 2003 file server and had recently promoted the Win2003 server to a domain controller using DCPROMO.EXE.  In the process of doing that, some tasks refused to run and we also had to delete and re-add a lot of tasks.
+This was a slightly odd one that did not show up on Google at all.  We had a bunch of backup jobs on our main Windows 2003 file server and had recently promoted the Win2003 server to a domain controller using DCPROMO.EXE.  In the process of doing that, some tasks refused to run and we also had to delete and re-add a lot of tasks.
 
 In the Scheduled Tasks window, we saw a result code of "0x57" in the Last Result column.  In the schedule log (Scheduled Tasks, Advanced, View Log):
 
@@ -18,10 +18,4 @@ In the Scheduled Tasks window, we saw a result code of "0x57" in the Last Result
     Finished 7/28/2006 8:30:48 PM
     Result: The task completed with an exit code of (57).</code>
 
-We checked a few things and finally took a very close look at the "Run" field in the task.  Turns out that we were missing a double-quote in the middle of the NTBACKUP command line.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Backups.shtml">Backups</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Win2003.shtml">Win2003</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:44](http://www.tgharold.com/techblog/2006/07/result-code-0x57-when-scheduling.shtml)
-
-		</div>
+We checked a few things and finally took a very close look at the "Run" field in the task.  Turns out that we were missing a double-quote in the middle of the NTBACKUP command line.

--- a/_posts/2006/2006-07-29-new-motherboard-bundle-listing.md
+++ b/_posts/2006/2006-07-29-new-motherboard-bundle-listing.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Updated pricing now that AMD released their price cuts on July 24th.  As a result, I'm pushing straight towards basing our low end systems around the AMD Athlon64 X2 3800+ chip.
+Updated pricing now that AMD released their price cuts on July 24th.  As a result, I'm pushing straight towards basing our low end systems around the AMD Athlon64 X2 3800+ chip.
 
 The base costs for the system are (these are common, no matter which CPU we use):
 
@@ -92,10 +92,4 @@ $131 AA15070 WindowsXP Pro OEM
 $299 AA24200 Microsoft Office Pro 2003 OEM
 $45 small hard drives
 $18 DVD-ROM
-$9 Floppy drive<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[17:32](http://www.tgharold.com/techblog/2006/07/new-motherboard-bundle-listing.shtml)
-
-		</div>
+$9 Floppy drive

--- a/_posts/2006/2006-08-08-linksys-to-shorewall.md
+++ b/_posts/2006/2006-08-08-linksys-to-shorewall.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Over the past week, I've been encountering slowdowns on my DSL connection.  Normally, I can get 1.5Mbps download speeds, which is what I'm provisioned for and what the line is capable of.  But over the past week or so, my top download speed has gradually fallen to around 300-500Kbps (1/5 to 1/3 of the usual bandwidth).  It didn't seem to matter what protocol I was using at the time either.
+Over the past week, I've been encountering slowdowns on my DSL connection.  Normally, I can get 1.5Mbps download speeds, which is what I'm provisioned for and what the line is capable of.  But over the past week or so, my top download speed has gradually fallen to around 300-500Kbps (1/5 to 1/3 of the usual bandwidth).  It didn't seem to matter what protocol I was using at the time either.
 
 So I did some testing.  With the LinkSys router involved, I was seeing download rates of 300-500Kbps.  But if I hooked a laptop directly to the DLS modem, I could get 1.5Mbps again.  Ah ha!  That shows clearly that the issue is not any sort of bandwidth shaping or traffic limiting by the ISP but rather something strange going on with my Linksys BEFW11S4 router.
 
@@ -22,10 +22,4 @@ It took me around 2 hours to configure Shorewall for Gentoo on my C3 box.  So fa
 
 Now I can go read up on my Linux security books and figure out if I want to continue using Shorewall or not.
 
-Follow-up note: Unfortunately, I was never able to get PPTP pass-through working.  I was trying to use Shorewall in a SOHO environment where I create a VPN connection from my laptop out through the Shorewall NAT to a PPTP VPN server on the public internet.  But something in either the Linux kernel or the Shorewall / IPTables configuration is blocking all or some of the PPTP traffic.  So I had to drop the Linksys hardware router back in so that I could get work done.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/IPTables.shtml">IPTables</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NAT.shtml">NAT</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PPTP.shtml">PPTP</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Shorewall.shtml">Shorewall</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VPN.shtml">VPN</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[06:46](http://www.tgharold.com/techblog/2006/08/linksys-to-shorewall.shtml)
-
-		</div>
+Follow-up note: Unfortunately, I was never able to get PPTP pass-through working.  I was trying to use Shorewall in a SOHO environment where I create a VPN connection from my laptop out through the Shorewall NAT to a PPTP VPN server on the public internet.  But something in either the Linux kernel or the Shorewall / IPTables configuration is blocking all or some of the PPTP traffic.  So I had to drop the Linksys hardware router back in so that I could get work done.

--- a/_posts/2006/2006-08-17-virtualization-and-sans.md
+++ b/_posts/2006/2006-08-17-virtualization-and-sans.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One of my next projects at the office is to start migrating us from individual servers with direct attached storage (DAS) to a virtual server running on a storage area network (SAN).
+One of my next projects at the office is to start migrating us from individual servers with direct attached storage (DAS) to a virtual server running on a storage area network (SAN).
 
 <b>Individual servers with DAS</b>
 + Easy configuration
@@ -53,10 +53,4 @@ $2.00/GB - homegrown
 $4.50/GB - pre-built SATA iSCSI solutions
 $13.33/GB - pre-built SCSI iSCSI solutions
 
-Costs for half populated SANs are about double those $/GB values.  The SCSI SAN unit can only hold about 2/5 the capacity of the SATA SAN units.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[21:43](http://www.tgharold.com/techblog/2006/08/virtualization-and-sans.shtml)
-
-		</div>
+Costs for half populated SANs are about double those $/GB values.  The SCSI SAN unit can only hold about 2/5 the capacity of the SATA SAN units.

--- a/_posts/2006/2006-08-18-starting-an-iscsi-san-unit.md
+++ b/_posts/2006/2006-08-18-starting-an-iscsi-san-unit.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So here's my first stab at a SAN unit that can hold 14 or 17 SATA drives.  All of the drives will be mounted in hot-swap trays which should make things much easier.  Some of the components are a bit overkill (such as the pair of dual-port server NICs) but I'm planning ahead to when we have two gigabit switches and we want to connect multiple gigabit ports together for speed.
+So here's my first stab at a SAN unit that can hold 14 or 17 SATA drives.  All of the drives will be mounted in hot-swap trays which should make things much easier.  Some of the components are a bit overkill (such as the pair of dual-port server NICs) but I'm planning ahead to when we have two gigabit switches and we want to connect multiple gigabit ports together for speed.
 
 For the case, motherboard and misc parts:
 
@@ -66,10 +66,4 @@ I may also expand the memory in the SAN boxes to 6GB or 8GB down the road to max
 
 For home use, I wouldn't bother to build a 2nd SAN unit for redundancy.  Downtime in case of a blown power-supply would only be about 2 hours (assuming you have one on-hand) to a day or two.  I could also cut some costs by going with less expensive NICs or SATA controllers.  But that doesn't gain you much.
 
-The other advantage of building out slowly is that you can take advantage of the 1TB and 2TB drives that might appear in 2007-2009.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/iSCSI.shtml">iSCSI</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SAN.shtml">SAN</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:17](http://www.tgharold.com/techblog/2006/08/starting-iscsi-san-unit.shtml)
-
-		</div>
+The other advantage of building out slowly is that you can take advantage of the 1TB and 2TB drives that might appear in 2007-2009.

--- a/_posts/2006/2006-08-19-benchmarking---bonnie.md
+++ b/_posts/2006/2006-08-19-benchmarking---bonnie.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>The first test is done on /dev/md3 (composed of partitions on /dev/hda and /dev/sda).
+The first test is done on /dev/md3 (composed of partitions on /dev/hda and /dev/sda).
 
 <pre>nogitsune tmp # bonnie -s 16384 -m nogitsune-vgmirror
 File './Bonnie.9315', size: 17179869184
@@ -88,10 +88,3 @@ Seeker 1...Seeker 2...Seeker 3...start 'em...done...done...done...
 Machine    MB K/sec %CPU K/sec %CPU K/sec %CPU K/sec %CPU K/sec %CPU  /sec %CPU
 direct   2047  4517 83.2 11374 58.1  9073 54.7  6932 98.6 36154 52.7  99.8  3.2
 coppermine backup #</pre>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:06](http://www.tgharold.com/techblog/2006/08/benchmarking-bonnie.shtml)
-
-		</div>

--- a/_posts/2006/2006-08-19-benchmarking---hdparm.md
+++ b/_posts/2006/2006-08-19-benchmarking---hdparm.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So as I prepare for the iSCSI build, I need to start gathering tools to help me find bottlenecks.  As well as establishing baseline performance estimates.
+So as I prepare for the iSCSI build, I need to start gathering tools to help me find bottlenecks.  As well as establishing baseline performance estimates.
 
 <b>hdparm -tT {blockdevice name}</b> - This tool ships standard with most (all?) versions of Linux.  It's a read-only, non-destructive (if used properly), command that can be used to test raw read performance from any block device.  So you can check individual drives in a RAID array as well as doing a quick check of the over all RAID array performance.  Run time is generally around 10 seconds.
 
@@ -150,10 +150,4 @@ nogitsune etc # hdparm -tT /dev/sdb1
  Timing cached reads:   3232 MB in  2.00 seconds = 1615.90 MB/sec
  Timing buffered disk reads:  162 MB in  3.01 seconds =  53.85 MB/sec</code>
 
-What we see here is that for the RAID1 arrays, speed is equivalent to the disks within the array.  But for the RAID5 array with (3) disks, speed is 2x that of the single disks within the array.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:47](http://www.tgharold.com/techblog/2006/08/benchmarking-hdparm.shtml)
-
-		</div>
+What we see here is that for the RAID1 arrays, speed is equivalent to the disks within the array.  But for the RAID5 array with (3) disks, speed is 2x that of the single disks within the array.

--- a/_posts/2006/2006-08-19-san-design---part-2.md
+++ b/_posts/2006/2006-08-19-san-design---part-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Trying to decide how to allocate disks within the SAN unit.  I have (14) or (17) slots.  For now, I'll assume that the 5:3 bay units work which will give me a total of 17 disks.
+Trying to decide how to allocate disks within the SAN unit.  I have (14) or (17) slots.  For now, I'll assume that the 5:3 bay units work which will give me a total of 17 disks.
 
 <pre>-------------------------------------------------
 BAYS / DRIVE CONFIGURATION (2 INT, 15 BAY-COOLER)
@@ -60,10 +60,4 @@ B) The second configuration sets up a 8-disk RAID6 array
 
 The RAID0 over (3) RAID1 sets (a.k.a. RAID 10) should give me roughly 3x the performance of a regular RAID1 volume.  Reads and writes should both see a 3x improvement over a simple RAID1.
 
-For the RAID6 volume, I estimate that read performance will be 6x that of the RAID1 set but I'm not sure what write performance will be.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/iSCSI.shtml">iSCSI</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RAID.shtml">RAID</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SAN.shtml">SAN</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:40](http://www.tgharold.com/techblog/2006/08/san-design-part-2.shtml)
-
-		</div>
+For the RAID6 volume, I estimate that read performance will be 6x that of the RAID1 set but I'm not sure what write performance will be.

--- a/_posts/2006/2006-08-19-san-testing-switch.md
+++ b/_posts/2006/2006-08-19-san-testing-switch.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>For testing out the SAN, it looks like I can make use of either a 
+For testing out the SAN, it looks like I can make use of either a 
 SMC SMCGS16-SMART or SMC SMCGS24-SMART switch.  These are 16/24 port gigabit switches that support link aggragation.  Price on the 16-port unit is only $260 or so and the 24-port switch sells for $320.
 
 I'm still figuring out how I want to support bonding in the unit.  I have the (4) ports from the Intel Pro adapters plus the (2) ports on the motherboard.  My initial plan is to bond the Intel adapters together into a two pairs, then hook each pair to a different switch for fault-tolerance.  That would give me either 200MB/s of bandwidth or 400MB/s of bandwidth.
@@ -35,10 +35,4 @@ RAID10 (sequential reads/writes)
 12-spindle: 360MB/s
 16-spindle: 480MB/s
 
-Those are big S.W.A.G. estimates.  In reality, performance will probably be closer to the semi-random performance numbers.  Which means that the first set of drives needs to be configured into an 8-spindle RAID10 in order to be viable.  A PCI motherboard would choke on this amount of bandwidth, but the newer PCIe motherboards should be able to handle it.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[19:39](http://www.tgharold.com/techblog/2006/08/san-testing-switch.shtml)
-
-		</div>
+Those are big S.W.A.G. estimates.  In reality, performance will probably be closer to the semi-random performance numbers.  Which means that the first set of drives needs to be configured into an 8-spindle RAID10 in order to be viable.  A PCI motherboard would choke on this amount of bandwidth, but the newer PCIe motherboards should be able to handle it.

--- a/_posts/2006/2006-08-20-benchmarking---hdparm-follow-up.md
+++ b/_posts/2006/2006-08-20-benchmarking---hdparm-follow-up.md
@@ -10,16 +10,10 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>If you recall, the [last time I tested hdparm on my Celeron 566MHz system](http://www.tgharold.com/techblog/2006/08/benchmarking-hdparm.shtml), I was getting very poor read performance on /dev/hda.  
+If you recall, the [last time I tested hdparm on my Celeron 566MHz system](http://www.tgharold.com/techblog/2006/08/benchmarking-hdparm.shtml), I was getting very poor read performance on /dev/hda.  
 
 So I added in a HTP302 (HighPoint Rocket133) 2-port PCI card and moved hda over to the new card.
 
 I now get 20MB/s buffered reads from both the primary and secondary disk in the RAID1 array and 30MB/s buffered reads from the mirror set.  Which is a lot better then the 3.1MB/s for hda and 3.5MB/s for the overall RAID1 array.
 
-That should make the system feel a lot more snappy.  Now the bottleneck will probably be the CPU or the 100Mbit ethernet card.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:44](http://www.tgharold.com/techblog/2006/08/benchmarking-hdparm-follow-up.shtml)
-
-		</div>
+That should make the system feel a lot more snappy.  Now the bottleneck will probably be the CPU or the 100Mbit ethernet card.

--- a/_posts/2006/2006-08-21-rsync-and-ssh-on-windows-2003-server.md
+++ b/_posts/2006/2006-08-21-rsync-and-ssh-on-windows-2003-server.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Taking another stab at setting up RSync and SSH on our Windows 2003 servers.  The goal is that we can upload web files to a central server and then have it synchronize the other servers in the array.  Once again, I'm going to use the [cwRsync and copSSH packages](http://www.itefix.no/) (latest version is 2.0.9).
+Taking another stab at setting up RSync and SSH on our Windows 2003 servers.  The goal is that we can upload web files to a central server and then have it synchronize the other servers in the array.  Once again, I'm going to use the [cwRsync and copSSH packages](http://www.itefix.no/) (latest version is 2.0.9).
 
 Installation on a Windows 2003 Domain Controller:
 <ol>
@@ -83,10 +83,4 @@ type id_rsa.pub &gt;&gt; authorized_keys
 7. Now to configure SSHD on the host server.  You will need to find and edit the sshd_config file (probably in "C:\Program Files\cwRsyncServer\etc").  The following changes should be made in the current version default settings.
 
 PermitRootLogin no
-PasswordAuthentication no<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:55](http://www.tgharold.com/techblog/2006/08/rsync-and-ssh-on-windows-2003-server.shtml)
-
-		</div>
+PasswordAuthentication no

--- a/_posts/2006/2006-08-24-gentoo-amd64-and-asus-m2n32-sli-deluxe.md
+++ b/_posts/2006/2006-08-24-gentoo-amd64-and-asus-m2n32-sli-deluxe.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Finally got my Asus M2N32-SLI Deluxe motherboard setup and ready for installation.  Tossed the 2006.0 Gentoo AMD64 CD in and told it to use 80x25 for the old PCI video card that I have in it.  Unforunately, it hangs after a bit.
+Finally got my Asus M2N32-SLI Deluxe motherboard setup and ready for installation.  Tossed the 2006.0 Gentoo AMD64 CD in and told it to use 80x25 for the old PCI video card that I have in it.  Unforunately, it hangs after a bit.
 
 So my first plan of attack is to update the Asus BIOS from 0406 to 0603 (which is 2 revisions newer).  The 0603 revision was released on June 29, 2006.  The Asus BIOS includes an EZ-FLASH tool in the BIOS Setup (Tools menu), all I have to do is burn the BIOS file to a CD-ROM or diskette.
 
@@ -37,10 +37,4 @@ Hmm... still hangs.  Off to do some more research.
 
 Update #3: Finally got a system that seems to be working.
 
-Reverted the BIOS from the 0604 revision back to the 0503 revision.  Now I can boot the Gentoo AMD64 2006.0 minimal CD using the options <b>gentoo-nofb noapic</b>.  I still get the IRQ7 error that seems to be bugging other Gentoo users, but the system is stable enough to start the install.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:24](http://www.tgharold.com/techblog/2006/08/gentoo-amd64-and-asus-m2n32-sli-deluxe.shtml)
-
-		</div>
+Reverted the BIOS from the 0604 revision back to the 0503 revision.  Now I can boot the Gentoo AMD64 2006.0 minimal CD using the options <b>gentoo-nofb noapic</b>.  I still get the IRQ7 error that seems to be bugging other Gentoo users, but the system is stable enough to start the install.

--- a/_posts/2006/2006-08-24-xen-plans.md
+++ b/_posts/2006/2006-08-24-xen-plans.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So as I wait for parts to be delivered for the Test SAN unit, I'm reading up on Xen and iSCSI and debating what my plan of attack will be.  My options (roughly) are:
+So as I wait for parts to be delivered for the Test SAN unit, I'm reading up on Xen and iSCSI and debating what my plan of attack will be.  My options (roughly) are:
 
 1) Build a normal Gentoo server and load iscsitarget on top of it.  This is the simplest of all options and something that I'm very comfortable with.  However, if I were then then need to run other services on top of the unit, I run the risk of making the iSCSI server portion unstable.
 
@@ -20,10 +20,4 @@ What I'm not sure is whether to run iscsitarget in its own DomU or if it should 
 
 Links:
 
-[Infrastructure virtualisation with Xen advisory](http://docs.solstice.nl/index.php/Infrastructure_virtualisation_with_Xen_advisory)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/iSCSI.shtml">iSCSI</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/iSCSITarget.shtml">iSCSITarget</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Xen.shtml">Xen</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:43](http://www.tgharold.com/techblog/2006/08/xen-plans.shtml)
-
-		</div>
+[Infrastructure virtualisation with Xen advisory](http://docs.solstice.nl/index.php/Infrastructure_virtualisation_with_Xen_advisory)

--- a/_posts/2006/2006-08-25-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-1.md
+++ b/_posts/2006/2006-08-25-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-1.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Time to build the base Gentoo Linux O/S.  While I plan on switching over to a Xen hypervisor kernel in a few days, I still need to get a base Gentoo system up and running.  But first, let me document what sort of machine I'm building and the reasoning behind some of the decisions.
+Time to build the base Gentoo Linux O/S.  While I plan on switching over to a Xen hypervisor kernel in a few days, I still need to get a base Gentoo system up and running.  But first, let me document what sort of machine I'm building and the reasoning behind some of the decisions.
 
 The unit is a custom-built system that will serve as a test unit for building out an iSCSI SAN (and eventually serve as part of that SAN if it tests well).  There will be multiple NICs so that I can bond NICs for bandwidth and so that I can connect NICs to multiple switches in the SAN mesh (for fault-tolerance).  Initially, it will have only (2) SATA drives installed, but the eventual loadout will have a total of (14) SATA drives.
 
@@ -87,10 +87,4 @@ Other sysadmin tricks that I plan on using are:
 
 So it's a moderately complex setup, but provides me with multiple fall-back positions and restoration options.  Anything from reverting a configuration file to a newer version, to booting a known-good root partition, to restoring the system from backups.
 
-And there's always the last resort of putting a Gentoo boot CD in the unit, starting networking and the SSH daemon, and attempting to fix the unit remotely.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:03](http://www.tgharold.com/techblog/2006/08/gentoo-amd64-on-asus-m2n32-sli-deluxe.shtml)
-
-		</div>
+And there's always the last resort of putting a Gentoo boot CD in the unit, starting networking and the SSH daemon, and attempting to fix the unit remotely.

--- a/_posts/2006/2006-08-25-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-2.md
+++ b/_posts/2006/2006-08-25-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>As I said [last time](/techblog/2006/08/gentoo-amd64-on-asus-m2n32-sli-deluxe.shtml), I'm setting this unit up with the following partitions on the 2-disk RAID1 set (sda and sdb):
+As I said [last time](/techblog/2006/08/gentoo-amd64-on-asus-m2n32-sli-deluxe.shtml), I'm setting this unit up with the following partitions on the 2-disk RAID1 set (sda and sdb):
 
 sda1 (md0) - 128MB for /boot
 sda2 (md1) - 8GB for the root partition (primary)
@@ -100,10 +100,4 @@ Now for the supplementary volumes (logs, subversion and system backup).  I'm usi
 
 Whew, that's a big packet of LVM partitions.  But it prevents problems down the road.
 
-At this point, everything is setup and ready for the initial install (or a chroot into an existing system for repairs).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:35](http://www.tgharold.com/techblog/2006/08/gentoo-amd64-on-asus-m2n32-sli-deluxe_25.shtml)
-
-		</div>
+At this point, everything is setup and ready for the initial install (or a chroot into an existing system for repairs).

--- a/_posts/2006/2006-08-25-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-3.md
+++ b/_posts/2006/2006-08-25-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-3.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>It's now time to start refering to the [Gentoo Installation Handbook](http://www.gentoo.org/doc/en/handbook/index.xml) for AMD64.  While I'm pretty sure that my install method works, it's worthwhile verifying against the handbook.  Plus I'm using a minimal CD to do the installation, so things will be slightly different then normal.
+It's now time to start refering to the [Gentoo Installation Handbook](http://www.gentoo.org/doc/en/handbook/index.xml) for AMD64.  While I'm pretty sure that my install method works, it's worthwhile verifying against the handbook.  Plus I'm using a minimal CD to do the installation, so things will be slightly different then normal.
 
 (I use my own recipe for the initial configuration due to the mix of Software RAID + LVM2.  It has served me well over the past few years and works well.)
 
@@ -130,10 +130,4 @@ Read section 7 carefully.  I'm using the default "gentoo-sources" kernel.
 
 <code>(chroot) livecd / # USE="-doc symlink" emerge gentoo-sources</code>
 
-I'll cover configuration of the kernel in the next post.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[21:20](http://www.tgharold.com/techblog/2006/08/gentoo-amd64-on-asus-m2n32_115655834112027898.shtml)
-
-		</div>
+I'll cover configuration of the kernel in the next post.

--- a/_posts/2006/2006-08-26-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-4.md
+++ b/_posts/2006/2006-08-26-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-4.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This is a record of the kernel flags that I'm going to use for my AMD64 system. It's an Asus M2N32-SLI Deluxe (NVIDIA nForce 590 SLI MCP chipset) with an Athlon64 X2 4200+ chip along with 2GB of RAM. Hard drives are hooked up to the onboard SATA-II controller (NVIDIA nForce 590 SLI MCP chipset). Plus the motherboard has a pair of onboard gigabit ethernet NICs (Marvell 88E1116) and a Silicon Image Sil3132 SATA-II controller.  Other chips on the motherboard are the nVidia C51XE, nVidia MCP55PXE, AD1988B, and TSB43AB22A.
+This is a record of the kernel flags that I'm going to use for my AMD64 system. It's an Asus M2N32-SLI Deluxe (NVIDIA nForce 590 SLI MCP chipset) with an Athlon64 X2 4200+ chip along with 2GB of RAM. Hard drives are hooked up to the onboard SATA-II controller (NVIDIA nForce 590 SLI MCP chipset). Plus the motherboard has a pair of onboard gigabit ethernet NICs (Marvell 88E1116) and a Silicon Image Sil3132 SATA-II controller.  Other chips on the motherboard are the nVidia C51XE, nVidia MCP55PXE, AD1988B, and TSB43AB22A.
 
 In addition, I'll have even more hard drives hooked up to a  HighPoint RocketRAID 2300 PCIe card.  There's also a 3Com 3C905B PCI ethernet card installed along with a pair of Intel PRO/1000 PCIe gigabit NICs.
 
@@ -203,10 +203,4 @@ livecd / # umount /mnt/gentoo/home /mnt/gentoo/var/tmp /mnt/gentoo/tmp
 livecd / # umount /mnt/gentoo/boot /mnt/gentoo/dev /mnt/gentoo/proc /mnt/gentoo
 livecd / # reboot</code>
 
-Remove the LiveCD and cross your fingers.  Success!<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[00:04](http://www.tgharold.com/techblog/2006/08/gentoo-amd64-on-asus-m2n32-sli-deluxe_26.shtml)
-
-		</div>
+Remove the LiveCD and cross your fingers.  Success!

--- a/_posts/2006/2006-08-26-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-5.md
+++ b/_posts/2006/2006-08-26-gentoo-amd64-on-asus-m2n32-sli-deluxe-part-5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Now there were a few minor things that I had to fix after the reboot before I could SSH back in.  I hadn't pointed my swap line in /etc/fstab at the proper mdadm RAID volume, the 3c509 moved from eth7 to eth4 after the reboot, I had to use the "noapic" kernel option and I'm still getting the IRQ7 warning.
+Now there were a few minor things that I had to fix after the reboot before I could SSH back in.  I hadn't pointed my swap line in /etc/fstab at the proper mdadm RAID volume, the 3c509 moved from eth7 to eth4 after the reboot, I had to use the "noapic" kernel option and I'm still getting the IRQ7 warning.
 
 But the system is mostly in a workable state at this point.  So it's time to start installing administration packages and cleaning up the install.  I'll save the existing kernel as my "base" configuration in case I screw things up.
 
@@ -77,10 +77,4 @@ Now I'm going to [configure SubVersion](/techblog/2006/06/subversion-for-linux-a
 /usr/local/sbin (local sysadmin scripts that you create)
 /usr/src (the .config file, make sure you add the actual directory with "svn add -N" before adding the "linux" symbolic link)
 
-I know there are other folders to add, but I typically add them on the fly as I start customizing the system.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[06:45](http://www.tgharold.com/techblog/2006/08/gentoo-amd64-on-asus-m2n32_115658999475830052.shtml)
-
-		</div>
+I know there are other folders to add, but I typically add them on the fly as I start customizing the system.

--- a/_posts/2006/2006-08-27-irq-7-nobody-cared-try-booting-with-the-irqpoll-option.md
+++ b/_posts/2006/2006-08-27-irq-7-nobody-cared-try-booting-with-the-irqpoll-option.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Not sure what I'm going to do about this error on the AMD64 Asus M2N32-SLI Deluxe motherboard.
+Not sure what I'm going to do about this error on the AMD64 Asus M2N32-SLI Deluxe motherboard.
 
 <code>Aug 27 20:16:42 san1-azure irq 7: nobody cared (try booting with the "irqpoll" option)
 Aug 27 20:16:42 san1-azure 
@@ -23,10 +23,4 @@ Aug 27 20:16:42 san1-azure handlers:
 Aug 27 20:16:42 san1-azure [<ffffffff8045e684>] (usb_hcd_irq+0x0/0x54)
 Aug 27 20:16:42 san1-azure Disabling IRQ #7</ffffffff8045e684></ffffffff80216a38></ffffffff80207e40></ffffffff80207c72></eoi></ffffffff80209b94></ffffffff80207c47></ffffffff8020ba20></ffffffff8024e078></ffffffff8024e7b9></ffffffff8024e594></irq></code>
 
-Putting "irqpoll" on the end of the kernel line in grub.conf causes the system to panic during boot (has to do with the 2nd core in the X2 chip).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:23](http://www.tgharold.com/techblog/2006/08/irq-7-nobody-cared-try-booting-with.shtml)
-
-		</div>
+Putting "irqpoll" on the end of the kernel line in grub.conf causes the system to panic during boot (has to do with the 2nd core in the X2 chip).

--- a/_posts/2006/2006-08-29-creating-a-4-disk-raid10-using-mdadm.md
+++ b/_posts/2006/2006-08-29-creating-a-4-disk-raid10-using-mdadm.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Since I can't seem to find instructions on how to do this (yet)...
+Since I can't seem to find instructions on how to do this (yet)...
 
 I'm going to create a 4-disk RAID10 array using Linux Software RAID and mdadm.  The old way is to create individual RAID1 volumes and then stripe a RAID0 volume over the RAID1 arrays.  That requires creating extra /dev/mdN nodes which can be confusing to the admin that follows you.
 
@@ -43,10 +43,4 @@ A final note.  My mdadm.conf file is completely empty on this system.  That work
 
 <b>Updates:</b>
 
-Most of the arrays that I've built have been based on 7200 RPM SATA drives.  For small arrays (4 disks w/ a hot spare), often you can find enough ports on the motherboard.  For larger arrays, you'll need to look for PCIe SATA controllers.  I've used Promise and 3ware SATA RAID cards.  Basically any card that allows the SATA drives to be seen and is supported directly in the Linux kernel are good bets (going forward we're going to switch to Areca at work).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:25](http://www.tgharold.com/techblog/2006/08/creating-4-disk-raid10-using-mdadm.shtml)
-
-		</div>
+Most of the arrays that I've built have been based on 7200 RPM SATA drives.  For small arrays (4 disks w/ a hot spare), often you can find enough ports on the motherboard.  For larger arrays, you'll need to look for PCIe SATA controllers.  I've used Promise and 3ware SATA RAID cards.  Basically any card that allows the SATA drives to be seen and is supported directly in the Linux kernel are good bets (going forward we're going to switch to Areca at work).

--- a/_posts/2006/2006-09-30-gentoo-amd64-install-in-xen-domu.md
+++ b/_posts/2006/2006-09-30-gentoo-amd64-install-in-xen-domu.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>(I'm assuming that you've already created a working Xen Dom0 domain and that you already have a Xen DomU kernel with which you can boot the Gentoo guest OS.  I'm skipping a lot of steps and doing what I think works based on previous Gentoo installs.)
+(I'm assuming that you've already created a working Xen Dom0 domain and that you already have a Xen DomU kernel with which you can boot the Gentoo guest OS.  I'm skipping a lot of steps and doing what I think works based on previous Gentoo installs.)
 
 Disk preparation: I'm installing the Gentoo guest OSs into LVM volumes managed by the Dom0 hypervisor domain.  Each guest OS gets a single partition for root that is exported to the guest OS as /dev/sda1.  In rare cases, I'm also providing a 2nd and 3rd LVM partition for the guest OS which are exported as /dev/sda2 and /dev/sda3.
 
@@ -125,10 +125,4 @@ I strongly suggest running GNU "screen" in the Dom0 hypervisor domain.  That wil
 
 <code># xm create -c mydomainconfigfile</code>
 
-You can then shutdown (and exit) the domain by logging in as root and typing "shutdown -h now".  Once the guest domain seems to be working, fire it up without the "-c" option to get it running in the background.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Gentoo.shtml">Gentoo</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:11](http://www.tgharold.com/techblog/2006/09/gentoo-amd64-install-in-xen-domu.shtml)
-
-		</div>
+You can then shutdown (and exit) the domain by logging in as root and typing "shutdown -h now".  Once the guest domain seems to be working, fire it up without the "-c" option to get it running in the background.

--- a/_posts/2006/2006-10-03-short-list-of-ntfsclone-commands.md
+++ b/_posts/2006/2006-10-03-short-list-of-ntfsclone-commands.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This assumes that you have a hidden Linux partition (ext2/ext3) on the hard drive and that you're creating an image on that hidden drive.  Most of the time that means you're writing to either /dev/hda2 or /dev/sda2, but you should double-check that.
+This assumes that you have a hidden Linux partition (ext2/ext3) on the hard drive and that you're creating an image on that hidden drive.  Most of the time that means you're writing to either /dev/hda2 or /dev/sda2, but you should double-check that.
 
 List the partitions on the known hard drives:
 <code># fdisk -l</code>
@@ -32,10 +32,4 @@ Notes:
 
 - You'll probably want to use the underscore ("_") on the end of the image filename so that split adds the 2-letter suffix (aa, ab, ac, etc) in a way that is not confusing.
 
-- Note, the split size of 500MB is used in order to avoid the 2GB limit when writing to SMB network shares.  Plus it lets you spread the files across multiple disks if needed.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NTFSClone.shtml">NTFSClone</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:08](http://www.tgharold.com/techblog/2006/10/short-list-of-ntfsclone-commands.shtml)
-
-		</div>
+- Note, the split size of 500MB is used in order to avoid the 2GB limit when writing to SMB network shares.  Plus it lets you spread the files across multiple disks if needed.

--- a/_posts/2006/2006-10-27-putty-and-subversion-on-windows-2003.md
+++ b/_posts/2006/2006-10-27-putty-and-subversion-on-windows-2003.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One thing we use SubVersion for in the office is for tracking configuration changes to our Linux servers.  Everything under /etc or any other file that we change by hand (or with configuration tools) gets put into SVN which tracks the changes.  It's possible to do the same thing under Windows (although not everything can be tracked).
+One thing we use SubVersion for in the office is for tracking configuration changes to our Linux servers.  Everything under /etc or any other file that we change by hand (or with configuration tools) gets put into SVN which tracks the changes.  It's possible to do the same thing under Windows (although not everything can be tracked).
 
 A) Install PuTTY on the Win2003 server
 
@@ -80,10 +80,4 @@ D:\ svn co svn+ssh://user@svn.example.com/var/svn/repos/D .
 
 C:\ svn add -N Data
 C:\ svn add -N Data\Logs
-C:\ svn ci -m "log folder"<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PuTTY.shtml">PuTTY</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Win2003.shtml">Win2003</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:04](http://www.tgharold.com/techblog/2006/10/putty-and-subversion-on-windows-2003.shtml)
-
-		</div>
+C:\ svn ci -m "log folder"

--- a/_posts/2006/2006-11-11-motorola-q---initial-thoughts.md
+++ b/_posts/2006/2006-11-11-motorola-q---initial-thoughts.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I picked up a Motorola Q cell phone today.  
+I picked up a Motorola Q cell phone today.  
 
 [](/Imgs/2000s/MotorolaQ-C20061112-2466.jpg)
 
@@ -50,10 +50,4 @@ Some initial thoughts on the MotoQ:
 
 - NO synchronization of MS Outlook's notes out of the box.  A major and glaring oversight by Microsoft's Windows Mobile O/S for SmartPhones.
 
-- I miss my stylus!  Not having a touchscreen is going to take some getting used to.  I was extremely good at entering notes using Palm's modified alphabet and being able to draw on the screen was useful.  Plus, the PalmOS application designers had a lot more leeway to design useful interfaces where you could tap on the screen with a fingernail.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/MotorolaQ.shtml">MotorolaQ</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:22](http://www.tgharold.com/techblog/2006/11/motorola-q-initial-thoughts.shtml)
-
-		</div>
+- I miss my stylus!  Not having a touchscreen is going to take some getting used to.  I was extremely good at entering notes using Palm's modified alphabet and being able to draw on the screen was useful.  Plus, the PalmOS application designers had a lot more leeway to design useful interfaces where you could tap on the screen with a fingernail.

--- a/_posts/2006/2006-11-12-motoq---more-thoughts.md
+++ b/_posts/2006/2006-11-12-motoq---more-thoughts.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So after playing with the Motorola Q for a few more hours, I have the following thoughts:
+So after playing with the Motorola Q for a few more hours, I have the following thoughts:
 
 - No pocket quicken for the Smartphone yet (only PPC version of WM5).  So there are 2 versions of WM5... One for PPC one for SmartPhone.  Maybe Landware will get around to porting it one of these days.
 
@@ -36,10 +36,4 @@ This is something that I didn't know when I bought the phone (that there are 2 v
 
 - EVDO looks promising.  I installed a free map program that pulls over EVDO and works a lot like Google Maps.
 
-- Software availability for the SmartPhone version of WM5 is slim.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/MotorolaQ.shtml">MotorolaQ</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[12:32](http://www.tgharold.com/techblog/2006/11/motoq-more-thoughts.shtml)
-
-		</div>
+- Software availability for the SmartPhone version of WM5 is slim.

--- a/_posts/2006/2006-11-13-motoq---home-screens.md
+++ b/_posts/2006/2006-11-13-motoq---home-screens.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One nice part about the MotoQ (well, the SmartPhone OS) is that you can customize the "home" screen to match your tastes / needs.  There are even programs (like "Facade") that will let you pull task / calendar information onto the front screen for a better view of "what needs done right now".
+One nice part about the MotoQ (well, the SmartPhone OS) is that you can customize the "home" screen to match your tastes / needs.  There are even programs (like "Facade") that will let you pull task / calendar information onto the front screen for a better view of "what needs done right now".
 
 The best site that I've seen so far is [www.kooldezine.com](http://www.kooldezine.com/Q.htm).  The artist has done a huge selection of screens that work with or without requiring some popular add-ons.
 
@@ -26,10 +26,4 @@ These two show how the "Facade" software can bring task entries onto the home sc
 
 And the default Verizon Wireless home screen:
 
-[](/Imgs/2000s/MotorolaQ-C20061112-2507-Home-Screen-Verizon-Wireless.jpg)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/MotorolaQ.shtml">MotorolaQ</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:24](http://www.tgharold.com/techblog/2006/11/motoq-home-screens.shtml)
-
-		</div>
+[](/Imgs/2000s/MotorolaQ-C20061112-2507-Home-Screen-Verizon-Wireless.jpg)

--- a/_posts/2006/2006-11-14-motorola-q---virtual-earth-mobile.md
+++ b/_posts/2006/2006-11-14-motorola-q---virtual-earth-mobile.md
@@ -10,14 +10,8 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Finally, a pair of screens from the Virtual Earth Mobile software.  One of the handier pieces of software to have on the Q which takes advantage of the always-on EVDO data connection.
+Finally, a pair of screens from the Virtual Earth Mobile software.  One of the handier pieces of software to have on the Q which takes advantage of the always-on EVDO data connection.
 
 [](/Imgs/2000s/MotorolaQ-C20061112-2542-Virtual-Earth-Mobile-Road-View.jpg)
 
-[](/Imgs/2000s/MotorolaQ-C20061112-2532-Virtual-Earth-Mobile-Aerial+Road.jpg)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/MotorolaQ.shtml">MotorolaQ</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[00:51](http://www.tgharold.com/techblog/2006/11/motorola-q-virtual-earth-mobile.shtml)
-
-		</div>
+[](/Imgs/2000s/MotorolaQ-C20061112-2532-Virtual-Earth-Mobile-Aerial+Road.jpg)

--- a/_posts/2006/2006-12-13-ssh-authorized_keys-creating-pub-keys-using-securecrt.md
+++ b/_posts/2006/2006-12-13-ssh-authorized_keys-creating-pub-keys-using-securecrt.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>For optimal security, it's better to require public keys for logging into a server rather then allowing password authentication.  As long as the user's keep their SSH private key files safe (along with protecting them with a decent passphrase), you're less likely to encounter a break-in of your Unix/Linux servers.
+For optimal security, it's better to require public keys for logging into a server rather then allowing password authentication.  As long as the user's keep their SSH private key files safe (along with protecting them with a decent passphrase), you're less likely to encounter a break-in of your Unix/Linux servers.
 
 The process is similar for PuTTY, but SecureCRT offers a much cleaner interface then PuTTY.  Because of the way things work in SSH2-land, you typically create the SSH2 keys using the client software in Windows, then copy the public key up to your user directory on the server that it will be used for.  (Or you have an admin install the public key for you.)
 
@@ -56,10 +56,4 @@ eecdUWuxInAnMPmEn4f49sUAejO/0E7P8XKx1Mqx2CUYNOyoQ1EsX5lZXg6Hbx2Gc4BW
 1uPFJw13j/9jAfQlRYzAqK80uS/cUwTaH9o=
 ---- END SSH2 PUBLIC KEY ----
 
-9) Make a backup of your private key and public key files.  One option would be to burn them to CD-R (multiple copies on the disk), write the passphrase on the CD-R, then put it all into a sealed envelope in a secure offsite location (safe-deposit box).  Alternately, you may wish to simply print it out on paper and OCR it back if you lose the key files.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2006.shtml">2006</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SecureCRT.shtml">SecureCRT</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[19:15](http://www.tgharold.com/techblog/2006/11/ssh-authorizedkeys-creating-pub-keys.shtml)
-
-		</div>
+9) Make a backup of your private key and public key files.  One option would be to burn them to CD-R (multiple copies on the disk), write the passphrase on the CD-R, then put it all into a sealed envelope in a secure offsite location (safe-deposit box).  Alternately, you may wish to simply print it out on paper and OCR it back if you lose the key files.

--- a/_posts/2007/2007-01-05-forcing-users-to-use-public-ssh-keys-to-authenticate.md
+++ b/_posts/2007/2007-01-05-forcing-users-to-use-public-ssh-keys-to-authenticate.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Here are the steps I use when I create a new user account on a secure SSH server (where only public keys are allowed).
+Here are the steps I use when I create a new user account on a secure SSH server (where only public keys are allowed).
 
 # useradd -m username
 # passwd username
@@ -25,10 +25,4 @@ $ cat &gt; username@linux.pub
 $ ssh-keygen -i -f username@linux.pub &gt;&gt; authorized_keys
 $ chmod 600 *
 
-At this point, the user should be able to login via SecureCRT using their private/public key pair.  There's no need for them to know the password that you assigned to them on the server (so use something random and at least 30+ characters).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SecureCRT.shtml">SecureCRT</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[06:32](http://www.tgharold.com/techblog/2007/01/forcing-users-to-use-public-ssh-keys-to.shtml)
-
-		</div>
+At this point, the user should be able to login via SecureCRT using their private/public key pair.  There's no need for them to know the password that you assigned to them on the server (so use something random and at least 30+ characters).

--- a/_posts/2007/2007-02-20-ext3-tuning.md
+++ b/_posts/2007/2007-02-20-ext3-tuning.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>The ext3 system is a great workhorse filesystem.  Lots of tools, lots of distros that know how to read it, and it's pretty much the "safe" choice for almost all workloads.  Still, there are things that the default ext3 doesn't do as well as it should so most installations need a little TLC.
+The ext3 system is a great workhorse filesystem.  Lots of tools, lots of distros that know how to read it, and it's pretty much the "safe" choice for almost all workloads.  Still, there are things that the default ext3 doesn't do as well as it should so most installations need a little TLC.
 
 For the most part, you should plan on shutting down a system before tuning it (after making backups!).  Tuning doesn't take too long and is a lot simpler to do if the system is offline.  
 
@@ -63,10 +63,4 @@ Source links:
 [Tuning ext3 for large disk arrays (LKML, Peter Chubb, 2005)](http://lkml.org/lkml/2005/6/14/208)
 [Some ext3 Filesystem Tips (Gentoo Forums, Peter Gordon, 2005)](http://forums.gentoo.org/viewtopic-t-305871.html)
 [Performance Tuning Guidelines for Large Deployments (Zimbra, 2007)](http://wiki.zimbra.com/index.php?title=Performance_Tuning_Guidelines_for_Large_Deployments)
-[Linux Magazine: Tuning Journaling File Systems (2007, registration required)](http://www.linux-mag.com/id/2927/)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/ext3.shtml">ext3</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[00:26](http://www.tgharold.com/techblog/2007/05/ext3-tuning.shtml)
-
-		</div>
+[Linux Magazine: Tuning Journaling File Systems (2007, registration required)](http://www.linux-mag.com/id/2927/)

--- a/_posts/2007/2007-03-06-my-new-preferred-disk-layout-for-servers.md
+++ b/_posts/2007/2007-03-06-my-new-preferred-disk-layout-for-servers.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>With age comes wisdom?  After working with SoftwareRAID and Linux servers for a while, I've changed my preferred disk system design and layout.
+With age comes wisdom?  After working with SoftwareRAID and Linux servers for a while, I've changed my preferred disk system design and layout.
 
 <b>RAID</b>
 
@@ -42,10 +42,4 @@ The other physical partition that I consider necessary is /backup/system.  This 
 
 <b>Summary</b>
 
-This setup tries to walk the fine line between keeping it simple, but having enough flexibility to deal with a large set of potential failures.  Anything from a two-disk failure, to the primary OS being hosed, to both OS partitions having problems all the way up to boot records or the /boot partition being killed.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/DisasterRecovery.shtml">DisasterRecovery</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Linux.shtml">Linux</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:26](http://www.tgharold.com/techblog/2007/03/my-new-preferred-disk-layout-for.shtml)
-
-		</div>
+This setup tries to walk the fine line between keeping it simple, but having enough flexibility to deal with a large set of potential failures.  Anything from a two-disk failure, to the primary OS being hosed, to both OS partitions having problems all the way up to boot records or the /boot partition being killed.

--- a/_posts/2007/2007-04-28-starter-kit-for-an-iscsi-san.md
+++ b/_posts/2007/2007-04-28-starter-kit-for-an-iscsi-san.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Now that it's spring, it's time for us to start building out our preliminary iSCSI SAN unit.  Here's the hardware shopping list:
+Now that it's spring, it's time for us to start building out our preliminary iSCSI SAN unit.  Here's the hardware shopping list:
 
 $0600 Super Micro 4U/TOWER RM EATX BLACK ( CSE-942I-R760B )
 - triple-module redundant PSU w/ 760W
@@ -78,10 +78,4 @@ With an overall cost of around $5500 for the entire unit, the price per gigabyte
 $2.36/GB for (1) RAID10 array
 $1.97/GB for (2) RAID6 arrays
 
-Which is not terribly bad for a starter unit.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/iSCSI.shtml">iSCSI</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SAN.shtml">SAN</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[16:51](http://www.tgharold.com/techblog/2007/04/starter-kit-for-iscsi-san.shtml)
-
-		</div>
+Which is not terribly bad for a starter unit.

--- a/_posts/2007/2007-05-07-brute-force-disaster-recovery-for-centos5.md
+++ b/_posts/2007/2007-05-07-brute-force-disaster-recovery-for-centos5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Today's trick is moving a CentOS5 system from an old set of disks over to a new set of disks.  Along the way, I'll create an image of the system to allow me to restore it later on.
+Today's trick is moving a CentOS5 system from an old set of disks over to a new set of disks.  Along the way, I'll create an image of the system to allow me to restore it later on.
 
 The CentOS5 system is a fresh install running RAID-1 across (3) disks using Linux Software RAID (mdadm).  There are (4) primary partitions (boot, root, swap, LVM) with no data on the LVM partition.
 
@@ -185,10 +185,4 @@ Getting the Software RAID back up and happy is the trickiest of the steps.
 </li>
 </ol>
 
-Note: If your triple mirror RAID array puts the additional disks in as spares, make sure that you have (a) grown the number of raid devices to 3 for the RAID1 set and (b) make sure that there are no other arrays synchronizing as the same time.  It's also best to add the elements one at a time, rather then adding both at the same time.  I'm not sure if it's a bug in mdadm or just the way it works, but it took me two tries to get my triple mirror back up with all disks marked as "active" instead of (2) active and (1) hot-spare.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Backups.shtml">Backups</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/DisasterRecovery.shtml">DisasterRecovery</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:52](http://www.tgharold.com/techblog/2007/05/brute-force-disaster-recovery-for.shtml)
-
-		</div>
+Note: If your triple mirror RAID array puts the additional disks in as spares, make sure that you have (a) grown the number of raid devices to 3 for the RAID1 set and (b) make sure that there are no other arrays synchronizing as the same time.  It's also best to add the elements one at a time, rather then adding both at the same time.  I'm not sure if it's a bug in mdadm or just the way it works, but it took me two tries to get my triple mirror back up with all disks marked as "active" instead of (2) active and (1) hot-spare.

--- a/_posts/2007/2007-05-10-dealing-with-a-failed-software-raid-device.md
+++ b/_posts/2007/2007-05-10-dealing-with-a-failed-software-raid-device.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>As part of my server setup, I like to make sure that plans are working as expected...  which means intentionally breaking things like RAID sets.
+As part of my server setup, I like to make sure that plans are working as expected...  which means intentionally breaking things like RAID sets.
 
 In this particular case I have a triple-active RAID1 mirror set on the first 3 disks in the system (/dev/sda, /dev/sdb, /dev/sdc).  In this RAID1 set, all 3 disks are active, with no hot-spare.  I prefer this over a (2) active (1) hot-spare setup because it allows for up to 2 disks to fail before you lose data.  And if I'm already dedicating a hot-spare spindle solely for the use of the RAID1 set, I may as well get to use it.  The output of /proc/mdstat looks similar to (note that none of the slices are tagged with a "(S)").:
 
@@ -37,10 +37,4 @@ After which, you can use the "mdadm" command to add the new slices to the existi
 
 # mdadm --add /dev/mdX /dev/sdYZ 
 
-Last, don't forget to install GRUB to the MBR on the new disk.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:03](http://www.tgharold.com/techblog/2007/05/dealing-with-failed-software-raid.shtml)
-
-		</div>
+Last, don't forget to install GRUB to the MBR on the new disk.

--- a/_posts/2007/2007-05-25-iscsitarget-on-centos5.md
+++ b/_posts/2007/2007-05-25-iscsitarget-on-centos5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Setting up our test iSCSI SAN box this week.  The original plans were to run this on top of Gentoo (which is very powerful and flexible) but after 3 years, I'm not very pleased with Gentoo as a server OS.  Which is a whole different topic.  So we've migrated over to using CentOS5, which is derived from Red Hat Enterprise Linux 5, a distro that is more suited for corporate use.
+Setting up our test iSCSI SAN box this week.  The original plans were to run this on top of Gentoo (which is very powerful and flexible) but after 3 years, I'm not very pleased with Gentoo as a server OS.  Which is a whole different topic.  So we've migrated over to using CentOS5, which is derived from Red Hat Enterprise Linux 5, a distro that is more suited for corporate use.
 
 There's not much to talk about in terms of the base system.  It's a pretty vanilla 64bit CentOS5 install (from DVD) running on top of a dual-CPU dual-core pair of Socket F Opterons.  The primary packages that I've installed so far are "Yum Extender" (from stock repositories) and "rdiff-backup" (downloaded as an RPM).  The OS runs on top of a 3-disk RAID1 (mirror, all drives active) Software RAID for safety.
 

--- a/_posts/2007/2007-05-27-squid-selinux-and-using-a-separate-volume-for-the-cache_dir.md
+++ b/_posts/2007/2007-05-27-squid-selinux-and-using-a-separate-volume-for-the-cache_dir.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This was a slightly tricky one.  I'm running CentOS5 with SELinux and I was trying to setup Squid to put its cache_dir on a LVM volume (to keep it from using up space on the root partition).
+This was a slightly tricky one.  I'm running CentOS5 with SELinux and I was trying to setup Squid to put its cache_dir on a LVM volume (to keep it from using up space on the root partition).
 
 # /etc/init.d/squid stop
 # cd /var/spool
@@ -81,10 +81,4 @@ So, the problem is that SELinux had not yet been told to look at the newly creat
 # cd /var/spool/squid
 # /usr/sbin/squid -z
 # /sbin/restorecon -R *
-# /etc/init.d/squid start<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Squid.shtml">Squid</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[22:49](http://www.tgharold.com/techblog/2007/05/squid-selinux-and-using-separate-volume.shtml)
-
-		</div>
+# /etc/init.d/squid start

--- a/_posts/2007/2007-05-29-remote-install-of-centos5-using-vnc.md
+++ b/_posts/2007/2007-05-29-remote-install-of-centos5-using-vnc.md
@@ -10,16 +10,10 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I haven't tried this yet, but there are times when it could come in handy.
+I haven't tried this yet, but there are times when it could come in handy.
 
 [Centos 5 vnc remote installation](http://www.centos.org/modules/newbb/viewtopic.php?topic_id=8394&amp;forum=37)
 
 [Post details: Upgrading to CentOS4, over a remote vnc connection](http://www.karan.org/blog/index.php/2005/06/15/p35)
 
-I figured it was possible, I just hadn't looked.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VNC.shtml">VNC</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:08](http://www.tgharold.com/techblog/2007/05/remote-install-of-centos5-using-vnc.shtml)
-
-		</div>
+I figured it was possible, I just hadn't looked.

--- a/_posts/2007/2007-05-29-svk-for-system-management.md
+++ b/_posts/2007/2007-05-29-svk-for-system-management.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I'm a big fan of using a version control system in conjunction with system administration.  There's a great feeling to know that even if I screw up a configuration file, I have an easily accessible way to revert or track changes.  To accomplish this, I was using [SubVersion (SVN) as an administration tool](http://www.tgharold.com/techblog/2006/06/subversion-for-linux-administrators.shtml).
+I'm a big fan of using a version control system in conjunction with system administration.  There's a great feeling to know that even if I screw up a configuration file, I have an easily accessible way to revert or track changes.  To accomplish this, I was using [SubVersion (SVN) as an administration tool](http://www.tgharold.com/techblog/2006/06/subversion-for-linux-administrators.shtml).
 
 However, SVN comes with some downsides, primarily the issue that it creates ".svn" folders in the directory tree.  Which can cause issues and maybe even lead to security holes (yes/no? unsure about this).
 
@@ -39,10 +39,4 @@ You'll be presented with about a dozen questions, and you'll need to install all
 
 ...
 
-Well, after mucking with this for a few hours and getting self-test errors, I'm going to shelve this for now and go look at FSVS insteadk.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SVK.shtml">SVK</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:37](http://www.tgharold.com/techblog/2007/05/svk-for-system-management.shtml)
-
-		</div>
+Well, after mucking with this for a few hours and getting self-test errors, I'm going to shelve this for now and go look at FSVS insteadk.

--- a/_posts/2007/2007-05-31-fsvs-for-sysadmins.md
+++ b/_posts/2007/2007-05-31-fsvs-for-sysadmins.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Notes:</b> This entry was based on v1.1.4.  The 1.1.5 and later versions of FSVS also place a few files in /etc/fsvs.  
 
 <b>Original post follows</b>
@@ -259,10 +259,4 @@ committed revision      7 on 2007-06-04T00:17:13.808327Z as sys-fw1-pri</code>
 
 That just scratches the surface, but covers the majority of day-to-day use.  Unlike SVN, FSVS knows (assumes) that when a file is missing that it should implicity do a "delete" operation in the repository to make the repository match the file system.
 
-Other useful commands to know are "fsvs unversion" and "fsvs diff".<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FSVS.shtml">FSVS</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SystemAdministration.shtml">SystemAdministration</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:09](http://www.tgharold.com/techblog/2007/05/fsvs-for-sysadmins.shtml)
-
-		</div>
+Other useful commands to know are "fsvs unversion" and "fsvs diff".

--- a/_posts/2007/2007-06-20-remote-gui-administration-of-centos5-using-windows.md
+++ b/_posts/2007/2007-06-20-remote-gui-administration-of-centos5-using-windows.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Over the years, I've become very spoiled by Windows Terminal Services that we use to administer our Windows 2000 and Windows 2003 servers.  It's fast, it's slick, it allows copy-paste and with a bit of command line fu you can connect to the physical display (instead of one of the two virtual sessions).  It also uses built-in Windows authentication and offers encryption.
+Over the years, I've become very spoiled by Windows Terminal Services that we use to administer our Windows 2000 and Windows 2003 servers.  It's fast, it's slick, it allows copy-paste and with a bit of command line fu you can connect to the physical display (instead of one of the two virtual sessions).  It also uses built-in Windows authentication and offers encryption.
 
 So, now that I'm rolling out CentOS 5 servers - I need something similar that allows me to look at the graphical UI on the box from elsewhere.  From what I can tell, my options are:
 
@@ -139,10 +139,4 @@ If all goes well, you should see the Gnome desktop!
 
 <b>Final thoughts (for the moment)</b>
 
-Now, it's still not as slick as Terminal Services.  But it seems to work just fine and gives me a GUI desktop.  I still plan on doing most of my administration from the command line, but this provides a nice GUI for those who follow in my footsteps.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/X11.shtml">X11</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:55](http://www.tgharold.com/techblog/2007/06/remote-gui-administration-of-centos5.shtml)
-
-		</div>
+Now, it's still not as slick as Terminal Services.  But it seems to work just fine and gives me a GUI desktop.  I still plan on doing most of my administration from the command line, but this provides a nice GUI for those who follow in my footsteps.

--- a/_posts/2007/2007-06-20-ultravnc-server-install-on-windows-xp.md
+++ b/_posts/2007/2007-06-20-ultravnc-server-install-on-windows-xp.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Installing UltraVNC (see also "[UltraVNC Installation](http://www.uvnc.com/install/installation.html)")
+Installing UltraVNC (see also "[UltraVNC Installation](http://www.uvnc.com/install/installation.html)")
 <ol>
 
 <li>Download [UltraVNC](http://www.uvnc.com/) for MS Windows
@@ -93,10 +93,3 @@ AES Encryption plugin (a.k.a. DSM)
 
 </li>
 </ol>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/ServerAdministration.shtml">ServerAdministration</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/UltraVNC.shtml">UltraVNC</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VNC.shtml">VNC</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:02](http://www.tgharold.com/techblog/2007/06/ultravnc-server-install-on-windows-xp.shtml)
-
-		</div>

--- a/_posts/2007/2007-06-20-vnc-resource-links.md
+++ b/_posts/2007/2007-06-20-vnc-resource-links.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Various links about VNC
+Various links about VNC
 
 [Virtual Network Computing (VNC)](http://en.wikipedia.org/wiki/VNC) - Wikipedia entry about VNC.
 
@@ -24,10 +24,4 @@ tags:
 
 [Geek to Live: Secure VNC with Hamachi](http://lifehacker.com/software/vnc/geek-to-live--secure-vnc-with-hamachi-228862.php)
 
-[Secure VNC with two-factor authentication](http://rootprompt.org/article.php3?article=10969)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/ServerAdministration.shtml">ServerAdministration</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VNC.shtml">VNC</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:47](http://www.tgharold.com/techblog/2007/06/vnc-resource-links.shtml)
-
-		</div>
+[Secure VNC with two-factor authentication](http://rootprompt.org/article.php3?article=10969)

--- a/_posts/2007/2007-06-21-identifying-bandwidth-abusers-in-linux.md
+++ b/_posts/2007/2007-06-21-identifying-bandwidth-abusers-in-linux.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b># /sbin/ip link</b>
 
 This Linux command will display information about your interfaces.  When doing network analysis, the primary information that we're interested in is whether the interface is running in promiscuous mode.  An adapter that is running in promiscuous mode can capture any packets that pass by on the wire, not just the ones destined for its MAC address.  Here's an example of a ethernet adapter that is in promiscuous mode:
@@ -30,10 +30,4 @@ The nload utility is a console application that will graph the inbound and outbo
 
 <b>/usr/sbin/nettop -d 5 -i eth0</b>
 
-This is another console utility that you can add to a Linux firewall.  Nettop displays a tree-like listing of all activity on a particular interface, with the packets grouped by protocol and then port/service.  This gives you a quick idea of what services are abusing your bandwidth.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Firewalls.shtml">Firewalls</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:45](http://www.tgharold.com/techblog/2007/06/identifying-bandwidth-abusers-in-linux.shtml)
-
-		</div>
+This is another console utility that you can add to a Linux firewall.  Nettop displays a tree-like listing of all activity on a particular interface, with the packets grouped by protocol and then port/service.  This gives you a quick idea of what services are abusing your bandwidth.

--- a/_posts/2007/2007-06-22-fsvs-ignore-patterns-v115.md
+++ b/_posts/2007/2007-06-22-fsvs-ignore-patterns-v115.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Here's a list of the current ignore patterns that I use on my CentOS5 box.
+Here's a list of the current ignore patterns that I use on my CentOS5 box.
 
 # fsvs ignore dump
 ./backup
@@ -101,10 +101,4 @@ After mucking with a new box for a week, here's the set of ignore filters that I
 ./var/svn/
 ./var/tmp/
 ./var/www/
-[root@fw1-shimo /]#<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FSVS.shtml">FSVS</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:47](http://www.tgharold.com/techblog/2007/06/fsvs-ignore-patterns-v115.shtml)
-
-		</div>
+[root@fw1-shimo /]#

--- a/_posts/2007/2007-07-01-centos5-moving-varlog-to-a-separate-volume.md
+++ b/_posts/2007/2007-07-01-centos5-moving-varlog-to-a-separate-volume.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One thing I like to do is put /var/log on its own volume.  That keeps the root volume from overflowing and also gets the log files out of the way.  However, in CentOS5 (and probably RHEL5), SELinux is probably going to complain unless we tell it to "fixup" the new filesystem.
+One thing I like to do is put /var/log on its own volume.  That keeps the root volume from overflowing and also gets the log files out of the way.  However, in CentOS5 (and probably RHEL5), SELinux is probably going to complain unless we tell it to "fixup" the new filesystem.
 <ol>
 
 <li>Create the filesystem (I use ext3, so # /sbin/mke2fs -j /dev/mdX)
@@ -33,10 +33,4 @@ tags:
 </li>
 </ol>
 
-AFAIK, that's the extent of what's needed.  Looking at the directory listings using "ls -lZ" seems to show the correct SELinux flags on the files between the two different directories.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/ServerAdministration.shtml">ServerAdministration</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:21](http://www.tgharold.com/techblog/2007/07/centos5-moving-varlog-to-separate.shtml)
-
-		</div>
+AFAIK, that's the extent of what's needed.  Looking at the directory listings using "ls -lZ" seems to show the correct SELinux flags on the files between the two different directories.

--- a/_posts/2007/2007-07-02-lvm-and-selinux.md
+++ b/_posts/2007/2007-07-02-lvm-and-selinux.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I was a bit perplexed... I had created a LV called /dev/vg/svn, had it mounted, was reading/writing data to it with no issues.  But after I rebooted the CentOS5 server, I'm unable to mount the LV.
+I was a bit perplexed... I had created a LV called /dev/vg/svn, had it mounted, was reading/writing data to it with no issues.  But after I rebooted the CentOS5 server, I'm unable to mount the LV.
 
 <pre>[root@localhost /]# /usr/sbin/pvscan
 PV /dev/md6   VG vg   lvm2 [144.78 GB / 59.78 GB free]
@@ -47,10 +47,3 @@ Turns out that it's an SELinux issue.  Because SELinux was blocking access to th
 # /sbin/restorecon -v .cache
 # /usr/sbin/lvscan
 inactive          '/dev/vg/svn' [85.00 GB] inherit</pre>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/LVM.shtml">LVM</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:38](http://www.tgharold.com/techblog/2007/07/lvm-and-selinux.shtml)
-
-		</div>

--- a/_posts/2007/2007-07-04-setting-up-svnssh-on-an-alternate-point-for-tortoisesvn.md
+++ b/_posts/2007/2007-07-04-setting-up-svnssh-on-an-alternate-point-for-tortoisesvn.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This builds off a post to the TortoiseSVN user list: [Specifying custom port for svn+ssh: a workaround](http://svn.haxx.se/tsvnusers/archive-2007-01/0272.shtml)
+This builds off a post to the TortoiseSVN user list: [Specifying custom port for svn+ssh: a workaround](http://svn.haxx.se/tsvnusers/archive-2007-01/0272.shtml)
 <ol>
 
 <li>Right-click on the Pageant icon in the system tray (I'm assuming that you're loading the SSH public key that you use for SVN into Pageant).
@@ -33,10 +33,4 @@ Now you will be able to use both TortoiseSVN and the command-line version of SVN
 
 This is useful for cases where you want to put a SVN server on a publicly accessible IP address.  What you will find is that if you leave SSH running on the default port, you will be inviting attacks on your SSH server.  On the other hand, if you put the SSH server on an alternate port, you'll find that it gets attacked a lot less often (1-2 orders of magnitude difference would be likely).
 
-Since mid-Oct of last year (around 8.5 months), we've logged <b>90,300</b> attack attempts against our SSH server.  Usually they come in batches of attempting to guess accounts that normally exist or by attacking a list of common usernames.  Since we don't allow root login, we don't allow password authentication, we only allow public key authentication and our SSH keys are limited to running "svnserve -t", we have yet to see a break-in attempt succeed.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PuTTY.shtml">PuTTY</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:50](http://www.tgharold.com/techblog/2007/07/setting-up-svnssh-on-alternate-point.shtml)
-
-		</div>
+Since mid-Oct of last year (around 8.5 months), we've logged <b>90,300</b> attack attempts against our SSH server.  Usually they come in batches of attempting to guess accounts that normally exist or by attacking a list of common usernames.  Since we don't allow root login, we don't allow password authentication, we only allow public key authentication and our SSH keys are limited to running "svnserve -t", we have yet to see a break-in attempt succeed.

--- a/_posts/2007/2007-07-05-selinux-is-preventing-named-from-write-access.md
+++ b/_posts/2007/2007-07-05-selinux-is-preventing-named-from-write-access.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>It seems like the SELinux profile in CentOS5 may not be correct by default.  In my /var/log/messages file, I have thousands of entries per month consisting of:
+It seems like the SELinux profile in CentOS5 may not be correct by default.  In my /var/log/messages file, I have thousands of entries per month consisting of:
 
 Jul  4 05:01:04 fw1-hosho setroubleshoot:      SELinux is preventing /usr/sbin/named (named_t) "write" access to named (named_conf_t).      For complete SELinux messages. run sealert -l 663ea169-d194-4c49-a5bb-a6a4bb707990
 
@@ -71,10 +71,4 @@ pid=2628 scontext=system_u:system_r:named_t:s0 sgid=25
 subj=system_u:system_r:named_t:s0 suid=25 tclass=dir
 tcontext=root:object_r:named_conf_t:s0 tty=(none) uid=25</pre>
 
-The most helpful web page that I've found so far is the thread "[Permissions Issue starting Bind 9.3.1](http://www.webservertalk.com/message1323968.html)".  The gist seems to be that RedHat (and CentOS) are using a chroot bind installation in conjunction with an SELinux policy that expects the bind configuration files to be in a non-chroot setup.  But there aren't very clear instructions there on fixing it.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/BIND9.shtml">BIND9</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:55](http://www.tgharold.com/techblog/2007/07/selinux-is-preventing-named-from-write.shtml)
-
-		</div>
+The most helpful web page that I've found so far is the thread "[Permissions Issue starting Bind 9.3.1](http://www.webservertalk.com/message1323968.html)".  The gist seems to be that RedHat (and CentOS) are using a chroot bind installation in conjunction with an SELinux policy that expects the bind configuration files to be in a non-chroot setup.  But there aren't very clear instructions there on fixing it.

--- a/_posts/2007/2007-08-15-installing-angband-on-centos-5.md
+++ b/_posts/2007/2007-08-15-installing-angband-on-centos-5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Installation of Angband 3.0.9 on RedHat or CentOS5.
+Installation of Angband 3.0.9 on RedHat or CentOS5.
 
 1) Grab the latest source release from [http://rephial.org/release](http://rephial.org/release)
 
@@ -40,10 +40,4 @@ Which indicates that you need to install the ncurses library.  You can fix that 
 
 # ./configure --with-setgid=games --with-libpath=/usr/local/games/lib/angband                --bindir=/usr/local/games
 # make
-# make install<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Angband.shtml">Angband</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:35](http://www.tgharold.com/techblog/2007/08/installing-angband-on-centos-5.shtml)
-
-		</div>
+# make install

--- a/_posts/2007/2007-12-05-failed-drive-slice-in-a-software-raid-after-resync.md
+++ b/_posts/2007/2007-12-05-failed-drive-slice-in-a-software-raid-after-resync.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One of the things that I do periodically on my servers is to run a mdadm resync.  Because this can put a heavy strain on the disk system, I strongly suggest that you have good backups in place.  My home systems run a check about once a month, servers at work run a check early on Tuesday mornings.
+One of the things that I do periodically on my servers is to run a mdadm resync.  Because this can put a heavy strain on the disk system, I strongly suggest that you have good backups in place.  My home systems run a check about once a month, servers at work run a check early on Tuesday mornings.
 
 The script is very simple, and you can even fire off the command by writing "check" to the sync_action variable of the md process.
 
@@ -231,10 +231,4 @@ recommended polling time:        (   2) minutes.
 Extended self-test routine
 recommended polling time:        ( 130) minutes.</code>
 
-Personally, since I know the drive makes clicking noises and throws an error during the dd wipe, I'm going to swap it out.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:43](http://www.tgharold.com/techblog/2007/12/failed-drive-slice-in-software-raid.shtml)
-
-		</div>
+Personally, since I know the drive makes clicking noises and throws an error during the dd wipe, I'm going to swap it out.

--- a/_posts/2007/2007-12-21-replacing-a-failed-drive-in-a-software-raid-mirror-set.md
+++ b/_posts/2007/2007-12-21-replacing-a-failed-drive-in-a-software-raid-mirror-set.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Like I wrote about last time, I have a [failing drive in my triple active RAID mirror set on my firewall box](/techblog/2007/12/failed-drive-slice-in-software-raid.shtml).  See also "[Failing hard drive in a Software RAID](/techblog/2006/06/failing-hard-drive-in-software-raid.shtml)".  I'm still trying to decide whether the disk has actually failed, or if it is just having issues.
+Like I wrote about last time, I have a [failing drive in my triple active RAID mirror set on my firewall box](/techblog/2007/12/failed-drive-slice-in-software-raid.shtml).  See also "[Failing hard drive in a Software RAID](/techblog/2006/06/failing-hard-drive-in-software-raid.shtml)".  I'm still trying to decide whether the disk has actually failed, or if it is just having issues.
 
 <code># /sbin/badblocks -sv /dev/sdc2</code>
 
@@ -26,10 +26,4 @@ And force mdadm to verify the sync:
 
 <code># echo check &gt; /sys/block/md1/md/sync_action</code>
 
-It seems to be working.  I'm guessing that I finally convinced SMART to re-map the bad sector that was causing problems.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2007.shtml">2007</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:25](http://www.tgharold.com/techblog/2007/12/replacing-failed-drive-in-software-raid.shtml)
-
-		</div>
+It seems to be working.  I'm guessing that I finally convinced SMART to re-map the bad sector that was causing problems.

--- a/_posts/2008/2008-01-03-subversion-repository-creation-cheatsheet.md
+++ b/_posts/2008/2008-01-03-subversion-repository-creation-cheatsheet.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Whenever I setup new SVN repositories, I always create a unix group for people who need read/write access to the repository.  If the repository is named "tgh-public", then I choose to name the group as "svn-tgh-public".
+Whenever I setup new SVN repositories, I always create a unix group for people who need read/write access to the repository.  If the repository is named "tgh-public", then I choose to name the group as "svn-tgh-public".
 
 I also generally designate a single user as the initial owner of the SVN repository folder under /var/svn.  Alternately, you could just leave the repository owned by root.
 
@@ -39,10 +39,3 @@ Notes:
 
 </li>
 </ul>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:39](http://www.tgharold.com/techblog/2008/01/subversion-repository-creation.shtml)
-
-		</div>

--- a/_posts/2008/2008-03-10-postgresql-81-under-a-nondefault-directory-with-selinux.md
+++ b/_posts/2008/2008-03-10-postgresql-81-under-a-nondefault-directory-with-selinux.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So I like to keep my PostgreSQL install in a non-standard location.  Normally, this is as easy as setting PGDATA= in the /etc/sysconfig/pgsql/postgresql file.  But when SELinux is installed, you also have to deal with system context issues.
+So I like to keep my PostgreSQL install in a non-standard location.  Normally, this is as easy as setting PGDATA= in the /etc/sysconfig/pgsql/postgresql file.  But when SELinux is installed, you also have to deal with system context issues.
 
 One symptom of this is that /etc/init.d/postgresql start will fail, but starting the database interactively using the "su postgres" and pg_ctl commands will work.  This is because SELinux is a lot stricter with programs started in the startup scripts vs programs that are started from an interactive shell.
 
@@ -533,10 +533,4 @@ Notes:
 
 - If you ever re-tag the entire filesystem with SELinux, you will (probably) have to go back and re-tag your postgresql data directory.
 
-- Because of the above note, it may be better to mount the LVM or SAN partition for PostgreSQL at the default location of /var/lib/pgsql instead of forcing it into another location.  On the other hand, as long as you know how to fix it and don't re-tag indiscriminately, SELinux should never get in the way again.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PostgreSQL.shtml">PostgreSQL</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:42](http://www.tgharold.com/techblog/2008/03/postgresql-81-under-nondefault.shtml)
-
-		</div>
+- Because of the above note, it may be better to mount the LVM or SAN partition for PostgreSQL at the default location of /var/lib/pgsql instead of forcing it into another location.  On the other hand, as long as you know how to fix it and don't re-tag indiscriminately, SELinux should never get in the way again.

--- a/_posts/2008/2008-04-15-methods-ofr-remote-gui-control-of-linux-servers.md
+++ b/_posts/2008/2008-04-15-methods-ofr-remote-gui-control-of-linux-servers.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>There are currently (3) basic methods for getting a remote control GUI on a Linux server (like we do with Remote Desktop for Windows servers):
+There are currently (3) basic methods for getting a remote control GUI on a Linux server (like we do with Remote Desktop for Windows servers):
 
 1) X-Windows over TCP/IP
 
@@ -32,10 +32,4 @@ The downsides of VNC are:
 
 A company called NoMachines came out with a different solution called "NX".  NX is a protocol that is very similar to RDP and the client works rather similar to Remote Desktop.  You used to have to pay for the product, but over the years, they've opened up the source code.  So now there are (3) different server implementations (NX, FreeNX, and another) and you can download the NX client from NoMachines for free. 
 
-The big advantage here is that security is better and performance is better over slow WAN links.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FreeNX.shtml">FreeNX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Linux.shtml">Linux</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NX.shtml">NX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/VNC.shtml">VNC</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/X11.shtml">X11</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:53](http://www.tgharold.com/techblog/2008/04/methods-ofr-remote-gui-control-of-linux.shtml)
-
-		</div>
+The big advantage here is that security is better and performance is better over slow WAN links.

--- a/_posts/2008/2008-05-18-freenxnx-security.md
+++ b/_posts/2008/2008-05-18-freenxnx-security.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>After mucking around with NX/FreeNX, I have a general understanding of how it works, how to lock down your server and what some of the security ramifications are.
+After mucking around with NX/FreeNX, I have a general understanding of how it works, how to lock down your server and what some of the security ramifications are.
 
 <b>First line of defense - NX user key pair</b>
 
@@ -90,10 +90,4 @@ Now that we've gotten NX working using password authentication, it's time to clo
 
 ...
 
-(Someday I'll finish this post.  Probably have to run 2 copies of sshd, with different security settings.)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FreeNX.shtml">FreeNX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NX.shtml">NX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:55](http://www.tgharold.com/techblog/2008/05/freenxnx-security.shtml)
-
-		</div>
+(Someday I'll finish this post.  Probably have to run 2 copies of sshd, with different security settings.)

--- a/_posts/2008/2008-06-28-fsvs---install-on-centos-5.md
+++ b/_posts/2008/2008-06-28-fsvs---install-on-centos-5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>(Note: This has been mostly superseded by my newer post [FSVS: Install on CentOS 5.4](/techblog/2009/11/fsvs-install-on-centos-54.shtml))
+(Note: This has been mostly superseded by my newer post [FSVS: Install on CentOS 5.4](/techblog/2009/11/fsvs-install-on-centos-54.shtml))
 
 The following should be enough (and is probably overkill) to install all of the dependencies that FSVS 1.1.16 needs on CentOS 5 (and CentOS 5.1)
 
@@ -37,10 +37,4 @@ See `config.log' for more details.
 
 Note the addition of "apr-util-devel" at the end of the "yum install" line.  This fixes the error when you run ./configure for FSVS and get the "can't find APR" error.
 
-In older versions of CentOS 5, we did not need to also specify the apr-util-devel package.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FSVS.shtml">FSVS</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[22:52](http://www.tgharold.com/techblog/2008/06/fsvs-install-on-centos-5.shtml)
-
-		</div>
+In older versions of CentOS 5, we did not need to also specify the apr-util-devel package.

--- a/_posts/2008/2008-07-14-fsvs-urls-or-fsvs-initialize-results-in-no-such-file-or-directory-2-error.md
+++ b/_posts/2008/2008-07-14-fsvs-urls-or-fsvs-initialize-results-in-no-such-file-or-directory-2-error.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So I was setting up FSVS 1.1.16 on a new CentOS 5.1 box this week (one of the first things that I do as soon as possible before configuration starts).  And I encountered the following error:
+So I was setting up FSVS 1.1.16 on a new CentOS 5.1 box this week (one of the first things that I do as soon as possible before configuration starts).  And I encountered the following error:
 
 # fsvs -v urls svn+ssh://svn.example.com/sys-machinename
 
@@ -23,10 +23,4 @@ An error occurred at 14:40:31.865: No such file or directory (2)
 
 The fix is to create the "/etc/fsvs" folder
 
-fsvs 1.1.16 was smart enough to remind me to create /var/spool/fsvs, but it apparently doesn't give a good error message when the "/etc/fsvs" folder does not exist.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FSVS.shtml">FSVS</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:50](http://www.tgharold.com/techblog/2008/07/fsvs-urls-or-fsvs-initialize-results-in.shtml)
-
-		</div>
+fsvs 1.1.16 was smart enough to remind me to create /var/spool/fsvs, but it apparently doesn't give a good error message when the "/etc/fsvs" folder does not exist.

--- a/_posts/2008/2008-07-28-dovecot---cmusieve-errors.md
+++ b/_posts/2008/2008-07-28-dovecot---cmusieve-errors.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>After upgrading our CentOS 5 box to the latest revisions this week (including Dovecot 1.1), we're seeing the following error message in the log files.  Sieve was working fine with Dovecot 1.0.
+After upgrading our CentOS 5 box to the latest revisions this week (including Dovecot 1.1), we're seeing the following error message in the log files.  Sieve was working fine with Dovecot 1.0.
 
 # cat /var/vmail/dovecot-deliver.log
 
@@ -32,10 +32,4 @@ Not sure yet what went wrong during the upgrade.
 
 Update: The problem was that we had made a copy of Dovecot's "deliver" executable to make it setuid to work with virtual user local delivery.  After the update, we forgot to update this copy of the exectuable.
 
-Once we updated the setuid copy of "deliver", things worked fine.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Dovecot.shtml">Dovecot</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SMTP.shtml">SMTP</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:17](http://www.tgharold.com/techblog/2008/07/dovecot-cmusieve-errors.shtml)
-
-		</div>
+Once we updated the setuid copy of "deliver", things worked fine.

--- a/_posts/2008/2008-08-01-nggjs-and-fggjs-site-infections.md
+++ b/_posts/2008/2008-08-01-nggjs-and-fggjs-site-infections.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One of our users visited a website that was infected with the ngg.js and fgg.js codes (they get injected into the HTML files on the server towards the end of the page).
+One of our users visited a website that was infected with the ngg.js and fgg.js codes (they get injected into the HTML files on the server towards the end of the page).
 
 We've blocked it in our squid configuration by:
 
@@ -32,10 +32,4 @@ http_access deny blocked_regex
 /fgg\.js
 /ngg\.js
 
-I won't explain this too much except to say that the blocked_urls file is designed to block top-level domains, while the regexp file is for blocking URLs using a regular expression.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Security.shtml">Security</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Squid.shtml">Squid</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:51](http://www.tgharold.com/techblog/2008/08/nggjs-and-fggjs-site-infections.shtml)
-
-		</div>
+I won't explain this too much except to say that the blocked_urls file is designed to block top-level domains, while the regexp file is for blocking URLs using a regular expression.

--- a/_posts/2008/2008-08-06-linux-raid-tuning-and-troubleshooting.md
+++ b/_posts/2008/2008-08-06-linux-raid-tuning-and-troubleshooting.md
@@ -10,12 +10,6 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Ran across this while searching another topic.
+Ran across this while searching another topic.
 
-[http://makarevitch.org/rant/raid/](http://makarevitch.org/rant/raid/)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:44](http://www.tgharold.com/techblog/2008/08/linux-raid-tuning-and-troubleshooting.shtml)
-
-		</div>
+[http://makarevitch.org/rant/raid/](http://makarevitch.org/rant/raid/)

--- a/_posts/2008/2008-08-08-debugging-ssl-connections.md
+++ b/_posts/2008/2008-08-08-debugging-ssl-connections.md
@@ -10,6 +10,6 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>We're experiencing odd delays when talking to our mail server over SMTPS (SSL).  I just found this post which helps us debug it.
+We're experiencing odd delays when talking to our mail server over SMTPS (SSL).  I just found this post which helps us debug it.
 
 [How to debug SSL SMTP - by S](http://www.wains.be/index.php/2007/08/11/how-to-debug-ssl-smtp/)

--- a/_posts/2008/2008-09-30-selinux---dealing-with-exceptions.md
+++ b/_posts/2008/2008-09-30-selinux---dealing-with-exceptions.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So we're seeing errors in our /var/log/messages like:
+So we're seeing errors in our /var/log/messages like:
 
 Sep 28 03:52:51 fvs-pri setroubleshoot: SELinux is preventing freshclam (freshclam_t) "read" to ./main.cld (var_t). For complete SEL
 inux messages. run sealert -l 10ce7bfb-6c44-473e-94a1-4691c04d2bef
@@ -27,10 +27,4 @@ For example:
 
 # /usr/sbin/semodule -i clam20080930.pp
 
-Note: This is the very quick and dirty way of dealing with exceptions - it really doesn't fix the underlying issue.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:38](http://www.tgharold.com/techblog/2008/09/selinux-dealing-with-exceptions.shtml)
-
-		</div>
+Note: This is the very quick and dirty way of dealing with exceptions - it really doesn't fix the underlying issue.

--- a/_posts/2008/2008-10-27-current-frustrations-with-thunderbird.md
+++ b/_posts/2008/2008-10-27-current-frustrations-with-thunderbird.md
@@ -10,16 +10,10 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I'm currently plagued by the following showing up in my error console in Thunderbird 2.0.0.17 (20080914).
+I'm currently plagued by the following showing up in my error console in Thunderbird 2.0.0.17 (20080914).
 
 <code>Error: uncaught exception: [Exception... "Component returned failure code: 0x80550006 [nsIMsgFolder.getMsgDatabase]"  nsresult: "0x80550006 (<unknown>)"  location: "JS frame :: chrome://messenger/content/mailWidgets.xml :: parseFolder :: line 2061"  data: no]</unknown></code>
 
 The other thing that happens is that eventually, Thunderbird stops talking (hangs) to my IMAP mail server (over SSL).  So I'm unable to send e-mail messages over SMTP/SSL (port 465), or am I able to retrieve any messages from our IMAP (Dovecot over SSL) server until I restart Thunderbird.
 
-It can take anywhere from 5 minutes to 5 hours for this problem to occur.  Starting in safe mode fixes some of the issue, but Thunderbird still chokes up after I've hit a few dozen IMAP folders to get new headers and to download messages.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/IMAP.shtml">IMAP</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Thunderbird.shtml">Thunderbird</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:00](http://www.tgharold.com/techblog/2008/11/current-frustrations-with-thunderbird.shtml)
-
-		</div>
+It can take anywhere from 5 minutes to 5 hours for this problem to occur.  Starting in safe mode fixes some of the issue, but Thunderbird still chokes up after I've hit a few dozen IMAP folders to get new headers and to download messages.

--- a/_posts/2008/2008-11-04-update-1-to-current-frustrations-with-thunderbird.md
+++ b/_posts/2008/2008-11-04-update-1-to-current-frustrations-with-thunderbird.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Well, I started up Thunderbird in safe mode.  If you have installed Thunderbird in the default location, that's as easy as pressing [Windows-R] (or Start, Run...) and entering the following:
+Well, I started up Thunderbird in safe mode.  If you have installed Thunderbird in the default location, that's as easy as pressing [Windows-R] (or Start, Run...) and entering the following:
 
 C:\Program Files\Mozilla Thunderbird\thunderbird.exe -safe-mode
 
@@ -18,10 +18,4 @@ What I found is that, although the error still occurred, Thunderbird was a lot b
 
 So I'm going to uninstall most of my add-ons and see if I can make things work better.  Disabling the add-ons didn't have any effect, so I think I'll have to completely remove most of them instead.
 
-To give you an idea of what I consider "large".  I have an IMAP account on our mail server that contains 17GB (2,000,000 messages) worth of e-mail.  I have another two accounts that contain 1.7GB (40,000 messages) and 2.5GB (200,000 messages) respectively.  However, none of the individual IMAP folders have more then 60,000 messages each.  And most of the large folders only have 15,000 to 30,000 messages.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Thunderbird.shtml">Thunderbird</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:28](http://www.tgharold.com/techblog/2008/11/update-1-to-current-frustrations-with.shtml)
-
-		</div>
+To give you an idea of what I consider "large".  I have an IMAP account on our mail server that contains 17GB (2,000,000 messages) worth of e-mail.  I have another two accounts that contain 1.7GB (40,000 messages) and 2.5GB (200,000 messages) respectively.  However, none of the individual IMAP folders have more then 60,000 messages each.  And most of the large folders only have 15,000 to 30,000 messages.

--- a/_posts/2008/2008-11-11-new-smartphone.md
+++ b/_posts/2008/2008-11-11-new-smartphone.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I'm sorta in the market for a new smartphone.  What I have now is a Motorola Q from 2006.  I've been mostly happy with it (except that it wasn't a touchscreen device), but it's been giving me more and more trouble lately.  And the cell coverage by Verizon is, frankly, horrid at my current place of residence.  Which makes the phone rather useless for me at home.
+I'm sorta in the market for a new smartphone.  What I have now is a Motorola Q from 2006.  I've been mostly happy with it (except that it wasn't a touchscreen device), but it's been giving me more and more trouble lately.  And the cell coverage by Verizon is, frankly, horrid at my current place of residence.  Which makes the phone rather useless for me at home.
 
 Back when I bought the MotoQ, I made the mistake of not researching software requirements before buying.  I didn't understand that the non-touchscreen version of Windows Mobile was not the same as the touchscreen version of Windows Mobile.  Which means that there are a lot of applications that I simply cannot run on the MotoQ (especially Pocket Quicken).
 
@@ -34,10 +34,4 @@ BlackBerry, Windows Mobile, Symbian, J2ME, Palm OS and iPhone/iPod Touch!
 
 <b>[zaTelnet Professional](http://www.zatelnet.com/zap/main.php)</b>
 
-MS Smartphones and Pocket PC<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/MotorolaQ.shtml">MotorolaQ</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SmartPhones.shtml">SmartPhones</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:07](http://www.tgharold.com/techblog/2008/11/new-smartphone.shtml)
-
-		</div>
+MS Smartphones and Pocket PC

--- a/_posts/2008/2008-11-24-dovecot---upgrading-notes.md
+++ b/_posts/2008/2008-11-24-dovecot---upgrading-notes.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>At the office, we're using a virtual Dovecot server where each person's mail folders are owned by an unique user in the Linux account system.  
+At the office, we're using a virtual Dovecot server where each person's mail folders are owned by an unique user in the Linux account system.  
 
 [Dovecot: Virtual Users](http://wiki.dovecot.org/VirtualUsers) - covers the basics
 
@@ -101,10 +101,3 @@ The steps that we take when we update Dovecot are then:
 <b>grep "AVC" /var/log/audit/audit.log | tail -n 50</b> - look for any errors relating to Dovecot</li>
 
 </ol>
-<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Dovecot.shtml">Dovecot</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:57](http://www.tgharold.com/techblog/2008/11/dovecot-upgrading-notes.shtml)
-
-		</div>

--- a/_posts/2008/2008-11-25-xen---issues-with-windows-domu-client-clocks.md
+++ b/_posts/2008/2008-11-25-xen---issues-with-windows-domu-client-clocks.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [Time is off by an hour in my XEN vm](http://www.nabble.com/Time-is-off-by-an-hour-in-my-XEN-vm-td16027741.html)
 
 Quote:
@@ -20,10 +20,4 @@ There is a RealTimeIsUniversal registry flag hidden in the windows registry that
 
 Summary:
 
-The ultimate solution is to probably run an NTP client under the Windows environment to force the software clock to slave properly.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Win2000.shtml">Win2000</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Xen.shtml">Xen</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:10](http://www.tgharold.com/techblog/2008/11/xen-issues-with-windows-domu-client.shtml)
-
-		</div>
+The ultimate solution is to probably run an NTP client under the Windows environment to force the software clock to slave properly.

--- a/_posts/2008/2008-12-31-backfilling.md
+++ b/_posts/2008/2008-12-31-backfilling.md
@@ -10,10 +10,4 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Going to do a lot of backfill posts based on what I've been working on in the past year.  Most of it has to do with CentOS 5, PostgreSQL, LVM, Software RAID, with a smattering of other issues thrown in.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2008.shtml">2008</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/News.shtml">News</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:42](http://www.tgharold.com/techblog/2008/12/backfilling.shtml)
-
-		</div>
+Going to do a lot of backfill posts based on what I've been working on in the past year.  Most of it has to do with CentOS 5, PostgreSQL, LVM, Software RAID, with a smattering of other issues thrown in.

--- a/_posts/2009/2009-01-01-lvm-maximum-number-of-physical-extents.md
+++ b/_posts/2009/2009-01-01-lvm-maximum-number-of-physical-extents.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Working on a 15-disk system (750GB SATA drives) so this issue came up again:
+Working on a 15-disk system (750GB SATA drives) so this issue came up again:
 
 What is the maximum number of physical extents in LVM?
 
@@ -32,10 +32,4 @@ References:
 
 [LVM Manpage](http://www.fifi.org/cgi-bin/man2html/usr/share/man/man8/lvm.8lvm-10.gz) - Talks about the limit in IA32.
 [Maximum Size Of A Logical Volume In LVM](http://www.walkernews.net/2007/07/02/maximum-size-of-a-logical-volume-in-lvm/) - Walker News (blog entry)
-[Manage Linux Storage with LVM and Smartctl](http://www.enterprisenetworkingplanet.com/nethub/article.php/3733141) - Enterprise Networking Planet<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/LVM.shtml">LVM</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:40](http://www.tgharold.com/techblog/2009/01/lvm-maximum-number-of-physical-extents.shtml)
-
-		</div>
+[Manage Linux Storage with LVM and Smartctl](http://www.enterprisenetworkingplanet.com/nethub/article.php/3733141) - Enterprise Networking Planet

--- a/_posts/2009/2009-01-02-samba3-upgrading-to-v32-on-centos-5.md
+++ b/_posts/2009/2009-01-02-samba3-upgrading-to-v32-on-centos-5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>CentOS 5 currently only has Samba 3.0.28 in their BASE repository.  The DAG/RPMForge projects don't have updated Samba3 RPMs either (although I do see an OpenPkg RPM).  So the question that I've been dealing with for the past few weeks is "where do I get newer Samba RPMs"?
+CentOS 5 currently only has Samba 3.0.28 in their BASE repository.  The DAG/RPMForge projects don't have updated Samba3 RPMs either (although I do see an OpenPkg RPM).  So the question that I've been dealing with for the past few weeks is "where do I get newer Samba RPMs"?
 
 Ideally, I would get these RPMs from a repository, so that I could be notified via "yum check-update" for when there are security / feature updates.  While I don't mind the occasional source package in .tar.gz or .tar.bz2 format, they rapidly become a maintenance nightmare.  Especially for security-sensitive packages like Samba which tend to be attack targets.
 
@@ -33,10 +33,4 @@ Note: As always, before doing a major upgrade like this, <b>make backups</b>.  A
 # yum install samba3.x86_64
 # service smb start
 
-With luck, you should now be up and running with v3.2 of Samba.  You can verify this by looking at the latest log file in the /var/log/samba/ directory.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Samba.shtml">Samba</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:22](http://www.tgharold.com/techblog/2009/01/samba3-upgrading-to-v32-on-centos-5.shtml)
-
-		</div>
+With luck, you should now be up and running with v3.2 of Samba.  You can verify this by looking at the latest log file in the /var/log/samba/ directory.

--- a/_posts/2009/2009-01-06-setting-up-freenxnx-on-centos-5.md
+++ b/_posts/2009/2009-01-06-setting-up-freenxnx-on-centos-5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Quick guide to setting up FreeNX/NX.  This the approximate minimums on a fresh CentOS 5.1 box.  We're limiting things to using public-key authentication from the outside and we already have a second ssh daemon running (listening on localhost, allowing password authentication).
+Quick guide to setting up FreeNX/NX.  This the approximate minimums on a fresh CentOS 5.1 box.  We're limiting things to using public-key authentication from the outside and we already have a second ssh daemon running (listening on localhost, allowing password authentication).
 
 Note: If you have ATRPMs configured as a repository, make sure that you exclude nx* and freenx*.  (Add/edit the exclude= line in the ATRPMs .repo file.)
 
@@ -55,10 +55,4 @@ Restart the FreeNX/NX service:
 
 # service freenx-server restart
 
-You should now be able to connect (assuming that you specify the proper SSH port and paste the private key into the configuration).<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FreeNX.shtml">FreeNX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NX.shtml">NX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[14:29](http://www.tgharold.com/techblog/2009/01/setting-up-freenxnx-on-centos-5.shtml)
-
-		</div>
+You should now be able to connect (assuming that you specify the proper SSH port and paste the private key into the configuration).

--- a/_posts/2009/2009-01-06-setup-sshd-to-run-a-second-instance.md
+++ b/_posts/2009/2009-01-06-setup-sshd-to-run-a-second-instance.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>In order to lock down the servers like I prefer to, yet still allow FreeNX/NX to work, I have to setup a second copy of the sshd daemon.  The FreeNX/NX client requires that you have sshd running with password access (not just public key), but we prefer to only allow public-key access to our servers.
+In order to lock down the servers like I prefer to, yet still allow FreeNX/NX to work, I have to setup a second copy of the sshd daemon.  The FreeNX/NX client requires that you have sshd running with password access (not just public key), but we prefer to only allow public-key access to our servers.
 
 I did the following on CentOS 5, it should also work for Fedora or Red Hat Enterprise Linux (RHEL).  But proceed at your own risk.
 
@@ -80,10 +80,4 @@ References:
 
 [How to Add a New "sshd_adm" Service on Red Hat Advanced Server 2.1](http://blog.thilelli.net/post/2005/07/04/How-to-Add-a-New-sshd_adm-Service-on-Red-Hat-Advanced-Server-21)
 
-[How to install NX server and client under Ubuntu/Kubuntu Linux (revised)](http://michigantelephone.wordpress.com/2007/10/15/how-to-install-nx-server-and-client-under-ubuntukubuntu-linux/)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FreeNX.shtml">FreeNX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NX.shtml">NX</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SSH.shtml">SSH</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:57](http://www.tgharold.com/techblog/2009/01/setup-sshd-to-run-second-instance.shtml)
-
-		</div>
+[How to install NX server and client under Ubuntu/Kubuntu Linux (revised)](http://michigantelephone.wordpress.com/2007/10/15/how-to-install-nx-server-and-client-under-ubuntukubuntu-linux/)

--- a/_posts/2009/2009-01-07-very-basic-rsync-cp-backup-rotation-with-hardlinks.md
+++ b/_posts/2009/2009-01-07-very-basic-rsync-cp-backup-rotation-with-hardlinks.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Here's a very basic script that I use with RSync that makes use of hard links to reduce the overall size of the backup folder.  The limitations are:
+Here's a very basic script that I use with RSync that makes use of hard links to reduce the overall size of the backup folder.  The limitations are:
 
 - Every morning, a server copies the current version of all files across SSH (using scp) into a "current" folder.  There are two folders on the source server that get backed up daily (/home and /local).
 
@@ -67,10 +67,4 @@ References:
 
 [Easy Automated Snapshot-Style Backups with Linux and Rsync](http://www.mikerubel.org/computers/rsync_snapshots/)
 
-[Local incremental snap shots with rsync](http://www.synology.at/enu/forum/viewtopic.php?f=9&amp;t=11471&amp;p=48163)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Backups.shtml">Backups</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/RSync.shtml">RSync</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[05:12](http://www.tgharold.com/techblog/2009/01/very-basic-rsync-cp-backup-rotation.shtml)
-
-		</div>
+[Local incremental snap shots with rsync](http://www.synology.at/enu/forum/viewtopic.php?f=9&amp;t=11471&amp;p=48163)

--- a/_posts/2009/2009-01-08-postgresql---basic-backup-scheme.md
+++ b/_posts/2009/2009-01-08-postgresql---basic-backup-scheme.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Here's a basic backup scheme.  We're using pg_dump in plain-text mode, compressing the output with bzip2, and writing the results out to files named after the database, schema and table name.  It's not the most efficient method, but allows us to go back to:
+Here's a basic backup scheme.  We're using pg_dump in plain-text mode, compressing the output with bzip2, and writing the results out to files named after the database, schema and table name.  It's not the most efficient method, but allows us to go back to:
 
 - any of the past 7 days
 - any Sunday within the past month
@@ -119,10 +119,4 @@ do
     done
 done</pre>
 
-We tried using gzip instead of bzip2, but found that bzip2 worked a little better even though it uses up more CPU.  We use a block size of only 200k for bzip2 in order to be more friendly to an rsync push to an external server.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Backups.shtml">Backups</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PostgreSQL.shtml">PostgreSQL</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:24](http://www.tgharold.com/techblog/2009/01/postgresql-basic-backup-scheme.shtml)
-
-		</div>
+We tried using gzip instead of bzip2, but found that bzip2 worked a little better even though it uses up more CPU.  We use a block size of only 200k for bzip2 in order to be more friendly to an rsync push to an external server.

--- a/_posts/2009/2009-01-10-postgresql---backup-speed-tests.md
+++ b/_posts/2009/2009-01-10-postgresql---backup-speed-tests.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Our backup script for pgsql dumps the databases out in plain text SQL format (my preferred method for a variety of reasons).  The question was, do we leave it as plain text and/or which compressor do we use?
+Our backup script for pgsql dumps the databases out in plain text SQL format (my preferred method for a variety of reasons).  The question was, do we leave it as plain text and/or which compressor do we use?
 
 ...
 
@@ -76,10 +76,4 @@ Ultimately, we ended up going with bzip2 for a variety of reasons.
 
 - Better compression
 - The additional CPU usage was not an issue
-- We could change to a smaller block size (-c2) to be more friendly to rsync<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Backups.shtml">Backups</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PostgreSQL.shtml">PostgreSQL</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:45](http://www.tgharold.com/techblog/2009/01/postgresql-backup-speed-tests.shtml)
-
-		</div>
+- We could change to a smaller block size (-c2) to be more friendly to rsync

--- a/_posts/2009/2009-01-10-subversion-backups---finding-svn-repositories.md
+++ b/_posts/2009/2009-01-10-subversion-backups---finding-svn-repositories.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>The first trick when backing up SVN repositories is finding them so that you can run the svnadmin hotcopy command.  Well, you *could* just setup a list of export DIRS in your backup script - but as you add new SVN repositories, you have to constantly edit that script.
+The first trick when backing up SVN repositories is finding them so that you can run the svnadmin hotcopy command.  Well, you *could* just setup a list of export DIRS in your backup script - but as you add new SVN repositories, you have to constantly edit that script.
 
 Caveat #1: This setup probably only works for FSFS repositories.  I don't use BerkleyDB repositories (a.k.a. BDB) so I can't guarantee that it correctly locates them.  I've chosen to look for folders that contain the "db/uuid" file as our "marker" file.  Which should result in zero false-positives or mis-identified repositories.
 
@@ -111,10 +111,4 @@ done
 
 # insert rdiff-backup line here</pre>
 
-Hopefully that works out.  Note the use of "rm -r", which could cause data loss if there are errors in the script.  You will want  to be very careful while working on the script.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Backups.shtml">Backups</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/bash.shtml">bash</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:59](http://www.tgharold.com/techblog/2009/01/subversion-backups-finding-svn.shtml)
-
-		</div>
+Hopefully that works out.  Note the use of "rm -r", which could cause data loss if there are errors in the script.  You will want  to be very careful while working on the script.

--- a/_posts/2009/2009-01-12-postgresql---errors-during-insertions.md
+++ b/_posts/2009/2009-01-12-postgresql---errors-during-insertions.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>ERROR:  could not access status of transaction 84344832
+ERROR:  could not access status of transaction 84344832
 DETAIL:  Could not open file "pg_clog/0050": No such file or directory.
 
 ERROR:  could not access status of transaction 84344832
@@ -79,10 +79,4 @@ D) Restart the pgsql service.
 
 Final notes.  This is probably absolutely NOT the proper way to fix this error.  Proceed at your own risk.  The chance of lost data is VERY HIGH.
 
-For us, it was a table that was append only, that we were filling out with test data.  So I'm not all that concerned.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/PostgreSQL.shtml">PostgreSQL</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:43](http://www.tgharold.com/techblog/2009/01/postgresql-errors-during-insertions.shtml)
-
-		</div>
+For us, it was a table that was append only, that we were filling out with test data.  So I'm not all that concerned.

--- a/_posts/2009/2009-01-14-yum-error---metadata-file-does-not-match-checksum.md
+++ b/_posts/2009/2009-01-14-yum-error---metadata-file-does-not-match-checksum.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Ran into this issue today when the pgsql folks updated their repository.  All of our CentOS 5 machines are behind a transparent HTTP proxy cache server (squid).
+Ran into this issue today when the pgsql folks updated their repository.  All of our CentOS 5 machines are behind a transparent HTTP proxy cache server (squid).
 
 <pre>filelists.sqlite.bz2      100% |=========================| 157 kB    00:00     
 http://yum.pgsqlrpms.org/8.3/redhat/rhel-5-x86_64/repodata/filelists.sqlite.bz2: [Errno -1] Metadata file does not match checksum
@@ -31,10 +31,4 @@ http_caching=packages
 
 <b>References:</b>
 
-[FedoraForum.org &gt; Fedora Support  &gt; Installation Help &gt; yum "Metadata file does not match checksum" problem](http://forums.fedoraforum.org/showthread.php?t=67591&amp;page=2)<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Squid.shtml">Squid</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[10:19](http://www.tgharold.com/techblog/2009/01/yum-error-metadata-file-does-not-match.shtml)
-
-		</div>
+[FedoraForum.org &gt; Fedora Support  &gt; Installation Help &gt; yum "Metadata file does not match checksum" problem](http://forums.fedoraforum.org/showthread.php?t=67591&amp;page=2)

--- a/_posts/2009/2009-01-28-removing-a-failed-non-existent-drive-from-software-raid.md
+++ b/_posts/2009/2009-01-28-removing-a-failed-non-existent-drive-from-software-raid.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>So, you have a drive that has failed, you've replaced the drive on the fly (using hot-swap SATA) and now you need to remove the old RAID slice.
+So, you have a drive that has failed, you've replaced the drive on the fly (using hot-swap SATA) and now you need to remove the old RAID slice.
 
 For example:
 
@@ -33,10 +33,4 @@ So instead of specifying the name of the failed RAID slice we should instead us 
 <pre># mdadm /dev/md0 -r detached  
 mdadm: hot removed 8:17</pre>
 
-And there you have it, the failed raid slice that is no longer connected to the system has been removed.  It will not show up in "/proc/mdstat" any more.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[13:04](http://www.tgharold.com/techblog/2009/01/removing-failed-non-existent-drive-from.shtml)
-
-		</div>
+And there you have it, the failed raid slice that is no longer connected to the system has been removed.  It will not show up in "/proc/mdstat" any more.

--- a/_posts/2009/2009-02-05-selinux---troubleshooting-file-labeling-issues.md
+++ b/_posts/2009/2009-02-05-selinux---troubleshooting-file-labeling-issues.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>This is a follow-up to [SELinux - dealing with exceptions](/techblog/2008/09/selinux-dealing-with-exceptions.shtml).
+This is a follow-up to [SELinux - dealing with exceptions](/techblog/2008/09/selinux-dealing-with-exceptions.shtml).
 
 First off, a few basics:
 
@@ -105,10 +105,4 @@ References:
 
 [Red Hat Enterprise Linux 4: Red Hat SELinux Guide](http://www.redhat.com/docs/manuals/enterprise/RHEL-4-Manual/selinux-guide/rhlcommon-chapter-0007.html)
 
-[How to: Install and Setup XEN Virtualization Software on CentOS Linux 5](http://www.cyberciti.biz/tips/rhel-centos-xen-virtualization-installation-howto.html) - Covers how to use semanage to grant the Xen process access to a directory where it will store the DomU storage as files.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[07:03](http://www.tgharold.com/techblog/2009/02/selinux-troubleshooting-file-labeling.shtml)
-
-		</div>
+[How to: Install and Setup XEN Virtualization Software on CentOS Linux 5](http://www.cyberciti.biz/tips/rhel-centos-xen-virtualization-installation-howto.html) - Covers how to use semanage to grant the Xen process access to a directory where it will store the DomU storage as files.

--- a/_posts/2009/2009-02-05-selinux-and-nagios-v3.md
+++ b/_posts/2009/2009-02-05-selinux-and-nagios-v3.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <b>Note: This post was never finished... so it probably contains lots of errors and incorrect information, with one or two grains of useful information.</b>
 
 Now that Nagios has upgraded to v3, I'm going to revisit my SELinux configuration for it.  Back when I first started I was somewhat clueless about SELinux (and still greatly so) and I created a lot of really bad policy modules.  They were a brute-force approach to fixing the issue using only audit2allow and ignoring labeling issues in the underlying filesystem.
@@ -39,10 +39,4 @@ Enforcing
 # getenforce
 Permissive</code>
 
-Now we can startup Nagios, taking careful note of the time.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Nagios.shtml">Nagios</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SELinux.shtml">SELinux</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SystemAdministration.shtml">SystemAdministration</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:10](http://www.tgharold.com/techblog/2009/02/selinux-and-nagios-v3.shtml)
-
-		</div>
+Now we can startup Nagios, taking careful note of the time.

--- a/_posts/2009/2009-03-08-linux-checking-the-fstab-prior-to-a-reboot.md
+++ b/_posts/2009/2009-03-08-linux-checking-the-fstab-prior-to-a-reboot.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One of the joys of working on a server from a remote location is dealing with the issue caused by a broken /etc/fstab file.  Even the best admins make mistakes and mistakes in that file can lead to a server that won't boot.
+One of the joys of working on a server from a remote location is dealing with the issue caused by a broken /etc/fstab file.  Even the best admins make mistakes and mistakes in that file can lead to a server that won't boot.
 
 Which is fine; if you have an IP-based KVM where you can get console access without actually being at the facility.  But not so great when a screwed up fstab file requires you to go physically visit the location.
 
@@ -44,10 +44,4 @@ mount: sysfs already mounted on /sys
 /dev/md4x on /var/log type ext3 (rw,noatime)
 nothing was mounted</code>
 
-Now, there's probably a better way to do this, but this serves as at least a moderate check against shooting yourself in the foot.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Linux.shtml">Linux</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:40](http://www.tgharold.com/techblog/2009/09/linux-checking-fstab-prior-to-reboot.shtml)
-
-		</div>
+Now, there's probably a better way to do this, but this serves as at least a moderate check against shooting yourself in the foot.

--- a/_posts/2009/2009-04-10-issues-with-fraps.md
+++ b/_posts/2009/2009-04-10-issues-with-fraps.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>I tend to do a lot of FRAPS capture of games that I play for a variety of reasons (the ability to look back, review gameplay, hobby).  However, ever since I upgraded my NVIDIA display drivers a month or two ago, I've started running into the following issue in VirtualDub:
+I tend to do a lot of FRAPS capture of games that I play for a variety of reasons (the ability to look back, review gameplay, hobby).  However, ever since I upgraded my NVIDIA display drivers a month or two ago, I've started running into the following issue in VirtualDub:
 
 <code>The decompression codec cannot decompress to an RGB format. This is very unusual. Check that any "Force YUY2" options are not enabled in the codec's properties.</code>
 
@@ -24,10 +24,4 @@ Now for the fun symptoms:
 
 - When things are screwy, sometimes the VirtualDub menu will disappear while using the "File -&gt; Append AVI segment" menu option.  This symptom may or not actually be related to the issue.  By vanish, I mean that the preview window will bleed through from the background and wipe out the dropped down File menu.  But you can still select menu options by moving the mouse up/down.
 
-All of this points to problems in the video codec rendering path.  It's made mass conversion of FRAPS video a real PITA in VirtualDub, because I'm doing 2-pass XVid encoding so a failure in the 1st pass means that the 2nd pass also needs to be tossed.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FRAPS.shtml">FRAPS</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:15](http://www.tgharold.com/techblog/2009/08/issues-with-fraps.shtml)
-
-		</div>
+All of this points to problems in the video codec rendering path.  It's made mass conversion of FRAPS video a real PITA in VirtualDub, because I'm doing 2-pass XVid encoding so a failure in the 1st pass means that the 2nd pass also needs to be tossed.

--- a/_posts/2009/2009-05-06-basic-snmp-reference-links.md
+++ b/_posts/2009/2009-05-06-basic-snmp-reference-links.md
@@ -10,14 +10,8 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Reference links:
+Reference links:
 
 [IETF RFC 3410 - Introduction and Applicability Statements for Internet Standard Management Framework (SNMP)](http://tools.ietf.org/html/rfc3410) - Dec 2002.  An information RFC that covers the basics of SNMP.  See also RFC [3411 (Architecture)](http://tools.ietf.org/html/rfc3411), [3413 (Applications)](http://tools.ietf.org/html/rfc3413), [3416 (Version 2 of the Protocol Operations)](http://tools.ietf.org/html/rfc3416), and [3418 (Management Information Base)](http://tools.ietf.org/html/rfc3418) as well as [a few others in the 3400-3499 range](http://en.wikipedia.org/wiki/Simple_Network_Management_Protocol#RFC_references).
 
-[Simple Network Management Protocol (Wikipedia)](http://en.wikipedia.org/wiki/Simple_Network_Management_Protocol) - Covers the basics and links to additional reference works.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SNMP.shtml">SNMP</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:29](http://www.tgharold.com/techblog/2009/05/basic-snmp-reference-links.shtml)
-
-		</div>
+[Simple Network Management Protocol (Wikipedia)](http://en.wikipedia.org/wiki/Simple_Network_Management_Protocol) - Covers the basics and links to additional reference works.

--- a/_posts/2009/2009-06-12-svn-care-and-feeding-of-a-sparse-working-copy.md
+++ b/_posts/2009/2009-06-12-svn-care-and-feeding-of-a-sparse-working-copy.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One of the wonderful (and long awaited for us) features in SVN 1.5 was the addition of "sparse" working copies.  This allows you to create a working copy that checks out from the root of the repository, but without having to bring down the entire repository into your working copy.  Which is a great boon for situations where a large monolithic repository is preferred over having lots of smaller repositories.
+One of the wonderful (and long awaited for us) features in SVN 1.5 was the addition of "sparse" working copies.  This allows you to create a working copy that checks out from the root of the repository, but without having to bring down the entire repository into your working copy.  Which is a great boon for situations where a large monolithic repository is preferred over having lots of smaller repositories.
 
 This was a feature that Visual SourceSafe (VSS) and SourceOffSite (SOS) had for many years prior to SVN 1.5's sparse working copy feature.   We were an SOS shop for a long time prior to switching to SVN back in 2006 and our entire VSS repository was basically monolithic and we'd only bring down what we needed to our local working copies.
 
@@ -71,10 +71,4 @@ Note: Sometimes the Repo-Browser will lose track of what has / hasn't been broug
 </li>
 </ol>
 
-Note: If TortoiseSVN does not remove the folder, then there was something in it that was not committed or that it felt you wanted to keep around.  Which is why I recommend doing an Update and then using the Commit dialog to verify that the working copy folder is clean.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SubVersion.shtml">SubVersion</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[15:40](http://www.tgharold.com/techblog/2009/06/svn-care-and-feeding-of-sparse-working.shtml)
-
-		</div>
+Note: If TortoiseSVN does not remove the folder, then there was something in it that was not committed or that it felt you wanted to keep around.  Which is why I recommend doing an Update and then using the Commit dialog to verify that the working copy folder is clean.

--- a/_posts/2009/2009-07-22-3ware-9650se-sata-raid-and-centos-5-linux.md
+++ b/_posts/2009/2009-07-22-3ware-9650se-sata-raid-and-centos-5-linux.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>A few months ago, I picked up a 3ware 9650SE 16-port controller for use in my primary office server which runs CentOS 5.  So far, it's been an up and down ride.
+A few months ago, I picked up a 3ware 9650SE 16-port controller for use in my primary office server which runs CentOS 5.  So far, it's been an up and down ride.
 
 Problem #1 - The boot process could not find the array disks.
 
@@ -84,10 +84,4 @@ Updates:
 
 - Even the 2.6.18-128 RHEL/CentOS kernel displays sluggishness any time that we access units (a RAID 6, 8 drive unit that is the only thing on the array).  We have zero performance problems with drive attached to a different SATA controller running Software RAID.
 
-- I can't recommend using the 9650SE controller with RHEL/CentOS currently.  Performance is absolutely horrid under load.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/3ware.shtml">3ware</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SoftwareRAID.shtml">SoftwareRAID</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[08:47](http://www.tgharold.com/techblog/2009/07/3ware-9650se-sata-raid-and-centos-5.shtml)
-
-		</div>
+- I can't recommend using the 9650SE controller with RHEL/CentOS currently.  Performance is absolutely horrid under load.

--- a/_posts/2009/2009-07-22-3ware-sata-raid---reboot-and-select-proper-boot-device.md
+++ b/_posts/2009/2009-07-22-3ware-sata-raid---reboot-and-select-proper-boot-device.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 <code>Reboot and Select proper Boot device
 or Insert Boot Media in selected Boot device and press a key</code>
 
@@ -26,10 +26,4 @@ Updates:
 
 - After playing with a little more, it seems to be a BIOS issue where the BIOS gets confused if the 3ware controller presents more then 12 units to the BIOS.
 
-- The 3ware controller does not "hide the first few cylinders of the drive".  Instead, it seems to store it's metadata for the drive at the end.  Aside from the problem of losing data in the last few cylinders, you can take a drive configured as a "single-unit" and hook it up to a regular SATA controller with no issues.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/3ware.shtml">3ware</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:36](http://www.tgharold.com/techblog/2009/07/3ware-sata-raid-reboot-and-select.shtml)
-
-		</div>
+- The 3ware controller does not "hide the first few cylinders of the drive".  Instead, it seems to store it's metadata for the drive at the end.  Aside from the problem of losing data in the last few cylinders, you can take a drive configured as a "single-unit" and hook it up to a regular SATA controller with no issues.

--- a/_posts/2009/2009-08-03-second-copy-7-vs-samba-v3.md
+++ b/_posts/2009/2009-08-03-second-copy-7-vs-samba-v3.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>One of the tools that we use on our desktop machines is [Second Copy 7](http://www.centered.com/), which is a very useful tool for doing file-level backups that are user friendly.  It has a mode where it mirrors the source directory tree to the remote location, along with putting older copies of the files in a second remote location.
+One of the tools that we use on our desktop machines is [Second Copy 7](http://www.centered.com/), which is a very useful tool for doing file-level backups that are user friendly.  It has a mode where it mirrors the source directory tree to the remote location, along with putting older copies of the files in a second remote location.
 
 However, if things are strange, you'll find that Second Copy will end up making repeated copies of files in the "older copies" location every time the profile runs.
 
@@ -32,10 +32,4 @@ Addendum:
 
 - I'm pretty sure that the problem was not due to my referencing the backup location using UNC naming (i.e. \\servername\share\path).
 
-- This issue mostly comes into play when you are backing up from one machine to another (such as a share location on another desktop or a server share).  This is not something that you'll normally run into if you're backing up to a drive hooked directly to the machine.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/NTP.shtml">NTP</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Samba.shtml">Samba</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[11:26](http://www.tgharold.com/techblog/2009/08/second-copy-7-vs-samba-v3.shtml)
-
-		</div>
+- This issue mostly comes into play when you are backing up from one machine to another (such as a share location on another desktop or a server share).  This is not something that you'll normally run into if you're backing up to a drive hooked directly to the machine.

--- a/_posts/2009/2009-09-07-snmp-finding-oids-and-mibs.md
+++ b/_posts/2009/2009-09-07-snmp-finding-oids-and-mibs.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>The key tool in the toolbox for exploring MIBs and finding things in SNMP is either "snmpwalk" or looking at the actual MIB text definitions.  On CentOS 5 (and RHEL 5), the net-snmp package installs a default set of MIBs to "/usr/share/snmp/mibs/".
+The key tool in the toolbox for exploring MIBs and finding things in SNMP is either "snmpwalk" or looking at the actual MIB text definitions.  On CentOS 5 (and RHEL 5), the net-snmp package installs a default set of MIBs to "/usr/share/snmp/mibs/".
 
 <code># snmpwalk -v 2c -c public localhost diskIONReadX</code>
 
@@ -39,10 +39,4 @@ diskIONReadX OBJECT-TYPE
 
 # snmptranslate -m +ALL -IR <b>-Ou</b> diskIONReadX
 enterprises.ucdavis.ucdExperimental.ucdDiskIOMIB.diskIOTable.
-    diskIOEntry.diskIONReadX</code><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SNMP.shtml">SNMP</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:45](http://www.tgharold.com/techblog/2009/09/snmp-finding-oids-and-mibs.shtml)
-
-		</div>
+    diskIOEntry.diskIONReadX</code>

--- a/_posts/2009/2009-10-22-flash-memory-price-check.md
+++ b/_posts/2009/2009-10-22-flash-memory-price-check.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Flash memory prices have finally dropped below $2.00/GB (around $1.90 at the moment).  
+Flash memory prices have finally dropped below $2.00/GB (around $1.90 at the moment).  
 
 SDHC cards:
 
@@ -33,10 +33,4 @@ $680 256GB
 
 The sweet spot is either 64GB for $145 or 128GB for $280.  SSDs are still a bit above the $2/GB price point.  Probably due to the extra circuitry and packaging of a 2.5" SSD.
 
-Hopefully, by this time next year they'll break the $1/GB mark.  Magnetic 2.5" drives are down around $0.17/GB for 500GB drives.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Prices.shtml">Prices</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[23:54](http://www.tgharold.com/techblog/2009/10/flash-memory-price-check.shtml)
-
-		</div>
+Hopefully, by this time next year they'll break the $1/GB mark.  Magnetic 2.5" drives are down around $0.17/GB for 500GB drives.

--- a/_posts/2009/2009-11-09-centos-5-clamav-095-and-etcsysconfigclamav.md
+++ b/_posts/2009/2009-11-09-centos-5-clamav-095-and-etcsysconfigclamav.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Trying to configure the new ClamAV 0.95 as a milter for our Postfix install this week.  So I've been doing some digging into the configuration files.  Here's what I've found so far.
+Trying to configure the new ClamAV 0.95 as a milter for our Postfix install this week.  So I've been doing some digging into the configuration files.  Here's what I've found so far.
 
 In order to get the newer ClamAV for Red Hat Enterprise Linux 5 (RHEL5) and CentOS 5, I had to use the RPMForge repository in order to get the 0.95 version.  
 
@@ -24,10 +24,4 @@ If you were using the /etc/sysconfig/clamav file to turn on the milter in RHEL5,
 ERROR: Unknown option passed
 ERROR: Can't parse command line options</code>
 
-You'll need to convert your old command line options into configuration file options.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/ClamAV.shtml">ClamAV</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[09:36](http://www.tgharold.com/techblog/2009/11/centos-5-clamav-095-and.shtml)
-
-		</div>
+You'll need to convert your old command line options into configuration file options.

--- a/_posts/2009/2009-11-20-getting-started-with-gpg4win.md
+++ b/_posts/2009/2009-11-20-getting-started-with-gpg4win.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>
+
 [GNU Privacy Guard for Windows Home Page (GPG4Win)](http://www.gpg4win.org/) - The GPG4Win project recently released version 2.0.1 of their product, so I figured it was a good time to reexamine GPG4Win.  There have been a few changes since version 1, most notable for me is that WinPT is no longer part of the GPG4Win distribution.
 
 <b>Installation</b>
@@ -235,11 +235,4 @@ You should also export your currently usable public encryption key.
 
 <code>gpg -a --export aafa2876 &gt;&gt; my-public-key.asc</code>
 
-You should print these files out as well as keeping an electronic copy in a secure location such as a safe or safe-deposit box.  Don't leave the secret key ASCII file laying around.  A sealed security envelope with a phrase and the current date written across the sealed flap and then covered with transparent tape is a good countermeasure to detect tampering.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/Encryption.shtml">Encryption</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/GnuPG.shtml">GnuPG</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:04](http://www.tgharold.com/techblog/2009/11/getting-started-with-gpg4win.shtml)
-
-		</div>
-	</acme>
+You should print these files out as well as keeping an electronic copy in a secure location such as a safe or safe-deposit box.  Don't leave the secret key ASCII file laying around.  A sealed security envelope with a phrase and the current date written across the sealed flap and then covered with transparent tape is a good countermeasure to detect tampering.

--- a/_posts/2009/2009-11-21-fsvs-ignore-patterns-120.md
+++ b/_posts/2009/2009-11-21-fsvs-ignore-patterns-120.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>Here's an example of a more complex FSVS ignore/take pattern.
+Here's an example of a more complex FSVS ignore/take pattern.
 
 On our mail server, we store all mail in MailDir folders under the structure of:
 
@@ -45,10 +45,4 @@ Line 4 "group:take,./var/vmail/*/*/Home": Now we grab just the "Home" folder ins
 
 Line 5 "group:take,./var/vmail/*/*/Home/**": Grab everything inside of Home and below that point.  This will grab all of the Sieve scripts or other files that are located there.  If you wanted to exclude certain files in Home, you would insert that ignore rule above this line.
 
-Line 6 "group:ignore,./var/vmail/**": This is the clean-up rule.  Anything not explicitly mentioned above here will now be ignored.  This keeps us from versioning the messages inside the user's MailDir folders.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FSVS.shtml">FSVS</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[17:29](http://www.tgharold.com/techblog/2009/11/fsvs-ignore-patterns-120.shtml)
-
-		</div>
+Line 6 "group:ignore,./var/vmail/**": This is the clean-up rule.  Anything not explicitly mentioned above here will now be ignored.  This keeps us from versioning the messages inside the user's MailDir folders.

--- a/_posts/2009/2009-11-27-fsvs-install-on-centos-54.md
+++ b/_posts/2009/2009-11-27-fsvs-install-on-centos-54.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>(Also see my older post on this: [FSVS - Install on CentOS 5](http://www.tgharold.com/techblog/2008/06/fsvs-install-on-centos-5.shtml).  Or the original post where I explained the power of [FSVS for sysadmins](http://www.tgharold.com/techblog/2007/05/fsvs-for-sysadmins.shtml).)
+(Also see my older post on this: [FSVS - Install on CentOS 5](http://www.tgharold.com/techblog/2008/06/fsvs-install-on-centos-5.shtml).  Or the original post where I explained the power of [FSVS for sysadmins](http://www.tgharold.com/techblog/2007/05/fsvs-for-sysadmins.shtml).)
 
 I'm going to start with the assumption that this is a base CentOS 5.4 install without *any* package groups selected during the initial install.  In my case, this is a DomU that I'm setting up under Xen to serve as testing server for web development.  The only thing I've done so far is setting the root password and configuring it to use a static IP address.
 
@@ -210,10 +210,4 @@ You can check what FSVS is going to version by using the "fsvs status pathname" 
 
 <code># fsvs ci -m "base check-in" /etc</code>
 
-Repeat this for the various top level trees until you have checked everything in.  Then you should do one last check-in at the root level that catches anything you might have missed.<div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/CentOS5.shtml">CentOS5</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/FSVS.shtml">FSVS</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[20:28](http://www.tgharold.com/techblog/2009/11/fsvs-install-on-centos-54.shtml)
-
-		</div>
+Repeat this for the various top level trees until you have checked everything in.  Then you should do one last check-in at the root level that catches anything you might have missed.

--- a/_posts/2009/2009-12-06-snmp-and-mrtg-interesting-oids-in-net-snmp.md
+++ b/_posts/2009/2009-12-06-snmp-and-mrtg-interesting-oids-in-net-snmp.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-<div style="clear:both;"></div>These can all be found via the "snmpwalk" command in CentOS 5.4 (or RHEL 5.4).
+These can all be found via the "snmpwalk" command in CentOS 5.4 (or RHEL 5.4).
 
 <code># snmp -v 1 -c public localhost | less</code>
 
@@ -112,10 +112,4 @@ So by looking at the hrProcessorLoad for nodes 768 &amp; 769, we can track the C
 
 <code># snmpwalk -v 1 -c public localhost -On | egrep "(768|769)" | grep "INTEGER"
 .1.3.6.1.2.1.25.3.3.1.2.768 = INTEGER: 9
-.1.3.6.1.2.1.25.3.3.1.2.769 = INTEGER: 17</code><div style="clear:both; padding-bottom:0.25em"></div>
-Labels: <a rel="tag" href="http://www.tgharold.com/techblog/labels/2009.shtml">2009</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/MRTG.shtml">MRTG</a>, <a rel="tag" href="http://www.tgharold.com/techblog/labels/SNMP.shtml">SNMP</a>
-		<div class="Byline">
-			posted by Thomas at 
-			[18:26](http://www.tgharold.com/techblog/2009/12/snmp-and-mrtg-interesting-oids-in-net.shtml)
-
-		</div>
+.1.3.6.1.2.1.25.3.3.1.2.769 = INTEGER: 17</code>

--- a/remove-clearboth-divs.py
+++ b/remove-clearboth-divs.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import os
+import re
+from pathlib import Path
+
+def remove_clearboth_divs():
+    """Remove <div style="clear:both; padding-bottom:0.25em"></div> sections from blog posts"""
+
+    # Find all markdown files in _posts directory
+    posts_dir = Path("_posts")
+    markdown_files = posts_dir.rglob("*.md")
+
+    pattern = r'<div style="clear:both; padding-bottom:0.25em"></div>.*'
+
+    modified_count = 0
+
+    for file_path in markdown_files:
+        try:
+            # Read the file content
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+
+            # Check if file contains the pattern
+            if '<div style="clear:both; padding-bottom:0.25em"></div>' in content:
+                # Remove the pattern and everything after it
+                new_content = re.sub(pattern, '', content, flags=re.DOTALL)
+
+                # Remove any trailing whitespace
+                new_content = new_content.rstrip() + '\n'
+
+                # Write back to file if changed
+                if new_content != content:
+                    with open(file_path, 'w', encoding='utf-8') as f:
+                        f.write(new_content)
+                    print(f"Modified: {file_path}")
+                    modified_count += 1
+                else:
+                    print(f"No change needed: {file_path}")
+            else:
+                print(f"No pattern found: {file_path}")
+
+        except Exception as e:
+            print(f"Error processing {file_path}: {e}")
+
+    print(f"Processed {modified_count} files.")
+
+if __name__ == "__main__":
+    remove_clearboth_divs()


### PR DESCRIPTION
## Summary
This PR removes Blogger taglines and other conversion artifacts that were left over from the Blogger to Jekyll migration process.

## Changes
- Removed all instances of `<div style="clear:both; padding-bottom:0.25em"></div>` sections from 227 blog posts
- Removed associated labels and byline information that were part of the Blogger conversion
- Cleaned up the entire blog post archive to improve presentation and readability

## Why This Matters
The archived content had leftover formatting from the migration that cluttered the posts. This cleanup ensures the posts appear clean and professional.

## Files Affected
- 227 blog posts across the archive
- Added `remove-clearboth-divs.py` script for future cleanup operations
- Updated `CLAUDE.md` with documentation of this cleanup

Co-Authored-By: Qwen3-Coder-30B-A3B-Instruct-MLX-6bit <Claude Code>