### PR TITLE
Tweak the devcontainer.json file for opencode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "Jekyll",
 	"image": "mcr.microsoft.com/devcontainers/jekyll:bookworm",
+	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/devcontainers/features/python:1": {},
@@ -26,5 +27,9 @@
 				//"Anthropic.claude-code"
 			]
 		}
-	}
+	},
+	"runArgs": [
+		"--cap-drop=ALL", // Drop all kernel capabilities
+		"--security-opt=no-new-privileges" // Prevent privilege escalation
+	]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _asset_bundler_cache
 .jekyll-metadata
 _archives
 .claude/settings.local.json
+.opencode/


### PR DESCRIPTION
https://dev.to/jamiemccrindle/exploiting-visual-studio-code-devcontainers-16fb

https://danz.blog/blog/opencode-in-devcontainers

AFAIK, we were already running as "vscode".

The two runArgs might be useful:

    --cap-drop=ALL
    --security-opt=no-new-privileges

Beyond that is a bit of a guess as to what we'll need. i.e. I need to do more research.