### PR TITLE
Fix teaser image logic to prevent empty image tags when no teasers are defined

### DIFF
--- a/_includes/post-grid.html
+++ b/_includes/post-grid.html
@@ -1,6 +1,11 @@
 <article class="tile" itemscope itemtype="http://schema.org/Article">
-  <a href="{{ post.url | relative_url }}" title="{{ post.title }}" class="post-teaser">{% if post.image.teaser %}<img src="{{ post.image.teaser | relative_url }}" alt="teaser" itemprop="image">
-    {% else %}<img src="{{ site.teaser | relative_url }}" alt="teaser" itemprop="image">{% endif %}</a>
+  <a href="{{ post.url | relative_url }}" title="{{ post.title }}" class="post-teaser">
+    {% if post.image.teaser %}
+      <img src="{{ post.image.teaser | relative_url }}" alt="teaser" itemprop="image">
+    {% elsif site.teaser %}
+      <img src="{{ site.teaser | relative_url }}" alt="teaser" itemprop="image">
+    {% endif %}
+  </a>
   {% if post.date %}<p class="entry-date date published"><time datetime="{{ post.date | date: "%Y-%m-%d" }}" itemprop="datePublished">{{ post.date | date: "%B %d, %Y" }}</time></p>{% endif %}
   <h2 class="post-title" itemprop="name"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
   <p class="post-excerpt" itemprop="description">{{ post.excerpt | strip_html | truncate: 160 }}</p>


### PR DESCRIPTION
## Summary
This PR fixes an issue where teaser text would appear on the blog homepage when no teaser images were defined in posts or site configuration.

## Changes
- Modified `_includes/post-grid.html` to properly handle teaser image logic
- Changed conditional logic to only render image tags when teasers are actually available
- Uses proper Liquid `elsif` syntax instead of `else` for cleaner fallback handling

## Testing
The fix ensures that when no teaser images are defined (either in individual posts or site-wide), no empty image elements are rendered, preventing display artifacts.

## Co-Authored-By
Qwen3-Coder-30B-A3B-Instruct-MLX-6bit <Claude Code>