### PR TITLE
Add functionality to generate unique old_url CSV file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Redoing things in a git repo gives me more control, less dependency on a 3rd par
 
 This blog is based on the [Minimal Mistakes Skinny Bones](https://github.com/mmistakes/skinny-bones-jekyll/) template.
 It had to be adjusted slightly to account for GitHub pages putting the root of the GitHub repo at the "/blog" sub-directory.
+
+## URL Mapping CSV Files
+Two CSV files are generated during the URL mapping process:
+1. `convert_blogger_to_jekyll_url_mappings_results.csv` - Contains all file_path/old_url mappings
+2. `convert_blogger_to_jekyll_url_mappings.csv` - Contains unique old_url values only

--- a/convert_blogger_to_jekyll_url_mappings.py
+++ b/convert_blogger_to_jekyll_url_mappings.py
@@ -30,9 +30,21 @@ def write_csv(file_data, output_file):
         for path, old_url in file_data:
             writer.writerow([path, old_url])
 
+def write_unique_old_urls_csv(old_urls, output_file):
+    """Write unique old_url values to a separate CSV file."""
+    unique_old_urls = list(set(old_urls))
+    unique_old_urls.sort()  # Sort for consistent output
+
+    with open(output_file, 'w', newline='', encoding='utf-8') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(['old_url'])
+        for old_url in unique_old_urls:
+            writer.writerow([old_url])
+
 def main():
     search_dir = '_posts'
     output_file = 'convert_blogger_to_jekyll_url_mappings_results.csv'
+    unique_output_file = 'convert_blogger_to_jekyll_url_mappings.csv'
 
     if not os.path.exists(search_dir):
         print(f"Error: Directory '{search_dir}' does not exist.")
@@ -44,9 +56,14 @@ def main():
 
     print(f"Found {len(url_mappings)} URL mappings in files containing the pattern.")
 
+    # Write the original CSV with file_path and old_url
     write_csv(url_mappings, output_file)
-
     print(f"Results written to '{output_file}'")
+
+    # Extract all old_url values and write unique ones to a separate CSV
+    old_urls = [old_url for _, old_url in url_mappings]
+    write_unique_old_urls_csv(old_urls, unique_output_file)
+    print(f"Unique old_url values written to '{unique_output_file}'")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Enhance the URL mapping script to generate two CSV files:
1. convert_blogger_to_jekyll_url_mappings_results.csv - Contains all file_path/old_url mappings
2. convert_blogger_to_jekyll_url_mappings.csv - Contains unique old_url values only

This provides better organization of the URL mapping data for analysis and migration purposes.

Co-Authored-By: Qwen3-Coder-30B-A3B-Instruct-MLX-6bit <Claude Code>