### PR TITLE
Fix home link navigation to use correct blog/ prefix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: "Technical stuff."
 logo: # 120x120 px default image used for Twitter summary card
 teaser: # 400x250 px default teaser image used in image archive grid
 locale: en
-url:
+url: "https://tgharold.github.io"
 feed:
   path: atom.xml
 baseurl: "/blog"

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,5 +1,5 @@
 <ul class="menu-item">
-	<li class="home"><a href="{{ site.url }}{{ site.baseurl }}/">">{{ site.title }}</a></li>
+	<li class="home"><a href="{{ site.url }}{{ site.baseurl }}/">{{ site.title }}</a></li>
 	{% for link in site.data.navigation %}
     {% if link.url contains 'http' %}
         {% assign domain = '' %}


### PR DESCRIPTION
## Summary
This PR fixes the issue where the home link on blog posts was incorrectly pointing to the root of the site (`/`) instead of the correct blog subdirectory (`/blog/`).

## Changes
- Fixed `_config.yml` by setting `url: "https://tgharold.github.io"` so that `{{ site.url }}` properly resolves to the base URL
- Fixed `_includes/navigation.html` by removing an extra `>` character in the home link tag that was causing a syntax error

## Problem
The navigation links were not properly constructed due to:
1. An empty `site.url` field in the configuration that was preventing correct URL generation
2. A syntax error in the navigation template that was preventing proper rendering

## Testing
- Verified the fix works in local Jekyll development
- Confirmed the home link now correctly points to `https://tgharold.github.io/blog/` instead of `https://tgharold.github.io/`

## Related
Fixes the issue described in the GitHub issue where the home link on blog posts was incorrectly directing to the site root rather than the blog subdirectory.