### PR TITLE
build.sh: Default to showing drafts during local development

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,8 +30,8 @@ build() {
 
 # Function to serve the site locally
 serve() {
-    echo "Starting development server..."
-    bundle exec jekyll serve --watch --force_polling
+    echo "Starting development server with drafts..."
+    bundle exec jekyll serve --watch --force_polling --drafts
 }
 
 # Main logic


### PR DESCRIPTION
When running the local development server with './build.sh serve', automatically include the --drafts flag so that draft posts are visible during local testing.

This makes it easier to develop and preview draft posts without having to remember to add the --drafts flag manually.

Fixes #45

Co-Authored-By: Qwen3-Coder-30B-A3B-Instruct-MLX-6bit <Claude Code>