### PR TITLE
Fix relative links to use new Jekyll permalink structure

### DIFF
--- a/_posts/2004/2004-04-27-gentoo-epia-install-part-1.md
+++ b/_posts/2004/2004-04-27-gentoo-epia-install-part-1.md
@@ -93,4 +93,4 @@ And the "proc" file system (last bit of chapter 4e in the handbook)
 mkdir /mnt/gentoo/proc
 mount -t proc none /mnt/gentoo/proc
 
-Taking a break for a bit. ([continued in next post](/techblog/2004/04/gentoo-epia-install-part-2.shtml))
+Taking a break for a bit. ([continued in next post](/blog/2004-04-27-gentoo-epia-install-part-2/))

--- a/_posts/2004/2004-04-27-gentoo-epia-install-part-2.md
+++ b/_posts/2004/2004-04-27-gentoo-epia-install-part-2.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-Picking up at [chapter 5c of the Gentoo Handbook, Using a Stage from the LiveCD](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=5).  (Also see my [previous post](/techblog/2004/04/gentoo-epia-install-part-1.shtml) where I configured the disks.)  Here is where it gets fun...  I'm going to try starting with the x86 stage1 file:
+Picking up at [chapter 5c of the Gentoo Handbook, Using a Stage from the LiveCD](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=5).  (Also see my [previous post](/blog/2004-04-27-gentoo-epia-install-part-1/) where I configured the disks.)  Here is where it gets fun...  I'm going to try starting with the x86 stage1 file:
 
 cd /mnt/gentoo
 tar -xvjpf /mnt/cdrom/stages/stage1-x86-20040218.tar.bz2

--- a/_posts/2004/2004-04-28-gentoo-epia-install-part-3.md
+++ b/_posts/2004/2004-04-28-gentoo-epia-install-part-3.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-([Previous blog entry](/techblog/2004/04/gentoo-epia-install-part-2.shtml))
+([Previous blog entry](/blog/2004-04-27-gentoo-epia-install-part-2/))
 
 While I'm not exactly sure when the first phase finished overnight, it was probably around 8-12 hours.  I don't see any errors on the screen, so I'm assuming that I'm good to go for the [next step](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=6) in the handbook (chapter 6d).
 
@@ -20,4 +20,4 @@ Anyway, not much to this step, and it's another one that takes a while to run:
 
 emerge system
 
-Back in a few... ([next entry](/techblog/2004/04/gentoo-epia-install-part-4.shtml)).
+Back in a few... ([next entry](/blog/2004-04-28-gentoo-epia-install-part-4/)).

--- a/_posts/2004/2004-04-28-gentoo-epia-install-part-4.md
+++ b/_posts/2004/2004-04-28-gentoo-epia-install-part-4.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-([previous blog entry](/techblog/2004/04/gentoo-epia-install-part-3.shtml))
+([previous blog entry](/blog/2004-04-28-gentoo-epia-install-part-3/))
 
 Stage 2 compile is finished ([step 6d in the handbook](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=6)).  Not bad, emerge system took about 5.5 hours to run on my little VIA EPIA ME6000.  Now for [step 7, configuring the kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7)
 
@@ -55,4 +55,4 @@ Picking a kernel is tough... (make sure to read [gentoo kernel guide](http://www
 
 # emerge development-sources
 
-([next entry](/techblog/2004/04/gentoo-epia-install-part-3.shtml))
+([next entry](/blog/2004-04-28-gentoo-epia-install-part-3/))

--- a/_posts/2004/2004-04-28-gentoo-epia-install-part-5.md
+++ b/_posts/2004/2004-04-28-gentoo-epia-install-part-5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-([previous entry](/techblog/2004/04/gentoo-epia-install-part-4.shtml))
+([previous entry](/blog/2004-04-27-gentoo-epia-install-part-4/))
 
 Well, that took somewhere around 2 hours to import and build the kernel from the development-sources package.    Now I need to [configure the kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7) (per chapter 7c of the handbook).  There are also notes over at [epiawiki.org](http://www.epiawiki.org/wiki/tiki-index.php?page=EpiaTheEpiaKernel) and [building a small MP3 server](http://www.ath0.com/meta/prose/mp3-server/part3.html) about configuring that I'll need to investigate (specifically looking at [their copy of the make config file](http://www.ath0.com/meta/prose/mp3-server/m10000-kernel-config-meta) which goes in "/usr/src/linux/.config").
 
@@ -57,4 +57,4 @@ Hit "Exit" when done and save your new kernel configuration.  Use "make &amp;&am
 # cp System.map /boot/System.map-2.6.3-gentoo
 # cp .config /boot/config-2.6.3-gentoo
 
-([next entry](/techblog/2004/04/gentoo-epia-install-part-6.shtml))
+([next entry](/blog/2004-04-29-gentoo-epia-install-part-6/))

--- a/_posts/2004/2004-04-28-gentoo-epia-install-part-6.md
+++ b/_posts/2004/2004-04-28-gentoo-epia-install-part-6.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-([previous entry](/techblog/2004/04/gentoo-epia-install-part-5.shtml))
+([previous entry](/blog/2004-04-28-gentoo-epia-install-part-5/))
 
 Now to start with [chapter 7e, installing extra kernel modules](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  I didn't see any extra modules that needed to be emerge'd, so I skipped straight to the editing of the autoload file.  Actually I lie, I have to add in LVM2 module support.  So I need to follow the steps in [step 13 of the LVM install guide](http://www.gentoo.org/doc/en/lvm2.xml) and add LVM to the auto-load listing.
 
@@ -48,7 +48,7 @@ uhci
 ehci-hcd    
 usb-storage
 
-Don't forget to run "modules-update" when done.  Onward to [chapter 8, configuring your system](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=8).  First up is editing the "/etc/fstab" table, which controls what gets mounted at startup.  I'm using a rather complex partitioning system, plus LVM2, so this will look a bit wild.  It also helps to [refer back to the mount commands used earlier](/techblog/2004/04/gentoo-epia-install-part-4.shtml).
+Don't forget to run "modules-update" when done.  Onward to [chapter 8, configuring your system](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=8).  First up is editing the "/etc/fstab" table, which controls what gets mounted at startup.  I'm using a rather complex partitioning system, plus LVM2, so this will look a bit wild.  It also helps to [refer back to the mount commands used earlier](/blog/2004-04-28-gentoo-epia-install-part-4/).
 
 /dev/hda1 /boot ext2 noauto,noatime 1 2
 /dev/hda2 / ext3 natime 0 1

--- a/_posts/2004/2004-06-16-gentoo-install-4-installing-the-kernel-sources.md
+++ b/_posts/2004/2004-06-16-gentoo-install-4-installing-the-kernel-sources.md
@@ -10,9 +10,9 @@ tags:
 ---
 
 
-([previous post](/techblog/2004/06/gentoo-install-3-bootstrapping.shtml))
+([previous post](/blog/2004-06-15-gentoo-install-3-bootstrapping/))
 
-Picking up with [7. Configuring the Kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  If your system crashes after this point, I do have a few notes jotted down on [how to get back to here without rebuilding everything](/techblog/2004/04/gentoo-epia-install-part-4.shtml).  (Since this is where I screwed up last time and put the machine into an unusable state.)
+Picking up with [7. Configuring the Kernel](http://www.gentoo.org/doc/en/handbook/handbook-x86.xml?part=1&amp;chap=7).  If your system crashes after this point, I do have a few notes jotted down on [how to get back to here without rebuilding everything](/blog/2004-04-28-gentoo-epia-install-part-4/).  (Since this is where I screwed up last time and put the machine into an unusable state.)
 
 Timezone for me is EST5EDT, so here's how to set that up.
 <pre># ls /usr/share/zoneinfo
@@ -27,4 +27,4 @@ Next, [pick your kernel](http://www.gentoo.org/doc/en/gentoo-kernel.xml).  For m
 
 This will take a while to run.  Last time I think it took somewhere around 2 hours, this time it only took 30-40 minutes.  So my previous estimate was probably a bit off (or it took longer to download last time).
 
-([next step](/techblog/2004/06/gentoo-install-5-manual-kernel.shtml))
+([next step](/blog/2004-06-16-gentoo-install-5-manual-kernel-configuration/))


### PR DESCRIPTION
## Summary
Fixed broken relative links in blog posts that were using the old Blogger-style format.

## Changes
- Updated links from `/techblog/YYYY/MM/post-title.shtml` to `/blog/YYYY-MM-DD-post-title/`
- Fixed navigation between related posts in the Gentoo installation series
- Ensures proper linking when deployed to GitHub Pages

## Test plan
- Verify that all links in the affected posts now work correctly
- Check that cross-references between related posts function properly
- Confirm navigation between blog posts in the Gentoo series works as expected

## Related
This addresses the issue where relative links like `([previous entry](/techblog/2004/04/gentoo-epia-install-part-4.shtml))` were broken due to the migration to Jekyll with a new permalink structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)